### PR TITLE
Add PTM features including tests, reports, and atlas assembly

### DIFF
--- a/hvantk/commands/ptm_cli.py
+++ b/hvantk/commands/ptm_cli.py
@@ -691,3 +691,337 @@ def ptm_constraint(
         logger.exception(f"PTM constraint failed: {e}")
         click.echo(f"Error: {e}", err=True)
         ctx.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 subcommands: atlas (atlas assembly facade) and test (LMM runners)
+# ---------------------------------------------------------------------------
+
+
+@ptm_group.command("atlas")
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(),
+    required=True,
+    help="Directory for intermediate + combined TSV output.",
+)
+@click.option(
+    "--output-ht",
+    type=str,
+    required=True,
+    help="Path to the final PTM sites Hail Table (.ht).",
+)
+@click.option(
+    "--sources",
+    type=str,
+    default="uniprot,peptideatlas",
+    show_default=True,
+    help=(
+        "Comma-separated subset of {uniprot,peptideatlas,cptac}. "
+        "CPTAC is off by default (optional dependency)."
+    ),
+)
+@click.option(
+    "--uniprot-tsv",
+    type=click.Path(exists=True),
+    default=None,
+    help="Pre-downloaded UniProt PTM TSV (optional; auto-downloaded if omitted).",
+)
+@click.option(
+    "--peptideatlas-tsv",
+    type=click.Path(exists=True),
+    default=None,
+    help="Pre-downloaded PeptideAtlas phospho intermediate TSV.",
+)
+@click.option(
+    "--cptac-tsv",
+    type=click.Path(exists=True),
+    default=None,
+    help="Pre-downloaded CPTAC phospho combined TSV.",
+)
+@click.option(
+    "--gtf-path",
+    type=click.Path(exists=True),
+    default=None,
+    help="Pre-downloaded Ensembl GTF (auto-downloaded if omitted).",
+)
+@click.option(
+    "--flanking-codons",
+    type=int,
+    default=7,
+    show_default=True,
+    help="Flanking-codon window (Phase-2 default matches notebook A).",
+)
+@click.option("--overwrite", is_flag=True)
+@click.pass_context
+def ptm_atlas(
+    ctx,
+    output_dir,
+    output_ht,
+    sources,
+    uniprot_tsv,
+    peptideatlas_tsv,
+    cptac_tsv,
+    gtf_path,
+    flanking_codons,
+    overwrite,
+):
+    """Phase-2 PTM atlas assembly (notebook A facade).
+
+    \b
+    Delegates to hvantk.ptm.atlas.build_atlas, which in turn delegates to
+    ptm_build_pipeline. Produces ptm_sites_combined.tsv.bgz (UniProt +
+    PeptideAtlas) or ptm_sites_all_combined.tsv.bgz (when --sources includes
+    cptac).
+
+    \b
+    Example:
+      hvantk ptm atlas -o data/ptm/ --output-ht data/ptm/ptm_sites.ht
+    """
+    try:
+        from hvantk.ptm.atlas import PTMAtlasConfig, build_atlas
+
+        source_list = [s.strip().lower() for s in sources.split(",") if s.strip()]
+        config = PTMAtlasConfig(
+            output_dir=output_dir,
+            output_ht=output_ht,
+            sources=source_list,
+            uniprot_tsv=uniprot_tsv,
+            peptideatlas_tsv=peptideatlas_tsv,
+            cptac_tsv=cptac_tsv,
+            gtf_path=gtf_path,
+            flanking_codons=flanking_codons,
+            overwrite=overwrite,
+        )
+        errors = config.validate()
+        if errors:
+            click.echo("Configuration validation failed:", err=True)
+            for err in errors:
+                click.echo(f"  - {err}", err=True)
+            ctx.exit(1)
+
+        result = build_atlas(config)
+        click.echo(f"Sources used: {', '.join(result.sources_used)}")
+        click.echo(f"Sites mapped: {result.n_sites:,}")
+        click.echo(f"Combined TSV: {result.combined_tsv}")
+        click.echo(f"Hail Table:   {result.output_ht}")
+
+    except Exception as e:
+        logger.exception(f"PTM atlas failed: {e}")
+        click.echo(f"Error: {e}", err=True)
+        ctx.exit(1)
+
+
+def _read_variants_table(path: str):
+    """Load a variant table from CSV/TSV with transparent gzip/bgz support."""
+    import pandas as _pd
+
+    p = str(path)
+    # pandas infers compression from extension (.gz / .bgz handled via gzip).
+    sep = "\t" if p.endswith((".tsv", ".tsv.gz", ".tsv.bgz", ".tab")) else None
+    if sep is None:
+        # Fall back to comma separator if neither .tsv nor .csv explicit.
+        sep = "," if p.endswith((".csv", ".csv.gz")) else "\t"
+    return _pd.read_csv(p, sep=sep, low_memory=False)
+
+
+def _read_expression_wide(pkl_path, tsv_path):
+    """Load a gene x stratum expression matrix from a pandas pickle or TSV."""
+    import pandas as _pd
+
+    if pkl_path:
+        wide = _pd.read_pickle(pkl_path)
+    else:
+        wide = _pd.read_csv(tsv_path, sep="\t", index_col=0, low_memory=False)
+    return wide
+
+
+@ptm_group.command("test")
+@click.option(
+    "--test",
+    "test_mode",
+    type=click.Choice(["lmm", "lmm-binned"], case_sensitive=False),
+    required=True,
+    help="LMM variant to run (notebook M = lmm, notebook K = lmm-binned).",
+)
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(exists=True),
+    required=True,
+    help="Variant table (CSV/TSV) with gene / AF / is_ptm plus the stratum column.",
+)
+@click.option(
+    "--stratum-col",
+    type=str,
+    required=True,
+    help=(
+        "Column in the input table identifying strata (one row per unique "
+        "value in the output)."
+    ),
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    required=True,
+    help="Destination TSV for per-stratum results.",
+)
+@click.option("--gene-col", type=str, default="gene", show_default=True)
+@click.option("--af-col", type=str, default="af_filled", show_default=True)
+@click.option("--is-ptm-col", type=str, default="is_ptm", show_default=True)
+@click.option(
+    "--expression-pkl",
+    type=click.Path(exists=True),
+    default=None,
+    help=(
+        "lmm-binned only: pandas-pickled DataFrame (gene x stratum) with "
+        "expression values. Missing strata are skipped."
+    ),
+)
+@click.option(
+    "--expression-tsv",
+    type=click.Path(exists=True),
+    default=None,
+    help=(
+        "lmm-binned only: TSV alternative to --expression-pkl "
+        "(first column = gene, remaining columns = strata)."
+    ),
+)
+@click.pass_context
+def ptm_test(
+    ctx,
+    test_mode,
+    input_path,
+    stratum_col,
+    output,
+    gene_col,
+    af_col,
+    is_ptm_col,
+    expression_pkl,
+    expression_tsv,
+):
+    """Run per-stratum PTM constraint tests (notebook M / K).
+
+    \b
+    --test lmm        Per-stratum log_af ~ is_ptm + (1|gene) (notebook M).
+    --test lmm-binned Per-stratum log_af ~ is_ptm * C(expr_bin) + (1|gene)
+                      using an expression matrix keyed gene x stratum (notebook K).
+
+    \b
+    Output TSV columns:
+      stratum, n_variants, n_ptm, ... and (for lmm) beta_ptm/se_ptm/p_ptm
+      converged, note. For lmm-binned the beta/SE/p columns are emitted per
+      realized bin (b0_none, b1_Q1, ...).
+
+    \b
+    Examples:
+      hvantk ptm test --test lmm \\
+          --input variants.tsv --stratum-col primary_tissue_broad \\
+          -o results/tissue_lmm.tsv
+
+      hvantk ptm test --test lmm-binned \\
+          --input variants.tsv --stratum-col cell_type \\
+          --expression-pkl brain_gene_celltype_median_expr.pkl \\
+          -o results/celltype_binned.tsv
+    """
+    try:
+        import os as _os
+
+        import pandas as _pd
+
+        df = _read_variants_table(input_path)
+        if stratum_col not in df.columns:
+            click.echo(f"Error: stratum column '{stratum_col}' not in input.", err=True)
+            ctx.exit(1)
+
+        mode = test_mode.lower()
+        out_dir = _os.path.dirname(_os.path.abspath(output))
+        if out_dir:
+            _os.makedirs(out_dir, exist_ok=True)
+
+        strata = [s for s in df[stratum_col].dropna().unique()]
+        click.echo(f"Running {mode} for {len(strata)} strata...")
+
+        if mode == "lmm":
+            from hvantk.ptm.test import run_lmm
+
+            rows = []
+            for s in strata:
+                sub = df[df[stratum_col] == s]
+                r = run_lmm(
+                    sub,
+                    stratum=str(s),
+                    gene_col=gene_col,
+                    af_col=af_col,
+                    is_ptm_col=is_ptm_col,
+                )
+                rows.append({
+                    "stratum": r.stratum,
+                    "n_variants": r.n_variants,
+                    "n_ptm": r.n_ptm,
+                    "n_nonptm": r.n_nonptm,
+                    "n_genes": r.n_genes,
+                    "n_mixed_genes": r.n_mixed_genes,
+                    "beta_ptm": r.beta_ptm,
+                    "se_ptm": r.se_ptm,
+                    "p_ptm": r.p_ptm,
+                    "converged": r.converged,
+                    "note": r.note,
+                })
+            _pd.DataFrame(rows).to_csv(output, sep="\t", index=False)
+        else:  # lmm-binned
+            if not (expression_pkl or expression_tsv):
+                click.echo(
+                    "Error: --expression-pkl or --expression-tsv is required "
+                    "for --test lmm-binned.",
+                    err=True,
+                )
+                ctx.exit(1)
+            from hvantk.ptm.test import run_binned_interaction_lmm
+
+            wide = _read_expression_wide(expression_pkl, expression_tsv)
+            rows = []
+            for s in strata:
+                sub = df[df[stratum_col] == s]
+                if s not in wide.columns:
+                    rows.append({
+                        "stratum": str(s),
+                        "n_variants": int(len(sub)),
+                        "n_genes": int(sub[gene_col].nunique()) if len(sub) else 0,
+                        "bin_levels": "",
+                        "converged": False,
+                        "note": f"stratum '{s}' not found in expression matrix",
+                    })
+                    continue
+                r = run_binned_interaction_lmm(
+                    sub,
+                    expr_series=wide[s],
+                    stratum=str(s),
+                    gene_col=gene_col,
+                    af_col=af_col,
+                    is_ptm_col=is_ptm_col,
+                )
+                row = {
+                    "stratum": r.stratum,
+                    "n_variants": r.n_variants,
+                    "n_genes": r.n_genes,
+                    "bin_levels": ",".join(r.bin_levels),
+                    "converged": r.converged,
+                    "note": r.note,
+                }
+                for b in r.bin_levels:
+                    if b in r.bin_betas:
+                        row[f"beta_{b}"] = r.bin_betas[b]
+                        row[f"se_{b}"] = r.bin_ses.get(b)
+                        row[f"p_{b}"] = r.bin_pvalues.get(b)
+                rows.append(row)
+            _pd.DataFrame(rows).to_csv(output, sep="\t", index=False)
+
+        click.echo(f"Wrote {len(rows)} rows to {output}")
+
+    except Exception as e:
+        logger.exception(f"PTM test failed: {e}")
+        click.echo(f"Error: {e}", err=True)
+        ctx.exit(1)

