### PR TITLE
Add Expression Atlas integration and Hail MatrixTable utilities

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,6 @@ dependencies:
       - hail
       - requests
       - tqdm
+      - pandas
+      - numpy
+      - matplotlib

--- a/hvantk/datasets/expression_atlas_datasets.py
+++ b/hvantk/datasets/expression_atlas_datasets.py
@@ -55,7 +55,7 @@ class ExpressionAtlasDataset:
         Download a specific file for this dataset by file type.
 
         Args:
-            file_type: Type of the file to download (e.g., "tpm", "fpkm", "sdrf")
+            file_type: Type of the file to download (e.g., "transcript-tpm", "sdrf")
             out_dir: Directory where the file will be saved
 
         Returns:
@@ -80,24 +80,20 @@ class ExpressionAtlasDataset:
                 f"Failed to download {file_type} file for {self.accession}: {str(e)}"
             ) from e
 
-    def download_expression_data(self, out_dir: str, format: str = "tpm") -> str:
+    def download_expression_data(self, out_dir: str) -> str:
         """
-        Download expression data for this dataset.
+        Download expression data (transcript TPM) for this dataset.
 
         Args:
             out_dir: Directory where the file will be saved
-            format: Format of the expression data to download ("tpm" or "fpkm")
 
         Returns:
             Path to the downloaded file
 
         Raises:
-            ValueError: If the specified format is not available or download fails
+            ValueError: If the transcript-tpm file is not available or download fails
         """