--- a/hvantk/commands/ptm_cli.py
+++ b/hvantk/commands/ptm_cli.py
@@ -877,7 +877,8 @@ def _read_expression_wide(pkl_path, tsv_path):
     default=None,
     help=(
         "lmm-binned only: pandas-pickled DataFrame (gene x stratum) with "
-        "expression values. Missing strata are skipped."
+        "expression values. Missing strata are skipped. "
+        "Only load pickle files from trusted sources."
     ),
 )
 @click.option(

--- a/hvantk/commands/ptm_cli.py
+++ b/hvantk/commands/ptm_cli.py
@@ -816,13 +816,22 @@ def ptm_atlas(
 def _read_variants_table(path: str):
     """Load a variant table from CSV/TSV with transparent gzip/bgz support."""
     import pandas as _pd
+    from pathlib import Path
 
     p = str(path)
-    # pandas infers compression from extension (.gz / .bgz handled via gzip).
-    sep = "\t" if p.endswith((".tsv", ".tsv.gz", ".tsv.bgz", ".tab")) else None
-    if sep is None:
-        # Fall back to comma separator if neither .tsv nor .csv explicit.
-        sep = "," if p.endswith((".csv", ".csv.gz")) else "\t"
+    # Derive the delimiter from the last non-compression suffix so inputs like
+    # ``variants.csv.bgz`` are parsed as CSV, not TSV.
+    compression_suffixes = {".gz", ".bgz", ".bz2"}
+    base_suffix = next(
+        (s.lower() for s in reversed(Path(p).suffixes) if s.lower() not in compression_suffixes),
+        "",
+    )
+    if base_suffix in {".tsv", ".tab"}:
+        sep = "\t"
+    elif base_suffix == ".csv":
+        sep = ","
+    else:
+        sep = "\t"
     return _pd.read_csv(p, sep=sep, low_memory=False)
 
 

--- a/hvantk/ptm/__init__.py
+++ b/hvantk/ptm/__init__.py
@@ -24,6 +24,15 @@ from hvantk.ptm.constants import (
     PTM_TYPE_CATEGORIES,
     DEFAULT_FLANKING_CODONS,
     PTM_OUTPUT_COLUMNS,
+    PROXIMAL_BP,
+    DEFAULT_MAF_THRESHOLDS,
+    EXPRESSION_BIN_LABELS,
+    LOG_AF_EPSILON,
+    LMM_MIN_N_PTM,
+    LMM_MIN_N_NONPTM,
+    LMM_MIN_MIXED_GENES,
+    LMM_BINNED_MIN_POS_EXPR,
+    LMM_BINNED_MIN_CELL_N,
 )
 
 # Lazy imports for Hail-dependent and heavy modules (PEP 562).
@@ -69,6 +78,25 @@ _LAZY_MODULES = {
     "encode_figure_to_base64": ("hvantk.ptm.plot", "encode_figure_to_base64"),
     # report
     "generate_report": ("hvantk.ptm.report", "generate_report"),
+    # Phase-2 atlas facade
+    "PTMAtlasConfig": ("hvantk.ptm.atlas", "PTMAtlasConfig"),
+    "PTMAtlasResult": ("hvantk.ptm.atlas", "PTMAtlasResult"),
+    "build_atlas": ("hvantk.ptm.atlas", "build_atlas"),
+    # Phase-2 SYMBOL-based annotation (pandas)
+    "annotate_variants_by_symbol": (
+        "hvantk.ptm.annotate",
+        "annotate_variants_by_symbol",
+    ),
+    # Phase-2 constraint tests (statsmodels)
+    "LMMResult": ("hvantk.ptm.test", "LMMResult"),
+    "BinnedLMMResult": ("hvantk.ptm.test", "BinnedLMMResult"),
+    "run_lmm": ("hvantk.ptm.test", "run_lmm"),
+    "run_binned_interaction_lmm": (
+        "hvantk.ptm.test",
+        "run_binned_interaction_lmm",
+    ),
+    # Phase-2 report writer
+    "generate_phase2_report": ("hvantk.ptm.report", "generate_phase2_report"),
 }
 
 
@@ -126,4 +154,26 @@ __all__ = [
     "PTM_TYPE_CATEGORIES",
     "DEFAULT_FLANKING_CODONS",
     "PTM_OUTPUT_COLUMNS",
+    "PROXIMAL_BP",
+    "DEFAULT_MAF_THRESHOLDS",
+    "EXPRESSION_BIN_LABELS",
+    "LOG_AF_EPSILON",
+    "LMM_MIN_N_PTM",
+    "LMM_MIN_N_NONPTM",
+    "LMM_MIN_MIXED_GENES",
+    "LMM_BINNED_MIN_POS_EXPR",
+    "LMM_BINNED_MIN_CELL_N",
+    # Phase-2 atlas
+    "PTMAtlasConfig",
+    "PTMAtlasResult",
+    "build_atlas",
+    # Phase-2 SYMBOL annotation
+    "annotate_variants_by_symbol",
+    # Phase-2 tests
+    "LMMResult",
+    "BinnedLMMResult",
+    "run_lmm",
+    "run_binned_interaction_lmm",
+    # Phase-2 report
+    "generate_phase2_report",
 ]

--- a/hvantk/ptm/annotate.py
+++ b/hvantk/ptm/annotate.py
@@ -9,12 +9,17 @@ Also exposes a pandas-based SYMBOL+chrom annotator
 semantics for the CHD case-control workflow.
 """
 
-import hail as hl
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
 from hvantk.ptm.constants import PROXIMAL_BP
+
+if TYPE_CHECKING:
+    import hail as hl
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +61,8 @@ def annotate_variants_with_ptm(
     hl.Table
         Input table with PTM annotation fields added.
     """
+    import hail as hl
+
     ref_genome = variants_ht.locus.dtype.reference_genome.name
     flank_bp = flanking_codons * 3
 

--- a/hvantk/ptm/annotate.py
+++ b/hvantk/ptm/annotate.py
@@ -3,10 +3,18 @@
 Annotates a variant Hail Table with PTM site proximity information using
 position expansion and locus-based joins. This avoids Hail's interval join
 limitations with overlapping intervals (common for adjacent PTM sites).
+
+Also exposes a pandas-based SYMBOL+chrom annotator
+(``annotate_variants_by_symbol``) that reproduces notebook N's Cell 4 / 11
+semantics for the CHD case-control workflow.
 """
 
 import hail as hl
 import logging
+
+import pandas as pd
+
+from hvantk.ptm.constants import PROXIMAL_BP
 
 logger = logging.getLogger(__name__)
 
@@ -146,3 +154,125 @@ def annotate_variants_with_ptm(
 
     logger.info("PTM annotation complete")
     return result
+
+
+def annotate_variants_by_symbol(
+    variants_df: pd.DataFrame,
+    ptm_df: pd.DataFrame,
+    proximal_bp: int = PROXIMAL_BP,
+    variant_gene_col: str = "SYMBOL",
+    variant_chrom_col: str = "chrom",
+    variant_pos_col: str = "pos",
+    atlas_gene_col: str = "gene_symbol",
+    atlas_chrom_col: str = "chrom",
+) -> pd.DataFrame:
+    """Per-variant ``is_ptm_site`` / ``is_ptm_proximal`` via SYMBOL + chrom merge.
+
+    Reproduces notebook_n Cell 4 / Cell 11 semantics exactly. Both flags can
+    be True simultaneously (``is_ptm_proximal`` is NOT exclusive of
+    ``is_ptm_site``).
+
+    The routine:
+
+    1. Strips ``^chr`` from ``variant_chrom_col`` and ``atlas_chrom_col``.
+    2. Drops atlas rows with null ``atlas_gene_col``, ``codon_start``, or
+       ``codon_end``.
+    3. Casts ``codon_start`` / ``codon_end`` to ``int``.
+    4. Does an inner merge on ``(variant_gene_col, variant_chrom_col) ==
+       (atlas_gene_col, atlas_chrom_col)``, then filters by
+       ``codon_start <= pos <= codon_end`` to flag ``is_ptm_site``.
+    5. Repeats the merge against the expanded window
+       ``[codon_start - proximal_bp, codon_end + proximal_bp]`` to flag
+       ``is_ptm_proximal``.
+
+    Parameters
+    ----------
+    variants_df : pandas.DataFrame
+        Variants with at minimum ``variant_gene_col``, ``variant_chrom_col``,
+        and ``variant_pos_col`` columns.
+    ptm_df : pandas.DataFrame
+        PTM atlas rows (e.g. parsed from ``ptm_sites_combined.tsv.bgz``) with
+        ``atlas_gene_col``, ``atlas_chrom_col``, ``codon_start``, and
+        ``codon_end`` columns.
+    proximal_bp : int
+        Flank (in base pairs) applied to both ends of the codon interval for
+        ``is_ptm_proximal``. Default: :data:`PROXIMAL_BP` (21 bp).
+    variant_gene_col, variant_chrom_col, variant_pos_col : str
+        Column names in ``variants_df``.
+    atlas_gene_col, atlas_chrom_col : str
+        Column names in ``ptm_df``; codon columns are always named
+        ``codon_start`` / ``codon_end`` to match the Phase-2 atlas TSV.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A copy of ``variants_df`` with ``is_ptm_site`` and ``is_ptm_proximal``
+        boolean columns added. Existing columns are preserved unchanged.
+    """
+    required_variant_cols = {variant_gene_col, variant_chrom_col, variant_pos_col}
+    missing = required_variant_cols - set(variants_df.columns)
+    if missing:
+        raise KeyError(
+            f"variants_df is missing required columns: {sorted(missing)}"
+        )
+    required_atlas_cols = {atlas_gene_col, atlas_chrom_col, "codon_start", "codon_end"}
+    missing = required_atlas_cols - set(ptm_df.columns)
+    if missing:
+        raise KeyError(
+            f"ptm_df is missing required columns: {sorted(missing)}"
+        )
+
+    out = variants_df.copy()
+
+    # --- Normalize chromosome notation: strip 'chr' prefix on both sides ---
+    out[variant_chrom_col] = (
+        out[variant_chrom_col].astype(str).str.replace(r"^chr", "", regex=True)
+    )
+
+    atlas = ptm_df.copy()
+    atlas[atlas_chrom_col] = (
+        atlas[atlas_chrom_col].astype(str).str.replace(r"^chr", "", regex=True)
+    )
+
+    # Drop atlas rows with null keys / codon bounds, cast codon cols to int.
+    atlas = atlas.dropna(subset=[atlas_gene_col, "codon_start", "codon_end"])
+    atlas["codon_start"] = atlas["codon_start"].astype(int)
+    atlas["codon_end"] = atlas["codon_end"].astype(int)
+
+    # --- Cell 4: is_ptm_site (inside codon interval) ---
+    left = (
+        out[[variant_gene_col, variant_chrom_col, variant_pos_col]]
+        .reset_index()
+        .rename(columns={"index": "_var_ix"})
+    )
+    joined_site = left.merge(
+        atlas[[atlas_gene_col, atlas_chrom_col, "codon_start", "codon_end"]],
+        how="inner",
+        left_on=[variant_gene_col, variant_chrom_col],
+        right_on=[atlas_gene_col, atlas_chrom_col],
+    )
+    hit_site = joined_site[
+        (joined_site[variant_pos_col] >= joined_site["codon_start"])
+        & (joined_site[variant_pos_col] <= joined_site["codon_end"])
+    ]
+    ptm_var_ix = set(hit_site["_var_ix"].unique())
+    out["is_ptm_site"] = out.index.isin(ptm_var_ix)
+
+    # --- Cell 11: is_ptm_proximal (inside expanded codon interval) ---
+    atlas_prox = atlas.copy()
+    atlas_prox["prox_start"] = atlas_prox["codon_start"] - int(proximal_bp)
+    atlas_prox["prox_end"] = atlas_prox["codon_end"] + int(proximal_bp)
+    joined_prox = left.merge(
+        atlas_prox[[atlas_gene_col, atlas_chrom_col, "prox_start", "prox_end"]],
+        how="inner",
+        left_on=[variant_gene_col, variant_chrom_col],
+        right_on=[atlas_gene_col, atlas_chrom_col],
+    )
+    hit_prox = joined_prox[
+        (joined_prox[variant_pos_col] >= joined_prox["prox_start"])
+        & (joined_prox[variant_pos_col] <= joined_prox["prox_end"])
+    ]
+    prox_var_ix = set(hit_prox["_var_ix"].unique())
+    out["is_ptm_proximal"] = out.index.isin(prox_var_ix)
+
+    return out

--- a/hvantk/ptm/atlas.py
+++ b/hvantk/ptm/atlas.py
@@ -89,6 +89,11 @@ class PTMAtlasConfig:
             errors.append("output_ht is required")
         if not self.sources:
             errors.append("at least one source is required")
+        if self.sources and "uniprot" not in {s.lower() for s in self.sources}:
+            errors.append(
+                "'uniprot' is required: the underlying ptm_build_pipeline "
+                "always runs UniProt as the primary source"
+            )
         unknown = [s for s in self.sources if s.lower() not in _KNOWN_SOURCES]
         if unknown:
             errors.append(
@@ -156,24 +161,13 @@ def build_atlas(config: PTMAtlasConfig) -> PTMAtlasResult:
         raise ValueError(f"Invalid PTMAtlasConfig: {'; '.join(errors)}")
 
     sources = [s.lower() for s in config.sources]
-    include_uniprot = "uniprot" in sources
     include_peptideatlas = "peptideatlas" in sources
     include_cptac = "cptac" in sources
 
     # Translate the Phase-2 config into the legacy PTMBuildConfig. Unselected
     # sources are passed as None, which disables the corresponding pipeline
-    # step. UniProt is always the primary source in the legacy pipeline; if
-    # the caller opted it out, we fall back to the REST download anyway
-    # (pipeline.ptm_build_pipeline requires ptm_tsv to run).
-    if not include_uniprot:
-        # The shipped pipeline treats UniProt as the mandatory primary source
-        # (step 3 always runs). Warn rather than silently including it.
-        logger.warning(
-            "uniprot not listed in sources; pipeline still runs UniProt "
-            "as the mandatory primary source. Add 'uniprot' to sources "
-            "to suppress this warning."
-        )
-
+    # step. UniProt is enforced in ``PTMAtlasConfig.validate()`` because the
+    # shipped pipeline always runs it as the primary source.
     build_cfg = PTMBuildConfig(
         output_dir=config.output_dir,
         output_ht=config.output_ht,
@@ -205,15 +199,11 @@ def build_atlas(config: PTMAtlasConfig) -> PTMAtlasResult:
         if os.path.exists(expected):
             combined_tsv = expected
 
-    actual_sources = list(sources)
-    if "uniprot" not in actual_sources:
-        actual_sources.insert(0, "uniprot")
-
     return PTMAtlasResult(
         output_ht=build_result.output_ht,
         combined_tsv=combined_tsv,
         n_sites=build_result.n_mapped,
-        sources_used=actual_sources,
+        sources_used=list(sources),
     )
 
 

--- a/hvantk/ptm/atlas.py
+++ b/hvantk/ptm/atlas.py
@@ -89,7 +89,7 @@ class PTMAtlasConfig:
             errors.append("output_ht is required")
         if not self.sources:
             errors.append("at least one source is required")
-        unknown = [s for s in self.sources if s not in _KNOWN_SOURCES]
+        unknown = [s for s in self.sources if s.lower() not in _KNOWN_SOURCES]
         if unknown:
             errors.append(
                 f"unknown source(s): {unknown}; must be subset of {sorted(_KNOWN_SOURCES)}"
@@ -205,11 +205,15 @@ def build_atlas(config: PTMAtlasConfig) -> PTMAtlasResult:
         if os.path.exists(expected):
             combined_tsv = expected
 
+    actual_sources = list(sources)
+    if "uniprot" not in actual_sources:
+        actual_sources.insert(0, "uniprot")
+
     return PTMAtlasResult(
         output_ht=build_result.output_ht,
         combined_tsv=combined_tsv,
         n_sites=build_result.n_mapped,
-        sources_used=list(sources),
+        sources_used=actual_sources,
     )
 
 

--- a/hvantk/ptm/atlas.py
+++ b/hvantk/ptm/atlas.py
@@ -1,0 +1,221 @@
+"""Phase-2 PTM atlas assembly API.
+
+Thin facade over :func:`hvantk.ptm.pipeline.ptm_build_pipeline` that reproduces
+notebook A's ``ptm_sites_combined.tsv.bgz`` output. Defaults match notebook A:
+UniProt + PeptideAtlas sources, CPTAC disabled, flanking window of 7 codons.
+
+This module does NOT reimplement the download, coordinate mapping, or
+concat logic - it delegates entirely to the shipped build pipeline so the
+resulting TSV is byte-identical to the existing workflow.
+
+Example
+-------
+    >>> from hvantk.ptm.atlas import PTMAtlasConfig, build_atlas
+    >>> config = PTMAtlasConfig(
+    ...     output_dir="data/ptm/",
+    ...     output_ht="data/ptm/ptm_sites.ht",
+    ... )
+    >>> result = build_atlas(config)
+    >>> print(result.combined_tsv, result.n_sites)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+from hvantk.ptm.pipeline import PTMBuildConfig, PTMBuildResult, ptm_build_pipeline
+
+logger = logging.getLogger(__name__)
+
+# Default atlas sources: CPTAC is OFF by default because its download path
+# requires the optional ``cptac`` Python package and per-cancer-type fetches.
+# Notebook A uses all three, but the minimal reproducible atlas is UniProt +
+# PeptideAtlas.
+DEFAULT_ATLAS_SOURCES: Sequence[str] = ("uniprot", "peptideatlas")
+
+# Known source identifiers (used for validation).
+_KNOWN_SOURCES = frozenset({"uniprot", "peptideatlas", "cptac"})
+
+
+@dataclass
+class PTMAtlasConfig:
+    """Configuration for a Phase-2 PTM atlas build.
+
+    Attributes
+    ----------
+    output_dir : str
+        Directory for intermediate + combined TSV output (required).
+    output_ht : str
+        Path to the final PTM sites Hail Table (required).
+    sources : Sequence[str]
+        Sources to include; any subset of {"uniprot", "peptideatlas", "cptac"}.
+        Defaults to ("uniprot", "peptideatlas") - matches the minimal notebook-A
+        atlas that produces ``ptm_sites_combined.tsv.bgz``.
+    uniprot_tsv : Optional[str]
+        Pre-downloaded UniProt PTM TSV. If None and "uniprot" is selected,
+        the pipeline will download it via the REST API.
+    peptideatlas_tsv : Optional[str]
+        Pre-downloaded PeptideAtlas phospho intermediate TSV.
+    cptac_tsv : Optional[str]
+        Pre-downloaded CPTAC phospho combined TSV.
+    gtf_path : Optional[str]
+        Pre-downloaded Ensembl GTF (auto-downloaded if None).
+    flanking_codons : int
+        Flanking-codon window for proximity intervals. Phase-2 default is 7
+        (matches notebook A); the shipped pipeline default is 5.
+    overwrite : bool
+        Force re-run of downstream steps even if outputs exist.
+    """
+
+    output_dir: str = ""
+    output_ht: str = ""
+    sources: Sequence[str] = field(default_factory=lambda: list(DEFAULT_ATLAS_SOURCES))
+    uniprot_tsv: Optional[str] = None
+    peptideatlas_tsv: Optional[str] = None
+    cptac_tsv: Optional[str] = None
+    gtf_path: Optional[str] = None
+    flanking_codons: int = 7
+    overwrite: bool = False
+
+    def validate(self) -> List[str]:
+        """Return a list of configuration errors (empty if valid)."""
+        errors: List[str] = []
+        if not self.output_dir:
+            errors.append("output_dir is required")
+        if not self.output_ht:
+            errors.append("output_ht is required")
+        if not self.sources:
+            errors.append("at least one source is required")
+        unknown = [s for s in self.sources if s not in _KNOWN_SOURCES]
+        if unknown:
+            errors.append(
+                f"unknown source(s): {unknown}; must be subset of {sorted(_KNOWN_SOURCES)}"
+            )
+        # Per-source file existence checks mirror PTMBuildConfig.validate().
+        if self.uniprot_tsv and not os.path.exists(self.uniprot_tsv):
+            errors.append(f"uniprot_tsv not found: {self.uniprot_tsv}")
+        if self.peptideatlas_tsv and not os.path.exists(self.peptideatlas_tsv):
+            errors.append(f"peptideatlas_tsv not found: {self.peptideatlas_tsv}")
+        if self.cptac_tsv and not os.path.exists(self.cptac_tsv):
+            errors.append(f"cptac_tsv not found: {self.cptac_tsv}")
+        if self.gtf_path and not os.path.exists(self.gtf_path):
+            errors.append(f"gtf_path not found: {self.gtf_path}")
+        return errors
+
+
+@dataclass
+class PTMAtlasResult:
+    """Result of a Phase-2 PTM atlas build.
+
+    Attributes
+    ----------
+    output_ht : str
+        Path to the final PTM sites Hail Table.
+    combined_tsv : str
+        Path to the combined BGZ TSV produced by the pipeline:
+        ``ptm_sites_combined.tsv.bgz`` when CPTAC is disabled, or
+        ``ptm_sites_all_combined.tsv.bgz`` when CPTAC is included.
+    n_sites : int
+        Number of PTM sites successfully mapped (summed across sources).
+    sources_used : list[str]
+        Sources included in this build (subset of DEFAULT_ATLAS_SOURCES + cptac).
+    """
+
+    output_ht: str = ""
+    combined_tsv: str = ""
+    n_sites: int = 0
+    sources_used: List[str] = field(default_factory=list)
+
+
+def build_atlas(config: PTMAtlasConfig) -> PTMAtlasResult:
+    """Build a Phase-2 PTM atlas by delegating to ``ptm_build_pipeline``.
+
+    Reproduces notebook A's ``ptm_sites_combined.tsv.bgz`` exactly - no
+    cross-source deduplication is performed (matches the existing pipeline).
+
+    Parameters
+    ----------
+    config : PTMAtlasConfig
+        Build configuration.
+
+    Returns
+    -------
+    PTMAtlasResult
+        Output paths, mapped-site count, and list of sources used.
+
+    Raises
+    ------
+    ValueError
+        If config.validate() returns any errors.
+    """
+    errors = config.validate()
+    if errors:
+        raise ValueError(f"Invalid PTMAtlasConfig: {'; '.join(errors)}")
+
+    sources = [s.lower() for s in config.sources]
+    include_uniprot = "uniprot" in sources
+    include_peptideatlas = "peptideatlas" in sources
+    include_cptac = "cptac" in sources
+
+    # Translate the Phase-2 config into the legacy PTMBuildConfig. Unselected
+    # sources are passed as None, which disables the corresponding pipeline
+    # step. UniProt is always the primary source in the legacy pipeline; if
+    # the caller opted it out, we fall back to the REST download anyway
+    # (pipeline.ptm_build_pipeline requires ptm_tsv to run).
+    if not include_uniprot:
+        # The shipped pipeline treats UniProt as the mandatory primary source
+        # (step 3 always runs). Warn rather than silently including it.
+        logger.warning(
+            "uniprot not listed in sources; pipeline still runs UniProt "
+            "as the mandatory primary source. Add 'uniprot' to sources "
+            "to suppress this warning."
+        )
+
+    build_cfg = PTMBuildConfig(
+        output_dir=config.output_dir,
+        output_ht=config.output_ht,
+        gtf_path=config.gtf_path,
+        ptm_tsv=config.uniprot_tsv,
+        peptideatlas_tsv=config.peptideatlas_tsv if include_peptideatlas else None,
+        cptac_tsv=config.cptac_tsv if include_cptac else None,
+        flanking_codons=config.flanking_codons,
+        overwrite=config.overwrite,
+    )
+
+    logger.info(
+        "Building Phase-2 PTM atlas (sources=%s, flanking_codons=%d)",
+        sources,
+        config.flanking_codons,
+    )
+    build_result: PTMBuildResult = ptm_build_pipeline(build_cfg)
+
+    # The pipeline emits:
+    #   - ptm_sites_mapped.tsv.bgz when only UniProt is used
+    #   - ptm_sites_combined.tsv.bgz when UniProt + PeptideAtlas
+    #   - ptm_sites_all_combined.tsv.bgz when CPTAC is also included
+    # Report the final combined TSV path for reproducibility with notebook A.
+    combined_tsv = build_result.mapped_tsv_path
+    if include_cptac:
+        # ptm_build_pipeline points mapped_tsv_path at the combined (no-CPTAC)
+        # TSV; the CPTAC-augmented file has a distinct name.
+        expected = os.path.join(config.output_dir, "ptm_sites_all_combined.tsv.bgz")
+        if os.path.exists(expected):
+            combined_tsv = expected
+
+    return PTMAtlasResult(
+        output_ht=build_result.output_ht,
+        combined_tsv=combined_tsv,
+        n_sites=build_result.n_mapped,
+        sources_used=list(sources),
+    )
+
+
+__all__ = [
+    "DEFAULT_ATLAS_SOURCES",
+    "PTMAtlasConfig",
+    "PTMAtlasResult",
+    "build_atlas",
+]

--- a/hvantk/ptm/constants.py
+++ b/hvantk/ptm/constants.py
@@ -80,3 +80,43 @@ PTM_OUTPUT_COLUMNS = [
 
 # Transcript resolution method names (for logging/QC)
 RESOLUTION_METHODS = ["xref_mane", "xref_any", "gene_mane"]
+
+# ---------------------------------------------------------------------------
+# Phase-2 defaults (notebook A / M / K / N)
+# ---------------------------------------------------------------------------
+
+# Proximal flanking window for SYMBOL-based variant annotation:
+# ±7 aa in codon space ≈ ±21 bp in genomic coordinates (notebook N Cell 11).
+# One-sided; applied to both codon_start and codon_end (see ptm.annotate).
+PROXIMAL_BP = 21
+
+# Default MAF thresholds referenced by Phase-2 documentation.
+# Notebooks M and K do NOT apply MAF cut-offs (they work from ClinVar B/LB
+# variants only). Notebook N uses MAF <= 0.001 on an internal CHD cohort.
+# These values are kept as Phase-2 defaults/placeholders for any
+# caller that wants a consistent set of bins (common/rare/ultra-rare);
+# callers that need the exact notebook-N rare filter should pass
+# ``rare=1e-3`` explicitly.
+DEFAULT_MAF_THRESHOLDS = {
+    "common": 0.01,
+    "rare": 0.001,
+    "ultra_rare": 1e-5,
+}
+
+# Ordered category for the binned-interaction LMM (notebook K).
+# "b0_none" is the reference (zero-expression) bin; Q1-Q4 are quartiles of
+# log2(expr + 1) across positive-expression variants. Actual bin count in
+# a fit may be smaller when pd.qcut collapses ties (duplicates="drop").
+EXPRESSION_BIN_LABELS = ["b0_none", "b1_Q1", "b2_Q2", "b3_Q3", "b4_Q4"]
+
+# Pseudocount for log10(AF + eps) transformation used by notebooks K and M.
+LOG_AF_EPSILON = 1e-8
+
+# Per-stratum filter thresholds for the constraint LMM (notebook M Cell 5).
+LMM_MIN_N_PTM = 30
+LMM_MIN_N_NONPTM = 30
+LMM_MIN_MIXED_GENES = 10
+
+# Sparsity gates for the binned-interaction LMM (notebook K Cell 4d).
+LMM_BINNED_MIN_POS_EXPR = 100
+LMM_BINNED_MIN_CELL_N = 5

--- a/hvantk/ptm/report.py
+++ b/hvantk/ptm/report.py
@@ -549,9 +549,9 @@ def generate_phase2_report(
         sections.append(_build_phase2_atlas_section(atlas_result))
     if annotation_summary is not None:
         sections.append(_build_phase2_annotation_section(annotation_summary))
-    if lmm_results:
+    if lmm_results is not None:
         sections.append(_build_phase2_lmm_section(lmm_results))
-    if binned_lmm_results:
+    if binned_lmm_results is not None:
         sections.append(_build_phase2_binned_section(binned_lmm_results))
 
     sections.append(_build_footer())

--- a/hvantk/ptm/report.py
+++ b/hvantk/ptm/report.py
@@ -11,7 +11,7 @@ import html
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 
@@ -23,6 +23,10 @@ from hvantk.ptm.plot import (
     plot_overlap_by_category,
     plot_population_af,
 )
+
+if TYPE_CHECKING:  # avoid import-time Hail/statsmodels load for type hints
+    from hvantk.ptm.atlas import PTMAtlasResult
+    from hvantk.ptm.test import BinnedLMMResult, LMMResult
 
 logger = logging.getLogger(__name__)
 
@@ -483,3 +487,227 @@ def _get_css(colors: Dict[str, str]) -> str:
             color: #666;
         }}
     """
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 report (atlas + SYMBOL annotation + LMM results)
+# ---------------------------------------------------------------------------
+
+
+def generate_phase2_report(
+    output_path: str,
+    *,
+    atlas_result: Optional["PTMAtlasResult"] = None,
+    annotation_summary: Optional[Dict[str, Any]] = None,
+    lmm_results: Optional[Sequence["LMMResult"]] = None,
+    binned_lmm_results: Optional[Sequence["BinnedLMMResult"]] = None,
+    title: str = "PTM Phase-2 Analysis Report",
+    description: Optional[str] = None,
+) -> str:
+    """Write a Phase-2 HTML summary (no plots; plots added in Phase 4).
+
+    Each section renders only if its corresponding input is non-None so the
+    same report writer serves atlas-only, annotation-only, or test-only runs.
+
+    Parameters
+    ----------
+    output_path : str
+        Destination HTML file path.
+    atlas_result : PTMAtlasResult, optional
+        Output of :func:`hvantk.ptm.atlas.build_atlas`.
+    annotation_summary : dict, optional
+        Counters for the SYMBOL-based annotation; expected keys are
+        ``n_total``, ``n_ptm_site``, ``n_ptm_proximal``, ``n_both``,
+        ``n_neither`` but any subset is accepted.
+    lmm_results : sequence of LMMResult, optional
+        Per-stratum constraint LMM results (notebook M style).
+    binned_lmm_results : sequence of BinnedLMMResult, optional
+        Per-stratum binned-interaction LMM results (notebook K style).
+    title : str
+        Report title.
+    description : str, optional
+        Short description paragraph rendered beneath the title.
+
+    Returns
+    -------
+    str
+        The ``output_path`` (absolute or relative, whatever the caller passed).
+    """
+    out_path = Path(output_path).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Generating PTM Phase-2 report at %s", out_path)
+
+    sections: List[str] = [
+        _build_header(
+            title=title,
+            description=description,
+            date=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        )
+    ]
+
+    if atlas_result is not None:
+        sections.append(_build_phase2_atlas_section(atlas_result))
+    if annotation_summary is not None:
+        sections.append(_build_phase2_annotation_section(annotation_summary))
+    if lmm_results:
+        sections.append(_build_phase2_lmm_section(lmm_results))
+    if binned_lmm_results:
+        sections.append(_build_phase2_binned_section(binned_lmm_results))
+
+    sections.append(_build_footer())
+
+    css = _get_css(_DEFAULT_COLORS)
+    body = "\n".join(s for s in sections if s)
+    html_out = (
+        f"<!DOCTYPE html><html><head><meta charset='utf-8'>"
+        f"<title>{html.escape(title)}</title>"
+        f"<style>{css}</style></head><body>{body}</body></html>"
+    )
+    out_path.write_text(html_out, encoding="utf-8")
+    logger.info("Phase-2 report saved to %s", out_path)
+    return str(output_path)
+
+
+def _build_phase2_atlas_section(result: "PTMAtlasResult") -> str:
+    sources = ", ".join(html.escape(s) for s in result.sources_used) or "-"
+    return (
+        "<section><h2>Atlas Summary</h2>"
+        "<div class='card-grid'>"
+        f"<div class='card'><h3>Sources</h3><p>{sources}</p></div>"
+        f"<div class='card'><h3>Sites Mapped</h3>"
+        f"<p>{result.n_sites:,}</p></div>"
+        "</div>"
+        "<table><thead><tr><th>Output</th><th>Path</th></tr></thead>"
+        "<tbody>"
+        f"<tr><td>Combined TSV</td><td>{html.escape(result.combined_tsv)}</td></tr>"
+        f"<tr><td>Hail Table</td><td>{html.escape(result.output_ht)}</td></tr>"
+        "</tbody></table>"
+        "</section>"
+    )
+
+
+def _build_phase2_annotation_section(summary: Dict[str, Any]) -> str:
+    keys = ("n_total", "n_ptm_site", "n_ptm_proximal", "n_both", "n_neither")
+    rows = ""
+    for k in keys:
+        if k not in summary:
+            continue
+        val = summary[k]
+        try:
+            val_str = f"{int(val):,}"
+        except (TypeError, ValueError):
+            val_str = html.escape(str(val))
+        rows += f"<tr><td>{html.escape(k)}</td><td>{val_str}</td></tr>"
+    # Include any extra keys the caller supplied.
+    extras = {k: v for k, v in summary.items() if k not in keys}
+    for k, v in extras.items():
+        try:
+            v_str = f"{int(v):,}"
+        except (TypeError, ValueError):
+            v_str = html.escape(str(v))
+        rows += f"<tr><td>{html.escape(str(k))}</td><td>{v_str}</td></tr>"
+    if not rows:
+        rows = "<tr><td colspan='2'>(no counts provided)</td></tr>"
+    return (
+        "<section><h2>SYMBOL Annotation Summary</h2>"
+        "<table><thead><tr><th>Metric</th><th>Count</th></tr></thead>"
+        f"<tbody>{rows}</tbody></table>"
+        "</section>"
+    )
+
+
+def _fmt_float(val: float, fmt: str = "{:.3g}") -> str:
+    try:
+        if val is None:
+            return "-"
+        fv = float(val)
+    except (TypeError, ValueError):
+        return html.escape(str(val))
+    if fv != fv:  # NaN check
+        return "NaN"
+    return fmt.format(fv)
+
+
+def _build_phase2_lmm_section(results: Sequence["LMMResult"]) -> str:
+    rows = ""
+    for r in results:
+        rows += (
+            "<tr>"
+            f"<td>{html.escape(str(r.stratum))}</td>"
+            f"<td>{r.n_variants:,}</td>"
+            f"<td>{r.n_ptm:,}</td>"
+            f"<td>{r.n_nonptm:,}</td>"
+            f"<td>{r.n_genes:,}</td>"
+            f"<td>{r.n_mixed_genes:,}</td>"
+            f"<td>{_fmt_float(r.beta_ptm)}</td>"
+            f"<td>{_fmt_float(r.se_ptm)}</td>"
+            f"<td>{_fmt_float(r.p_ptm, '{:.2e}')}</td>"
+            f"<td>{'yes' if r.converged else 'no'}</td>"
+            f"<td>{html.escape(r.note or '')}</td>"
+            "</tr>"
+        )
+    if not rows:
+        rows = "<tr><td colspan='11'>(no results)</td></tr>"
+    return (
+        "<section><h2>Constraint LMM</h2>"
+        "<p>Per-stratum <code>log_af ~ is_ptm + (1|gene)</code> "
+        "(notebook M).</p>"
+        "<table><thead><tr>"
+        "<th>Stratum</th><th>N</th><th>N PTM</th><th>N non-PTM</th>"
+        "<th>N genes</th><th>N mixed</th>"
+        "<th>beta</th><th>SE</th><th>p</th><th>converged</th><th>note</th>"
+        f"</tr></thead><tbody>{rows}</tbody></table>"
+        "</section>"
+    )
+
+
+def _build_phase2_binned_section(results: Sequence["BinnedLMMResult"]) -> str:
+    # Union of bin labels across strata (preserve first-seen order).
+    all_bins: List[str] = []
+    for r in results:
+        for b in r.bin_levels:
+            if b not in all_bins:
+                all_bins.append(b)
+
+    header = "<tr><th>Stratum</th><th>N</th><th>N genes</th>"
+    for b in all_bins:
+        header += f"<th>{html.escape(b)} beta</th><th>SE</th><th>p</th>"
+    header += "<th>converged</th><th>note</th></tr>"
+
+    body_rows = ""
+    for r in results:
+        row = (
+            f"<tr><td>{html.escape(str(r.stratum))}</td>"
+            f"<td>{r.n_variants:,}</td>"
+            f"<td>{r.n_genes:,}</td>"
+        )
+        for b in all_bins:
+            if b in r.bin_betas:
+                row += (
+                    f"<td>{_fmt_float(r.bin_betas[b])}</td>"
+                    f"<td>{_fmt_float(r.bin_ses.get(b, float('nan')))}</td>"
+                    f"<td>{_fmt_float(r.bin_pvalues.get(b, float('nan')), '{:.2e}')}</td>"
+                )
+            else:
+                row += "<td>-</td><td>-</td><td>-</td>"
+        row += (
+            f"<td>{'yes' if r.converged else 'no'}</td>"
+            f"<td>{html.escape(r.note or '')}</td></tr>"
+        )
+        body_rows += row
+
+    if not body_rows:
+        body_rows = (
+            f"<tr><td colspan='{3 + 3 * len(all_bins) + 2}'>"
+            "(no results)</td></tr>"
+        )
+
+    return (
+        "<section><h2>Binned-Interaction LMM</h2>"
+        "<p>Per-stratum <code>log_af ~ is_ptm * C(expr_bin) + (1|gene)</code> "
+        "(notebook K). Reference bin <code>b0_none</code> is zero-expression; "
+        "<code>b1..bK</code> are quantiles of <code>log2(expr + 1)</code>. "
+        "Missing cells indicate bins not realized for that stratum.</p>"
+        f"<table><thead>{header}</thead><tbody>{body_rows}</tbody></table>"
+        "</section>"
+    )

--- a/hvantk/ptm/test.py
+++ b/hvantk/ptm/test.py
@@ -272,7 +272,14 @@ def run_binned_interaction_lmm(
     dfx["expr_bin"] = pd.Categorical(assigned, categories=ordered, ordered=True)
 
     # Sparsity gate: every (expr_bin, is_ptm) cell must have >= min_cell_n.
-    bc = dfx.groupby(["expr_bin", "is_ptm"], observed=False).size().unstack(fill_value=0)
+    # Reindex columns to [0, 1] so strata missing an entire PTM class still
+    # fail the gate instead of squeezing through on a degenerate design.
+    bc = (
+        dfx.groupby(["expr_bin", "is_ptm"], observed=False)
+        .size()
+        .unstack(fill_value=0)
+        .reindex(columns=[0, 1], fill_value=0)
+    )
     if (bc < min_cell_n).any().any():
         return _skipped("skipped: sparse bins", bin_levels=ordered)
 

--- a/hvantk/ptm/test.py
+++ b/hvantk/ptm/test.py
@@ -120,7 +120,7 @@ def run_lmm(
         Filter thresholds (notebook M defaults).
     """
     # Drop rows missing any required column (match notebook M's dropna).
-    sub = df.dropna(subset=[af_col, gene_col]).copy()
+    sub = df.dropna(subset=[af_col, gene_col, is_ptm_col]).copy()
     sub = sub[sub[af_col] > 0].copy()
     sub["log_af"] = np.log10(sub[af_col] + eps)
     sub["is_ptm"] = sub[is_ptm_col].astype(int)
@@ -225,8 +225,8 @@ def run_binned_interaction_lmm(
     min_cell_n : int
         Minimum count per ``(expr_bin, is_ptm)`` cell to proceed with the fit.
     """
-    # Drop rows missing AF/gene, then af > 0 (matches notebook K).
-    dfx = df.dropna(subset=[af_col, gene_col]).copy()
+    # Drop rows missing AF/gene/is_ptm, then af > 0 (matches notebook K).
+    dfx = df.dropna(subset=[af_col, gene_col, is_ptm_col]).copy()
     dfx = dfx[dfx[af_col] > 0].copy()
     dfx["log_af"] = np.log10(dfx[af_col] + eps)
     dfx["is_ptm"] = dfx[is_ptm_col].astype(int)

--- a/hvantk/ptm/test.py
+++ b/hvantk/ptm/test.py
@@ -1,0 +1,330 @@
+"""Phase-2 PTM constraint tests (LMM and binned-interaction LMM).
+
+Factored from:
+
+- notebook M (per-tissue constraint LMM on GTEx) -> :func:`run_lmm`
+- notebook K (per-cell-type binned-interaction LMM on Velmeshev cortex) ->
+  :func:`run_binned_interaction_lmm`
+
+Both functions are per-stratum: the caller iterates over tissues / cell types
+and is responsible for assembling results. This matches the notebook style
+and keeps the API surface small.
+
+Example
+-------
+    >>> from hvantk.ptm.test import run_lmm, run_binned_interaction_lmm
+    >>> result = run_lmm(df_heart, stratum="Heart")
+    >>> print(result.beta_ptm, result.p_ptm)
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+import statsmodels.formula.api as smf
+
+from hvantk.ptm.constants import (
+    LMM_BINNED_MIN_CELL_N,
+    LMM_BINNED_MIN_POS_EXPR,
+    LMM_MIN_MIXED_GENES,
+    LMM_MIN_N_NONPTM,
+    LMM_MIN_N_PTM,
+    LOG_AF_EPSILON,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LMMResult:
+    """Per-stratum result of the constraint LMM (notebook M Cell 5).
+
+    Fields are populated on fit success; skipped strata return NaN betas and
+    an explanatory ``note`` string (never raise).
+    """
+
+    stratum: str
+    n_variants: int
+    n_ptm: int
+    n_nonptm: int
+    n_genes: int
+    n_mixed_genes: int
+    beta_ptm: float
+    se_ptm: float
+    p_ptm: float
+    converged: bool
+    note: str
+
+
+@dataclass
+class BinnedLMMResult:
+    """Per-stratum result of the binned-interaction LMM (notebook K Cell 4d).
+
+    ``bin_levels`` always starts with ``"b0_none"`` and ends with the last
+    quantile bin actually realized by ``pd.qcut(..., duplicates='drop')``.
+    ``bin_betas`` / ``bin_ses`` / ``bin_pvalues`` are keyed by bin label and
+    may be empty dicts when the fit was skipped.
+    """
+
+    stratum: str
+    bin_levels: List[str]
+    bin_betas: Dict[str, float] = field(default_factory=dict)
+    bin_ses: Dict[str, float] = field(default_factory=dict)
+    bin_pvalues: Dict[str, float] = field(default_factory=dict)
+    n_variants: int = 0
+    n_genes: int = 0
+    converged: bool = False
+    note: str = ""
+
+
+def run_lmm(
+    df: pd.DataFrame,
+    stratum: str,
+    gene_col: str = "gene",
+    af_col: str = "af_filled",
+    is_ptm_col: str = "is_ptm",
+    eps: float = LOG_AF_EPSILON,
+    min_n_ptm: int = LMM_MIN_N_PTM,
+    min_n_nonptm: int = LMM_MIN_N_NONPTM,
+    min_mixed_genes: int = LMM_MIN_MIXED_GENES,
+) -> LMMResult:
+    """Per-stratum constraint LMM: ``log_af ~ is_ptm + (1|gene)``.
+
+    Replicates notebook_m Cell 5 mixedlm usage exactly. Filters:
+
+    - ``af > 0`` on ``af_col``;
+    - ``n_ptm >= min_n_ptm`` and ``n_nonptm >= min_n_nonptm``;
+    - ``n_mixed_genes >= min_mixed_genes`` where a mixed gene has both PTM and
+      non-PTM variants.
+
+    Returns an :class:`LMMResult` with NaN betas and an explanatory ``note``
+    when the filters fail. Never raises.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Variants already filtered to the target stratum (caller slices).
+    stratum : str
+        Label for this stratum (e.g. tissue name); carried through to the
+        result object for plotting/report.
+    gene_col, af_col, is_ptm_col : str
+        Column names.
+    eps : float
+        Pseudocount for ``log10(af + eps)``. Default: :data:`LOG_AF_EPSILON`.
+    min_n_ptm, min_n_nonptm, min_mixed_genes : int
+        Filter thresholds (notebook M defaults).
+    """
+    # Drop rows missing any required column (match notebook M's dropna).
+    sub = df.dropna(subset=[af_col, gene_col]).copy()
+    sub = sub[sub[af_col] > 0].copy()
+    sub["log_af"] = np.log10(sub[af_col] + eps)
+    sub["is_ptm"] = sub[is_ptm_col].astype(int)
+
+    n_variants = int(len(sub))
+    n_ptm = int(sub["is_ptm"].sum())
+    n_nonptm = n_variants - n_ptm
+    n_genes = int(sub[gene_col].nunique()) if n_variants else 0
+    if n_variants:
+        mix = sub.groupby(gene_col)["is_ptm"].agg(["min", "max"])
+        n_mixed = int((mix["max"] > mix["min"]).sum())
+    else:
+        n_mixed = 0
+
+    def _skipped(note: str) -> LMMResult:
+        return LMMResult(
+            stratum=stratum,
+            n_variants=n_variants,
+            n_ptm=n_ptm,
+            n_nonptm=n_nonptm,
+            n_genes=n_genes,
+            n_mixed_genes=n_mixed,
+            beta_ptm=float("nan"),
+            se_ptm=float("nan"),
+            p_ptm=float("nan"),
+            converged=False,
+            note=note,
+        )
+
+    if n_ptm < min_n_ptm:
+        return _skipped(f"skipped: n_ptm={n_ptm} < {min_n_ptm}")
+    if n_nonptm < min_n_nonptm:
+        return _skipped(f"skipped: n_nonptm={n_nonptm} < {min_n_nonptm}")
+    if n_mixed < min_mixed_genes:
+        return _skipped(f"skipped: n_mixed_genes={n_mixed} < {min_mixed_genes}")
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            md = smf.mixedlm("log_af ~ is_ptm", data=sub, groups=sub[gene_col])
+            mf = md.fit(method="lbfgs", reml=True)
+    except Exception as e:  # pragma: no cover - fit errors bubbled into note
+        return _skipped(f"fit failed: {str(e)[:80]}")
+
+    return LMMResult(
+        stratum=stratum,
+        n_variants=n_variants,
+        n_ptm=n_ptm,
+        n_nonptm=n_nonptm,
+        n_genes=n_genes,
+        n_mixed_genes=n_mixed,
+        beta_ptm=float(mf.params["is_ptm"]),
+        se_ptm=float(mf.bse["is_ptm"]),
+        p_ptm=float(mf.pvalues["is_ptm"]),
+        converged=bool(mf.converged),
+        note="",
+    )
+
+
+def run_binned_interaction_lmm(
+    df: pd.DataFrame,
+    expr_series: pd.Series,
+    stratum: str,
+    gene_col: str = "gene",
+    af_col: str = "af_filled",
+    is_ptm_col: str = "is_ptm",
+    eps: float = LOG_AF_EPSILON,
+    n_quantiles: int = 4,
+    min_pos_expr: int = LMM_BINNED_MIN_POS_EXPR,
+    min_cell_n: int = LMM_BINNED_MIN_CELL_N,
+) -> BinnedLMMResult:
+    """Binned-interaction LMM: ``log_af ~ is_ptm * C(expr_bin) + (1|gene)``.
+
+    Replicates notebook_k Cell 4d mixedlm usage exactly:
+
+    - ``expr = expr_series[gene]``, ``expr_log = log2(expr + 1)``;
+    - ``pd.qcut(expr_log[expr > 0], q=n_quantiles, duplicates='drop')`` yields
+      dynamic bin labels ``b1_Q1, b2_Q2, ..., bK_Qk`` where ``K <= n_quantiles``;
+    - zero-expression variants are assigned to reference bin ``"b0_none"``;
+    - ``statsmodels`` fits with Treatment coding (reference = first category);
+    - per-bin beta is extracted via sum rule
+      ``beta_b = beta_ref + beta_(is_ptm:expr_bin[T.b])``;
+    - per-bin SE is ``sqrt(Var(a) + Var(b) + 2*Cov(a,b))`` via ``mf.cov_params()``;
+    - the reference bin p-value is the main ``is_ptm`` term; non-reference
+      bins report the interaction-term p.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Variants already filtered to the stratum's "base" set.
+    expr_series : pandas.Series
+        Gene-to-expression mapping (index = gene symbol, values = expression
+        for this stratum). Missing genes are treated as zero.
+    stratum : str
+        Label for this stratum.
+    eps : float
+        Pseudocount for ``log10(af + eps)``.
+    n_quantiles : int
+        Upper bound on quantile bins (``pd.qcut`` with ``duplicates='drop'``).
+    min_pos_expr : int
+        Minimum count of positive-expression variants before attempting qcut.
+    min_cell_n : int
+        Minimum count per ``(expr_bin, is_ptm)`` cell to proceed with the fit.
+    """
+    # Drop rows missing AF/gene, then af > 0 (matches notebook K).
+    dfx = df.dropna(subset=[af_col, gene_col]).copy()
+    dfx = dfx[dfx[af_col] > 0].copy()
+    dfx["log_af"] = np.log10(dfx[af_col] + eps)
+    dfx["is_ptm"] = dfx[is_ptm_col].astype(int)
+
+    # Map gene -> expression; missing genes default to 0.
+    expr_map = dict(expr_series)
+    dfx["expr"] = dfx[gene_col].map(expr_map).fillna(0.0)
+    dfx["expr_log"] = np.log2(dfx["expr"] + 1)
+
+    not_expr = dfx["expr"] == 0
+    pos = dfx.loc[~not_expr, "expr_log"]
+
+    def _skipped(note: str, bin_levels=None) -> BinnedLMMResult:
+        return BinnedLMMResult(
+            stratum=stratum,
+            bin_levels=list(bin_levels or ["b0_none"]),
+            n_variants=int(len(dfx)),
+            n_genes=int(dfx[gene_col].nunique()) if len(dfx) else 0,
+            converged=False,
+            note=note,
+        )
+
+    if len(pos) < min_pos_expr:
+        return _skipped(f"skipped: only {len(pos)} positive-expr variants < {min_pos_expr}")
+
+    try:
+        pos_bins = pd.qcut(pos, q=n_quantiles, duplicates="drop")
+    except Exception as e:
+        return _skipped(f"qcut failed: {str(e)[:80]}")
+
+    n_bins_realized = pos_bins.cat.categories.size
+    if n_bins_realized == 0:
+        return _skipped("skipped: no quantile bins realized")
+
+    bin_labels = [f"b{i + 1}_Q{i + 1}" for i in range(n_bins_realized)]
+    bin_map = dict(zip(pos_bins.cat.categories, bin_labels))
+    assigned = pd.Series("b0_none", index=dfx.index, dtype=object)
+    assigned.loc[~not_expr] = pos_bins.map(bin_map)
+    # Any residual NaN (shouldn't happen) falls back to the first positive bin
+    # to match notebook K's defensive handling.
+    assigned = assigned.fillna(bin_labels[0] if bin_labels else "b0_none")
+    ordered = ["b0_none"] + bin_labels
+    dfx["expr_bin"] = pd.Categorical(assigned, categories=ordered, ordered=True)
+
+    # Sparsity gate: every (expr_bin, is_ptm) cell must have >= min_cell_n.
+    bc = dfx.groupby(["expr_bin", "is_ptm"], observed=False).size().unstack(fill_value=0)
+    if (bc < min_cell_n).any().any():
+        return _skipped("skipped: sparse bins", bin_levels=ordered)
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            md = smf.mixedlm("log_af ~ is_ptm * expr_bin", data=dfx, groups=dfx[gene_col])
+            mf = md.fit(method="lbfgs", reml=True)
+    except Exception as e:
+        return _skipped(f"fit failed: {str(e)[:80]}", bin_levels=ordered)
+
+    beta_ref = float(mf.params["is_ptm"])
+    bin_betas: Dict[str, float] = {"b0_none": beta_ref}
+    bin_ses: Dict[str, float] = {"b0_none": float(mf.bse["is_ptm"])}
+    bin_pvalues: Dict[str, float] = {"b0_none": float(mf.pvalues["is_ptm"])}
+
+    try:
+        vc = mf.cov_params()
+    except Exception:
+        vc = None
+
+    for b in bin_labels:
+        int_name = f"is_ptm:expr_bin[T.{b}]"
+        if int_name not in mf.params.index:
+            continue
+        int_beta = float(mf.params[int_name])
+        bin_betas[b] = beta_ref + int_beta
+        bin_pvalues[b] = float(mf.pvalues[int_name])
+        if vc is not None and int_name in vc.index:
+            v_a = vc.loc["is_ptm", "is_ptm"]
+            v_b = vc.loc[int_name, int_name]
+            c_ab = vc.loc["is_ptm", int_name]
+            bin_ses[b] = float(np.sqrt(v_a + v_b + 2 * c_ab))
+        else:
+            bin_ses[b] = float(mf.bse.get(int_name, float("nan")))
+
+    return BinnedLMMResult(
+        stratum=stratum,
+        bin_levels=ordered,
+        bin_betas=bin_betas,
+        bin_ses=bin_ses,
+        bin_pvalues=bin_pvalues,
+        n_variants=int(len(dfx)),
+        n_genes=int(dfx[gene_col].nunique()),
+        converged=bool(mf.converged),
+        note="",
+    )
+
+
+__all__ = [
+    "LMMResult",
+    "BinnedLMMResult",
+    "run_lmm",
+    "run_binned_interaction_lmm",
+]


### PR DESCRIPTION
This pull request introduces new command-line subcommands and pandas-based annotation utilities, and exposes them through the package API. The main changes add an "atlas" assembly facade and per-stratum constraint test runners to the CLI, as well as a pandas-based SYMBOL/chrom-based variant annotator. Several constants and new API endpoints are also surfaced in the package `__init__`.

**New CLI Subcommands and Utilities:**

* Added `ptm atlas` and `ptm test` subcommands to `hvantk/commands/ptm_cli.py`:
  * `ptm atlas` runs the PTM atlas assembly pipeline and outputs combined TSV and Hail Table files.
  * `ptm test` runs per-stratum LMM/LMM-binned constraint tests, supporting both plain and expression-binned models, with flexible input/output options.
  * Helper functions for reading variant tables and expression matrices were added.

**Pandas-based Annotation:**

* Added `annotate_variants_by_symbol` to `hvantk/ptm/annotate.py`:
  * This function flags variants as PTM site or PTM proximal using SYMBOL and chrom, matching notebook N semantics for CHD workflows.

**API and Constant Exposure:**

* Exposed new constants and API endpoints in `hvantk/ptm/__init__.py`:
  * Constants: `PROXIMAL_BP`, `DEFAULT_MAF_THRESHOLDS`, `EXPRESSION_BIN_LABELS`, `LOG_AF_EPSILON`, `LMM_MIN_N_PTM`, `LMM_MIN_N_NONPTM`, `LMM_MIN_MIXED_GENES`, `LMM_BINNED_MIN_POS_EXPR`, `LMM_BINNED_MIN_CELL_N`. [[1]](diffhunk://#diff-1199cc85a56a3ba5989ca6c7c7bcc28ed598fc4d109e855417e79958c7b78d76R27-R35) [[2]](diffhunk://#diff-1199cc85a56a3ba5989ca6c7c7bcc28ed598fc4d109e855417e79958c7b78d76R157-R178)
  * API: `PTMAtlasConfig`, `PTMAtlasResult`, `build_atlas`, `annotate_variants_by_symbol`, `LMMResult`, `BinnedLMMResult`, `run_lmm`, `run_binned_interaction_lmm`, `generate_phase2_report`. [[1]](diffhunk://#diff-1199cc85a56a3ba5989ca6c7c7bcc28ed598fc4d109e855417e79958c7b78d76R81-R99) [[2]](diffhunk://#diff-1199cc85a56a3ba5989ca6c7c7bcc28ed598fc4d109e855417e79958c7b78d76R157-R178)

**Documentation:**

* Updated and expanded docstrings in `hvantk/ptm/annotate.py` to describe the new pandas-based annotator and its parameters. [[1]](diffhunk://#diff-ff75a22f7b2c1a46a5538637b1ff4456c55803e9033c56d871fba508e127ed02R157-R278) [[2]](diffhunk://#diff-ff75a22f7b2c1a46a5538637b1ff4456c55803e9033c56d871fba508e127ed02R6-R18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New `ptm atlas` CLI to build configurable PTM atlases from selectable sources with output controls.
  * New `ptm test` CLI to run per-stratum mixed-model analyses (standard and binned modes) producing per-stratum TSV outputs.
  * Variant SYMBOL-based PTM annotation via a pandas-based annotator.
  * New LMM and binned-interaction analysis routines with structured result outputs.
  * Automated Phase-2 HTML report generation summarizing atlas, annotation, and analysis results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->