-        if format not in ["tpm", "fpkm"]:
-            raise ValueError(f"Invalid format '{format}'. Must be 'tpm' or 'fpkm'")
-        
-        return self.download_file(format, out_dir)
+        return self.download_file("transcript-tpm", out_dir)
 
     def download_metadata(self, out_dir: str) -> str:
         """

--- a/hvantk/resources/expression_atlas.json
+++ b/hvantk/resources/expression_atlas.json
@@ -11,16 +11,8 @@
         "name": "E-GTEX-8.condensed-sdrf.tsv"
       },
       {
-        "type": "tpm",
-        "name": "E-GTEX-8-tpms.tsv"
-      },
-      {
         "type": "transcript-tpm",
         "name": "E-GTEX-8-transcripts-tpms.tsv"
-      },
-      {
-        "type": "fpkm",
-        "name": "E-GTEX-8-fpkms.tsv"
       }
     ]
   },
@@ -36,16 +28,8 @@
         "name": "E-MTAB-6814.condensed-sdrf.tsv"
       },
       {
-        "type": "tpm",
-        "name": "E-MTAB-6814-tpms.tsv"
-      },
-       {
         "type": "transcript-tpm",
         "name": "E-MTAB-6814-transcripts-tpms.tsv"
-      },
-      {
-        "type": "fpkm",
-        "name": "E-MTAB-6814-fpkms.tsv"
       }
     ]
   },
@@ -61,16 +45,8 @@
         "name": "E-MTAB-6769.condensed-sdrf.tsv"
       },
       {
-        "type": "tpm",
-        "name": "E-MTAB-6769-tpms.tsv"
-      },
-      {
         "type": "transcript-tpm",
         "name": "E-MTAB-6769-transcripts-tpms.tsv"
-      },
-      {
-        "type": "fpkm",
-        "name": "E-MTAB-6769-fpkms.tsv"
       }
     ]
   },
@@ -86,16 +62,8 @@
         "name": "E-MTAB-6833.condensed-sdrf.tsv"
       },
       {
-        "type": "tpm",
-        "name": "E-MTAB-6833-tpms.tsv"
-      },
-      {
         "type": "transcript-tpm",
         "name": "E-MTAB-6833-transcripts-tpms.tsv"
-      },
-      {
-        "type": "fpkm",
-        "name": "E-MTAB-6833-fpkms.tsv"
       }
     ]
   },
@@ -111,16 +79,8 @@
         "name": "E-MTAB-6798.condensed-sdrf.tsv"
       },
       {
-        "type": "tpm",
-        "name": "E-MTAB-6798-tpms.tsv"
-      },
-      {
         "type": "transcript-tpm",
         "name": "E-MTAB-6798-transcripts-tpms.tsv"
-      },
-      {
-        "type": "fpkm",
-        "name": "E-MTAB-6798-fpkms.tsv"
       }
     ]
   },
@@ -136,16 +96,8 @@
         "name": "E-MTAB-6782.condensed-sdrf.tsv"
       },
       {
-        "type": "tpm",
-        "name": "E-MTAB-6782-tpms.tsv"
-      },
-      {
         "type": "transcript-tpm",
         "name": "E-MTAB-6782-transcripts-tpms.tsv"
-      },
-      {
-        "type": "fpkm",
-        "name": "E-MTAB-6782-fpkms.tsv"
       }
     ]
   },
@@ -161,16 +113,8 @@
         "name": "E-MTAB-6811.condensed-sdrf.tsv"
       },
       {
-        "type": "tpm",
-        "name": "E-MTAB-6811-tpms.tsv"
-      },
-       {
         "type": "transcript-tpm",
         "name": "E-MTAB-6811-transcripts-tpms.tsv"
-      },
-      {
-        "type": "fpkm",
-        "name": "E-MTAB-6811-fpkms.tsv"
       }
     ]
   }

--- a/hvantk/tests/test_expression_atlas_downloader.py
+++ b/hvantk/tests/test_expression_atlas_downloader.py
@@ -69,7 +69,7 @@ def test_download_experiments_accession_with_config(download_path):
     # Assert that the command was successful
     assert result.exit_code == 0
 
-    # Assert that sdrf the file was created
+    # Assert that the sdrf file was created
     sdrf_file_path = os.path.join(download_path, f"{accession}.condensed-sdrf.tsv")
     assert os.path.exists(sdrf_file_path)
 

--- a/hvantk/tests/test_expression_atlas_downloader.py
+++ b/hvantk/tests/test_expression_atlas_downloader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 from hvantk.commands import expression_atlas_downloader
+
 # Define the test directory path
 TEST_DIR = Path(__file__).parent.parent
 
@@ -13,7 +14,18 @@ def download_path(tmpdir):
     return str(tmpdir.mkdir("downloads"))
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI", "false").lower() == "true",
+    reason="Test skipped in CI environment - downloads all files and runs too slow",
+)
 def test_download_experiments_config(download_path):
+    """
+    This test download all files from experiments in the config file and
+    should run only locally and not in the CI/CD pipeline (too slow).
+
+    :param download_path: Path where downloaded files will be stored
+    :return: None
+    """
     # Create a CliRunner instance
     runner = CliRunner()
 
@@ -41,7 +53,7 @@ def test_download_experiments_accession_with_config(download_path):
 
     # Call the download_experiments function with the accession and download path
     config_path = str(TEST_DIR / "resources/expression_atlas.json")
-    accession = "E-GTEX-8"
+    accession = "E-MTAB-6798"
     result = runner.invoke(
         expression_atlas_downloader.download_experiments,
         [
@@ -57,12 +69,16 @@ def test_download_experiments_accession_with_config(download_path):
     # Assert that the command was successful
     assert result.exit_code == 0
 
-    # Assert that the file was created
-    file_path = os.path.join(download_path, "E-GTEX-8.condensed-sdrf.tsv")
-    assert os.path.exists(file_path)
+    # Assert that sdrf the file was created
+    sdrf_file_path = os.path.join(download_path, f"{accession}.condensed-sdrf.tsv")
+    assert os.path.exists(sdrf_file_path)
+
+    # Assert that the tpm-transcript file was created
+    tpm_file_path = os.path.join(download_path, f"{accession}-transcripts-tpms.tsv")
+    assert os.path.exists(tpm_file_path)
 
     # Assert that the file content is not empty
-    assert os.path.getsize(file_path) > 0
+    assert os.path.getsize(sdrf_file_path) > 0
 
 
 def test_download_experiments_without_accession_or_config(download_path):

--- a/hvantk/tests/test_matrix_utils.py
+++ b/hvantk/tests/test_matrix_utils.py
@@ -1,0 +1,262 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import hail as hl
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from hvantk.htables.ucsc import (
+    convert_ucsc_metadata_to_hail_table,
+    create_mt_from_ucsc_expression_matrix,
+)
+from hvantk.utils.constants import UCSC_CELL_ID_COLUMN, UCSC_GENE_COLUMN
+from hvantk.utils.matrix_utils import (
+    summarize_matrix,
+    filter_by_metadata,
+    filter_by_gene_list,
+    filter_by_expression,
+    visualize_expression_distribution,
+    get_top_expressed_genes
+)
+
+# Test data directory
+TESTDATA_DIR = Path(__file__).parent / "testdata" / "raw" / "ucsc"
+METADATA_FILE_PATH = (TESTDATA_DIR / "meta.test.tsv").resolve()
+EXPRESSION_MATRIX_FILE_PATH = (TESTDATA_DIR / "exprMatrix.test.tsv.bgz").resolve()
+
+
+@pytest.fixture
+def temp_dir():
+    # Create temporary directory for test outputs
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    # Clean up after test
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def sample_matrix_table(temp_dir):
+    """
+    Create a sample MatrixTable for testing using the UCSC test data
+    """
+    # Define output path
+    output_path = Path(temp_dir) / "test_matrix_utils.mt"
+
+    # Import metadata file to Hail Table
+    metadata_ht = convert_ucsc_metadata_to_hail_table(
+        str(METADATA_FILE_PATH), sep="\t", index_col=0, index_name=UCSC_CELL_ID_COLUMN
+    )
+
+    # Create the MatrixTable from the expression matrix file
+    mt = create_mt_from_ucsc_expression_matrix(
+        expression_matrix_path=str(EXPRESSION_MATRIX_FILE_PATH),
+        output_path=str(output_path),
+        delimiter="\t",
+        row_fields=None,
+        row_key=UCSC_GENE_COLUMN,
+        split_gene_field=True,
+        min_partitions=5,
+        force_bgz=True,
+        overwrite=True,
+        metadata_ht=metadata_ht,
+    )
+
+    return mt
+
+
+def test_summarize_matrix(sample_matrix_table):
+    """
+    Test the summarize_matrix function
+    """
+    # Get summary of the MatrixTable
+    summary = summarize_matrix(sample_matrix_table)
+
+    # Verify summary contains expected keys
+    assert 'dimensions' in summary
+    assert 'metadata_fields' in summary
+    assert 'metadata_stats' in summary
+    assert 'expression_stats' in summary
+
+    # Verify dimensions are correct
+    assert summary['dimensions']['n_samples'] == sample_matrix_table.count_cols()
+    assert summary['dimensions']['n_genes'] == sample_matrix_table.count_rows()
+
+    # Verify metadata fields exist if present in the MatrixTable
+    if 'metadata' in sample_matrix_table.col:
+        assert len(summary['metadata_fields']) > 0
+        assert len(summary['metadata_stats']) > 0
+
+    # print summary for debugging
+    print("Matrix Summary:" + str(summary))
+
+
+def test_filter_by_metadata(sample_matrix_table):
+    """
+    Test the filter_by_metadata function
+    """
+    if 'metadata' not in sample_matrix_table.col:
+        pytest.skip("Sample MatrixTable does not contain metadata")
+
+    # Get a metadata field to filter on
+    metadata_field = list(sample_matrix_table.col.metadata.dtype)[0]
+
+    # Get a value from that field to filter on
+    field_values = sample_matrix_table.aggregate_cols(
+        hl.agg.collect_as_set(sample_matrix_table.metadata[metadata_field])
+    )
+
+    if not field_values:
+        pytest.skip(f"No values found for metadata field {metadata_field}")
+
+    filter_value = list(field_values)[0]
+
+    # Filter the MatrixTable
+    filtered_mt = filter_by_metadata(sample_matrix_table, {metadata_field: filter_value})
+
+    # Check that all samples in filtered table have the filter value
+    all_match = filtered_mt.aggregate_cols(
+        hl.agg.all(filtered_mt.metadata[metadata_field] == filter_value)
+    )
+
+    assert all_match
+    assert filtered_mt.count_cols() <= sample_matrix_table.count_cols()
+
+
+def test_filter_by_gene_list(sample_matrix_table):
+    """
+    Test the filter_by_gene_list function
+    """
+
+    gene_field_name = 'gene'  # This is what we expect to be returned
+
+    # Get a few gene IDs to filter on
+    gene_ids = sample_matrix_table.aggregate_rows(
+        hl.agg.take(sample_matrix_table[gene_field_name], 5)
+    )
+
+    # Filter the MatrixTable by gene IDs
+    filtered_mt = filter_by_gene_list(sample_matrix_table, gene_ids=gene_ids, gene_id_field=gene_field_name)
+
+    # Check that filtered MatrixTable has only the specified genes
+    assert filtered_mt.count_rows() == len(gene_ids)
+
+    # Check that all gene IDs in the filtered table are in our list
+    all_in_list = filtered_mt.aggregate_rows(
+        hl.agg.all(hl.literal(set(gene_ids)).contains(filtered_mt[gene_field_name]))
+    )
+
+    assert all_in_list
+
+
+def test_filter_by_expression(sample_matrix_table):
+    """
+    Test the filter_by_expression function
+    """
+    # Get expression statistics to set reasonable thresholds
+    expr_stats = sample_matrix_table.aggregate_entries(
+        hl.struct(
+            mean=hl.agg.mean(sample_matrix_table.x),
+            std=hl.agg.stats(sample_matrix_table.x).stdev,
+            min=hl.agg.min(sample_matrix_table.x),
+            max=hl.agg.max(sample_matrix_table.x)
+        )
+    )
+
+    # Set min threshold to mean - std (but not less than 0)
+    min_threshold = max(0, expr_stats.mean - expr_stats.std)
+
+    # Filter by minimum expression
+    min_filtered_mt = filter_by_expression(sample_matrix_table, min_expr=min_threshold)
+
+    # Check that all expression values are either 0 or >= min_threshold
+    all_valid = min_filtered_mt.aggregate_entries(
+        hl.agg.all((min_filtered_mt.x == 0) | (min_filtered_mt.x >= min_threshold))
+    )
+
+    assert all_valid
+
+    # Test filter by min samples
+    min_samples = 2
+    sample_filtered_mt = filter_by_expression(sample_matrix_table, min_samples=min_samples)
+
+    # Check that the filtered matrix table has fewer or equal number of rows
+    assert sample_filtered_mt.count_rows() <= sample_matrix_table.count_rows()
+
+
+def test_get_top_expressed_genes(sample_matrix_table):
+    """
+    Test the get_top_expressed_genes function
+    """
+    # Get top 10 expressed genes
+    top_genes_df = get_top_expressed_genes(sample_matrix_table, n=10, gene_id_field='gene')
+
+    # Check that the function returns a pandas DataFrame
+    assert isinstance(top_genes_df, pd.DataFrame)
+
+    # Check that we got 10 genes
+    assert len(top_genes_df) == 10
+
+    # Check required columns are present - using the field name from the returned DataFrame
+    gene_field_name = 'gene'  # This is what we expect to be returned
+    assert gene_field_name in top_genes_df.columns
+    assert 'mean_expr' in top_genes_df.columns
+
+    # Check that genes are sorted by expression
+    assert top_genes_df['mean_expr'].is_monotonic_decreasing
+
+    # Test by_metadata if metadata is available
+    if 'metadata' in sample_matrix_table.col:
+        metadata_field = list(sample_matrix_table.col.metadata.dtype)[0]
+
+        # Get top genes by a metadata field
+        top_by_metadata = get_top_expressed_genes(
+            sample_matrix_table,
+            n=5,
+            by_metadata=metadata_field,
+            gene_id_field='gene'
+        )
+
+        # Check that the result includes the metadata field
+        assert metadata_field in top_by_metadata.columns
+        # print for debugging
+        print("Top expressed genes by metadata:\n", top_by_metadata)
+
+
+def test_visualize_expression_distribution(sample_matrix_table, temp_dir, show_figure=True):
+    """
+    Test the visualize_expression_distribution function
+
+    Args:
+        sample_matrix_table: Sample MatrixTable fixture
+        temp_dir: Temporary directory fixture
+        show_figure: If True, will display the figure (default: False)
+    """
+    # Generate the plot
+    fig = visualize_expression_distribution(sample_matrix_table, n_bins=20, log_scale=True)
+
+    # Check that the figure is a matplotlib figure
+    assert isinstance(fig, plt.Figure)
+
+    # Save the figure to check it was created properly
+    fig_path = os.path.join(temp_dir, 'expr_dist.png')
+    fig.savefig(fig_path)
+
+    # Display the figure if requested
+    if show_figure:
+        plt.figure(fig.number)
+        plt.show()
+
+    # Check that the file was created
+    assert os.path.exists(fig_path)
+
+    # Test with log_scale=False
+    fig2 = visualize_expression_distribution(sample_matrix_table, log_scale=False)
+    assert isinstance(fig2, plt.Figure)
+
+    # Display second figure if requested
+    if show_figure:
+        plt.figure(fig2.number)
+        plt.show()

--- a/hvantk/utils/matrix_utils.py
+++ b/hvantk/utils/matrix_utils.py
@@ -43,7 +43,7 @@ def summarize_matrix(mt: hl.MatrixTable) -> Dict:
         for field in metadata_fields:
             # Check if the field is likely numerical
             field_type = mt.col.metadata[field].dtype
-            is_numeric = isinstance(field_type, (hl.tint32, hl.tint64, hl.tfloat32, hl.tfloat64, hl.tfloat))
+            is_numeric = hl.is_numeric(field_type)
 
             if is_numeric:
                 # For numerical fields, compute summary statistics
@@ -54,7 +54,8 @@ def summarize_matrix(mt: hl.MatrixTable) -> Dict:
                     'std': field_stats.stdev,
                     'min': field_stats.min,
                     'max': field_stats.max,
-                    'n_missing': field_stats.n_missing
+                    'n': field_stats.n,
+                    'sum': field_stats.sum
                 }
             else:
                 # For categorical fields, first collect unique values then count them

--- a/hvantk/utils/matrix_utils.py
+++ b/hvantk/utils/matrix_utils.py
@@ -43,7 +43,7 @@ def summarize_matrix(mt: hl.MatrixTable) -> Dict:
         for field in metadata_fields:
             # Check if the field is likely numerical
             field_type = mt.col.metadata[field].dtype
-            is_numeric = str(field_type).startswith(('tfloat', 'tint', 'tdouble'))
+            is_numeric = isinstance(field_type, (hl.tint32, hl.tint64, hl.tfloat32, hl.tfloat64, hl.tfloat))
 
             if is_numeric:
                 # For numerical fields, compute summary statistics
@@ -260,7 +260,7 @@ def visualize_expression_distribution(mt: hl.MatrixTable,
 
         # Use plain Python integer for n_bins
         expr = hl.log10(hl.float64(mt[expr_field]))
-        hist = mt.aggregate_entries(hl.agg.hist(expr=expr, start=log_min, end=log_max, bins=n_bins))
+        hist = mt.aggregate_entries(hl.agg.hist(expr, log_min, log_max, n_bins))
         x_label = "log10(Expression)"
     else:
         min_val = mt.aggregate_entries(hl.agg.min(mt[expr_field]))
@@ -273,7 +273,7 @@ def visualize_expression_distribution(mt: hl.MatrixTable,
 
         # Use plain Python integer for n_bins
         expr = hl.float64(mt[expr_field])
-        hist = mt.aggregate_entries(hl.agg.hist(expr=expr, start=min_val, end=max_val, bins=n_bins))
+        hist = mt.aggregate_entries(hl.agg.hist(expr, min_val, max_val, n_bins))
         x_label = "Expression"
 
     # Plot using matplotlib

--- a/hvantk/utils/matrix_utils.py
+++ b/hvantk/utils/matrix_utils.py
@@ -1,0 +1,356 @@
+"""
+Utilities for working with Hail MatrixTable objects, specifically for gene expression data.
+
+This module provides functions for:
+- Summarizing MatrixTable contents
+- Filtering MatrixTables based on various criteria
+- Visualizing MatrixTable data through plots
+
+The functions are designed to work with MatrixTables having the following structure:
+- Column fields: sample_id (key), metadata (struct with sample attributes)
+- Row fields: Gene ID, Gene Name, GeneID (key)
+- Entry fields: x (expression values)
+"""
+
+from typing import List, Dict, Union, Optional
+
+import hail as hl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+def summarize_matrix(mt: hl.MatrixTable) -> Dict:
+    """
+    Provide a comprehensive summary of a MatrixTable.
+
+    Args:
+        mt: Hail MatrixTable to summarize
+
+    Returns:
+        Dict containing summary statistics and information about the MatrixTable
+    """
+    # Basic counts
+    n_samples = mt.count_cols()
+    n_genes = mt.count_rows()
+    n_entries = n_samples * n_genes
+
+    # Sample metadata summaries
+    if 'metadata' in mt.col:
+        metadata_fields = list(mt.col.metadata.dtype)
+        metadata_stats = {}
+
+        for field in metadata_fields:
+            # Check if the field is likely numerical
+            field_type = mt.col.metadata[field].dtype
+            is_numeric = str(field_type).startswith(('tfloat', 'tint', 'tdouble'))
+
+            if is_numeric:
+                # For numerical fields, compute summary statistics
+                field_stats = mt.aggregate_cols(hl.agg.stats(mt.metadata[field]))
+                # Convert to a more compact dict format
+                field_stats = {
+                    'mean': field_stats.mean,
+                    'std': field_stats.stdev,
+                    'min': field_stats.min,
+                    'max': field_stats.max,
+                    'n_missing': field_stats.n_missing
+                }
+            else:
+                # For categorical fields, first collect unique values then count them
+                unique_values = mt.aggregate_cols(hl.agg.collect_as_set(mt.metadata[field]))
+                unique_count = len(unique_values)
+
+                if unique_count <= 50:  # Only show counter for fields with reasonable cardinality
+                    field_stats = mt.aggregate_cols(hl.agg.counter(mt.metadata[field]))
+                else:
+                    # For high cardinality categorical fields, just show counts
+                    field_stats = {
+                        'n_unique': unique_count,
+                        'most_common': mt.aggregate_cols(hl.agg.take(mt.metadata[field], 5))
+                    }
+
+            metadata_stats[field] = field_stats
+    else:
+        metadata_fields = []
+        metadata_stats = {}
+
+    # Expression value statistics
+    if 'x' in mt.entry:
+        expr_stats = mt.aggregate_entries(
+            hl.struct(
+                mean=hl.agg.mean(mt.x),
+                std=hl.agg.stats(mt.x).stdev,
+                min=hl.agg.min(mt.x),
+                max=hl.agg.max(mt.x),
+                non_zero=hl.agg.count_where(mt.x > 0),
+                zeros=hl.agg.count_where(mt.x == 0)
+            )
+        )
+    else:
+        expr_stats = {}
+
+    # Prepare the complete summary
+    summary = {
+        'dimensions': {
+            'n_samples': n_samples,
+            'n_genes': n_genes,
+            'n_entries': n_entries,
+            'sparsity': 1 - (expr_stats.get('non_zero', 0) / n_entries) if n_entries > 0 else None
+        },
+        'metadata_fields': metadata_fields,
+        'metadata_stats': metadata_stats,
+        'expression_stats': expr_stats,
+    }
+
+    return summary
+
+
+def filter_by_metadata(mt: hl.MatrixTable,
+                       filters: Dict[str, Union[str, List[str]]]) -> hl.MatrixTable:
+    """
+    Filter the MatrixTable by sample metadata.
+
+    Args:
+        mt: Hail MatrixTable to filter
+        filters: Dictionary mapping metadata field names to values or lists of values
+                 to include
+
+    Returns:
+        Filtered MatrixTable
+    """
+    filtered_mt = mt
+
+    for field, values in filters.items():
+        if field not in mt.col.metadata.dtype:
+            raise ValueError(f"Field {field} not found in metadata")
+
+        # Convert single values to lists for uniform handling
+        if not isinstance(values, list):
+            values = [values]
+
+        # Create filter expression
+        filter_expr = hl.literal(set(values)).contains(mt.metadata[field])
+        filtered_mt = filtered_mt.filter_cols(filter_expr)
+
+    return filtered_mt
+
+
+def filter_by_gene_list(mt: hl.MatrixTable,
+                        gene_ids: Optional[List[str]] = None,
+                        gene_names: Optional[List[str]] = None,
+                        gene_id_field: str = 'GeneID',
+                        gene_name_field: str = 'Gene Name') -> hl.MatrixTable:
+    """
+    Filter the MatrixTable to include only specified genes.
+
+    Args:
+        mt: Hail MatrixTable to filter
+        gene_ids: List of gene IDs to include
+        gene_names: List of gene names to include
+        gene_id_field: Field name for gene IDs (default: 'GeneID')
+        gene_name_field: Field name for gene names (default: 'Gene Name')
+
+    Returns:
+        Filtered MatrixTable
+    """
+    filtered_mt = mt
+
+    if gene_ids is not None:
+        if gene_id_field not in mt.row:
+            raise ValueError(f"Field {gene_id_field} not found in row fields. Available fields: {list(mt.row)}")
+        filtered_mt = filtered_mt.filter_rows(hl.literal(set(gene_ids)).contains(filtered_mt[gene_id_field]))
+
+    if gene_names is not None:
+        if gene_name_field not in mt.row:
+            raise ValueError(f"Field {gene_name_field} not found in row fields. Available fields: {list(mt.row)}")
+        filtered_mt = filtered_mt.filter_rows(hl.literal(set(gene_names)).contains(filtered_mt[gene_name_field]))
+
+    return filtered_mt
+
+
+def filter_by_expression(mt: hl.MatrixTable,
+                         min_expr: float = None,
+                         max_expr: float = None,
+                         min_samples: int = None) -> hl.MatrixTable:
+    """
+    Filter the MatrixTable based on expression values.
+
+    Args:
+        mt: Hail MatrixTable to filter
+        min_expr: Minimum expression value to include
+        max_expr: Maximum expression value to include
+        min_samples: Minimum number of samples a gene must be expressed in
+
+    Returns:
+        Filtered MatrixTable
+    """
+    filtered_mt = mt
+
+    if min_expr is not None:
+        # For entry-level filtering, where we want to keep the structure
+        # but set values below threshold to NA or 0
+        filtered_mt = filtered_mt.annotate_entries(
+            x_filtered=hl.if_else(filtered_mt.x >= min_expr, filtered_mt.x, 0)
+        )
+        # Replace the original x with the filtered one
+        filtered_mt = filtered_mt.drop('x')
+        filtered_mt = filtered_mt.rename({'x_filtered': 'x'})
+
+    if max_expr is not None:
+        # Apply a maximum threshold
+        filtered_mt = filtered_mt.annotate_entries(
+            x_filtered=hl.if_else(filtered_mt.x <= max_expr, filtered_mt.x, max_expr)
+        )
+        filtered_mt = filtered_mt.drop('x')
+        filtered_mt = filtered_mt.rename({'x_filtered': 'x'})
+
+    if min_samples is not None:
+        # Count samples where gene is expressed per row
+        # We need to annotate the rows with the count first, then filter
+        filtered_mt = filtered_mt.annotate_rows(
+            n_expressed_samples=hl.agg.count_where(filtered_mt.x > 0)
+        )
+
+        # Filter genes expressed in at least min_samples
+        filtered_mt = filtered_mt.filter_rows(filtered_mt.n_expressed_samples >= min_samples)
+
+        # Clean up the annotation if desired
+        filtered_mt = filtered_mt.drop('n_expressed_samples')
+
+    return filtered_mt
+
+
+def visualize_expression_distribution(mt: hl.MatrixTable,
+                                      n_bins: int = 50,
+                                      log_scale: bool = True,
+                                      title: str = "Expression Value Distribution",
+                                      expr_field: str = 'x') -> plt.Figure:
+    """
+    Visualize the distribution of expression values in the MatrixTable using Hail's native histogram.
+
+    Args:
+        mt: Hail MatrixTable to visualize
+        n_bins: Number of histogram bins
+        log_scale: Whether to use log scale for values
+        title: Plot title
+        expr_field: Name of the entry field containing expression values (default: 'x')
+
+    Returns:
+        Matplotlib figure
+    """
+    # Verify the expression field exists
+    if expr_field not in mt.entry:
+        raise ValueError(f"Expression field '{expr_field}' not found in entry fields. Available fields: {list(mt.entry)}")
+
+    # Ensure n_bins is an integer
+    n_bins = int(n_bins)
+
+    # Compute min/max for histogram range
+    if log_scale:
+        min_val = mt.aggregate_entries(hl.agg.filter(mt[expr_field] > 0, hl.agg.min(mt[expr_field])))
+        max_val = mt.aggregate_entries(hl.agg.filter(mt[expr_field] > 0, hl.agg.max(mt[expr_field])))
+        if min_val is None or max_val is None or min_val <= 0 or max_val <= 0:
+            raise ValueError("No positive values found for log transformation")
+        log_min = float(np.floor(np.log10(min_val)))
+        log_max = float(np.ceil(np.log10(max_val)))
+        if log_min == log_max:
+            log_min -= 1
+            log_max += 1
+
+        # Use plain Python integer for n_bins
+        expr = hl.log10(hl.float64(mt[expr_field]))
+        hist = mt.aggregate_entries(hl.agg.hist(expr=expr, start=log_min, end=log_max, bins=n_bins))
+        x_label = "log10(Expression)"
+    else:
+        min_val = mt.aggregate_entries(hl.agg.min(mt[expr_field]))
+        max_val = mt.aggregate_entries(hl.agg.max(mt[expr_field]))
+        if min_val is None or max_val is None:
+            raise ValueError("No values found for histogram")
+        if min_val == max_val:
+            min_val -= 1
+            max_val += 1
+
+        # Use plain Python integer for n_bins
+        expr = hl.float64(mt[expr_field])
+        hist = mt.aggregate_entries(hl.agg.hist(expr=expr, start=min_val, end=max_val, bins=n_bins))
+        x_label = "Expression"
+
+    # Plot using matplotlib
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.bar(hist.bin_edges[:-1], hist.bin_freq, width=np.diff(hist.bin_edges), align='edge', edgecolor='black')
+    ax.set_title(title)
+    ax.set_xlabel(x_label)
+    ax.set_ylabel("Frequency")
+    return fig
+
+def get_top_expressed_genes(mt: hl.MatrixTable,
+                            n: int = 20,
+                            by_metadata: str = None,
+                            gene_id_field: str = 'GeneID',
+                            gene_name_field: str = 'Gene Name') -> pd.DataFrame:
+    """
+    Get the top expressed genes overall or by a metadata category.
+
+    Args:
+        mt: Hail MatrixTable to analyze
+        n: Number of top genes to return
+        by_metadata: If provided, return top genes for each category in this metadata field
+        gene_id_field: Field name for gene IDs (default: 'GeneID')
+        gene_name_field: Field name for gene names (default: 'Gene Name')
+
+    Returns:
+        Pandas DataFrame with top genes
+    """
+    # Verify field names exist in the row fields
+    row_fields = list(mt.row)
+    if gene_id_field not in row_fields:
+        raise ValueError(f"Field {gene_id_field} not found in row fields. Available fields: {row_fields}")
+
+    # Check if gene name field is available
+    has_gene_names = gene_name_field in row_fields
+
+    if by_metadata is None:
+        # Calculate mean expression per gene
+        mt = mt.annotate_rows(mean_expr=hl.agg.mean(mt.x))
+
+        # Select fields to include in output
+        tb = mt.rows().key_by()
+        fields_to_select = [gene_id_field, "mean_expr"]
+        if has_gene_names:
+            fields_to_select.insert(1, gene_name_field)
+        df = tb.select(*fields_to_select).to_pandas()
+
+        df = df.sort_values('mean_expr', ascending=False).head(n)
+
+    else:
+        # Group by metadata field and get top genes for each group
+        if by_metadata not in mt.col.metadata.dtype:
+            raise ValueError(f"Field {by_metadata} not found in metadata")
+
+        # First get the categories
+        categories = mt.aggregate_cols(hl.agg.collect_as_set(mt.metadata[by_metadata]))
+
+        # Initialize result dataframe
+        result_dfs = []
+
+        # For each category, filter and get top genes
+        for category in categories:
+            mt_filtered = filter_by_metadata(mt, {by_metadata: category})
+            mt_filtered = mt_filtered.annotate_rows(mean_expr=hl.agg.mean(mt_filtered.x))
+
+            # Get the top n genes
+            tb = mt_filtered.rows().key_by()
+            fields_to_select = [gene_id_field, "mean_expr"]
+            if has_gene_names:
+                fields_to_select.insert(1, gene_name_field)
+            df_category = tb.select(*fields_to_select).to_pandas()
+
+            df_category = df_category.sort_values('mean_expr', ascending=False).head(n)
+            df_category[by_metadata] = category
+
+            result_dfs.append(df_category)
+
+        df = pd.concat(result_dfs)
+
+    return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ hail
 requests
 tqdm
 pandas
+matplotlib
+numpy


### PR DESCRIPTION
### Description:

This pull request introduces enhancements to the integration of Expression Atlas data into the project. Key changes include:

- Implementation of a new `matrix_utils` module for Hail MatrixTable operations.
- Minor refactorings of UCSC module imports.

### Checklist:
- [x] New tests cover the added functionality.
- [x] Documentation is updated where necessary.
- [x] CI pipeline passes for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced utilities for summarizing, filtering, and visualizing gene expression data in MatrixTables, including functions to filter by metadata, gene lists, or expression thresholds, and to retrieve top expressed genes.
  - Added visualization tools for expression distributions and summary statistics.
  - Simplified expression data download to focus exclusively on "transcript-tpm" file type.

- **Tests**
  - Added comprehensive unit tests for all new matrix utility functions to ensure correct behavior and output.
  - Enhanced expression atlas downloader tests with improved file checks and CI skip conditions.

- **Chores**
  - Updated dependencies to include matplotlib and numpy for enhanced visualization and data processing.
  - Cleaned up resource files to remove deprecated "tpm" and "fpkm" data references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->