### PR TITLE
feat(expression): scverse-native summarize + backed-write + fused UCSC aggregation

### DIFF
--- a/docs_site/plans/2026-04-16-single-cell-aggregation-cli-plan.md
+++ b/docs_site/plans/2026-04-16-single-cell-aggregation-cli-plan.md
@@ -1,0 +1,1010 @@
+# Single-cell aggregation CLI — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a scverse-native `hvantk expression summarize` that emits a canonical `.h5ad` (groups × genes, aggregations as layers) via `scanpy.get.aggregate`, plus a stream-capable `mkmatrix ucsc` that handles multi-GB gzipped expression matrices without OOM.
+
+**Architecture:** Two-step Builder/Streamer pipeline. `build_ucsc_ad` streams raw UCSC gz → CSR-sparse AnnData (`.h5ad`); `summarize_expression_ad` wraps `sc.get.aggregate` to produce a small aggregated `.h5ad`. Notebook K.1 consumes the aggregated artifact directly.
+
+**Tech Stack:** Python 3.9+, scanpy ≥ 1.10 (`sc.get.aggregate`), anndata ≥ 0.10, scipy sparse, pandas, Click CLI.
+
+**Spec:** `docs_site/specs/2026-04-16-single-cell-aggregation-cli-design.md`
+
+**Git workflow:** Project policy forbids direct commits to `dev` or `main`. Work on a feature branch (e.g., `feat/sc-aggregation-cli`). Open a PR into `dev` at the end. Consider using `superpowers:using-git-worktrees` for isolation.
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `hvantk/tables/ucsc.py` | Modify | Stream chunks from gz → CSR → AnnData. |
+| `hvantk/tables/matrix_builders.py` | Modify | Plumb `chunk_size` kwarg through `build_ucsc_ad`. |
+| `hvantk/commands/make_matrix_cli.py` | Modify | Expose `--chunk-size` on `mkmatrix ucsc`. |
+| `hvantk/utils/matrix_utils.py` | Modify | Rewrite `summarize_expression_ad` on `sc.get.aggregate`. |
+| `hvantk/commands/summarize_expression_cli.py` | Modify | `.h5ad` output, `.h5ad` suffix validation, `--min-cells` default 10, new report card. |
+| `hvantk/tests/test_matrix_utils_anndata.py` | Modify | Migrate `TestSummarizeExpressionAd` to new AnnData return contract. |
+| `local/notebooks/ptm-eda/notebook_k1_brain_metaatlas_ptm.ipynb` | Modify | Replace Cell 3 streaming loop with CLI call + AnnData load. |
+
+No new files. No new tests (`MEMORY.md → feedback_no_more_tests.md`).
+
+---
+
+## Task 1: Stream-capable `create_anndata_from_ucsc_matrix`
+
+**Files:**
+- Modify: `hvantk/tables/ucsc.py` (function `create_anndata_from_ucsc_matrix`, lines 69–142)
+- Test: `hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd` (existing — must still pass, unchanged)
+
+Contract stays the same: input (gz or plain TSV) → `AnnData(cells × genes)` sparse CSR. Only the body changes. Because contract is unchanged, existing tests are the regression harness.
+
+- [ ] **Step 1: Verify existing ucsc-builder tests pass against current code**
+
+Run: `pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v`
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 2: Replace the body of `create_anndata_from_ucsc_matrix` with a streamed builder**
+
+In `hvantk/tables/ucsc.py`, replace the function body starting at line 106 (the `if not os.path.exists(...)` block) with the streamed implementation. Add a `chunk_size` kwarg to the signature. The full replacement function:
+
+```python
+def create_anndata_from_ucsc_matrix(
+    expression_matrix_path: str,
+    metadata_df: pd.DataFrame = None,
+    gene_column: str = UCSC_GENE_COLUMN,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+    chunk_size: int = 500,
+) -> ad.AnnData:
+    """Create an AnnData object from a UCSC Cell Browser expression matrix.
+
+    The input file has genes as rows and cells as columns. This function
+    streams the file in chunks of ``chunk_size`` genes, converts each chunk
+    to a ``scipy.sparse.csr_matrix``, and vstacks them, so peak RAM stays
+    roughly ``chunk_size × n_cells × 4 B`` plus the growing sparse result.
+    The stacked matrix is transposed to the AnnData convention
+    (obs = cells, var = genes) and stored as ``float32`` CSR.
+
+    Parameters
+    ----------
+    expression_matrix_path : str
+        Path to the expression TSV or `.tsv.gz` (genes x cells).
+    metadata_df : pd.DataFrame, optional
+        Cell metadata to join into ``adata.obs``. Index must match cell ids.
+    gene_column : str
+        Name of the first column containing gene identifiers.
+    delimiter : str
+        Column delimiter (default tab).
+    split_gene_field : bool
+        If True, split gene names on ``|`` and keep only the first element.
+    chunk_size : int
+        Gene rows per streaming chunk. Lower ⇒ less peak RAM, slower.
+
+    Returns
+    -------
+    ad.AnnData
+        AnnData with shape (n_cells, n_genes), sparse CSR X.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *expression_matrix_path* does not exist.
+    ValueError
+        If a chunk fails float32 conversion (names the offending gene row).
+    """
+    if not os.path.exists(expression_matrix_path):
+        raise FileNotFoundError(
+            f"Expression matrix file not found: {expression_matrix_path}"
+        )
+
+    logger.info(
+        "Streaming expression matrix from %s (chunk_size=%d)",
+        expression_matrix_path,
+        chunk_size,
+    )
+
+    gene_name_chunks = []
+    sparse_chunks = []
+    cell_ids = None
+    n_seen = 0
+
+    reader = pd.read_csv(
+        expression_matrix_path,
+        sep=delimiter,
+        header=0,
+        index_col=0,
+        chunksize=chunk_size,
+    )
+    for chunk in reader:
+        if cell_ids is None:
+            cell_ids = list(chunk.columns)
+
+        chunk_genes = chunk.index.astype(str)
+        if split_gene_field:
+            chunk_genes = chunk_genes.str.split("|").str[0]
+        gene_name_chunks.append(np.asarray(chunk_genes))
+
+        try:
+            chunk_values = chunk.to_numpy(dtype=np.float32, copy=False)
+        except (ValueError, TypeError) as exc:
+            bad_gene = chunk_genes[0] if len(chunk_genes) else "<unknown>"
+            raise ValueError(
+                f"Non-numeric value in chunk starting at gene {bad_gene!r}: {exc}"
+            ) from exc
+
+        sparse_chunks.append(sparse.csr_matrix(chunk_values))
+        n_seen += len(chunk_genes)
+        if n_seen % (chunk_size * 10) == 0:
+            logger.info("  streamed %d genes", n_seen)
+
+    if not sparse_chunks:
+        raise ValueError(
+            f"Expression matrix {expression_matrix_path!r} contained no data rows."
+        )
+
+    # Genes-x-cells sparse → cells-x-genes AnnData convention.
+    X = sparse.vstack(sparse_chunks, format="csr").T.tocsr()
+    gene_names = np.concatenate(gene_name_chunks)
+
+    var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
+    obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
+
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+
+    if metadata_df is not None:
+        common = adata.obs.index.intersection(metadata_df.index)
+        if len(common) == 0:
+            logger.warning(
+                "No overlapping cell ids between expression matrix and metadata"
+            )
+        meta_aligned = metadata_df.reindex(adata.obs.index)
+        for col in meta_aligned.columns:
+            adata.obs[col] = meta_aligned[col].values
+
+    logger.info("Built AnnData: %d cells × %d genes", adata.shape[0], adata.shape[1])
+    return adata
+```
+
+- [ ] **Step 3: Run existing ucsc-builder tests to verify no regression**
+
+Run: `pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v`
+
+Expected: all 4 tests PASS (no test changes; same contract). If any fail, the streaming body diverged from the previous contract — fix before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hvantk/tables/ucsc.py
+git commit -m "$(cat <<'EOF'
+feat(ucsc): stream exprMatrix in chunks to avoid dense OOM on large atlases
+
+create_anndata_from_ucsc_matrix now streams the gz/tsv in chunks of
+`chunk_size` genes, converting each chunk to a CSR sparse block before
+vstacking. Peak RAM ≈ chunk_size × n_cells × 4 B + growing sparse result,
+making 500k-cell UCSC atlases feasible on a laptop.
+EOF
+)"
+```
+
+---
+
+## Task 2: Plumb `chunk_size` through `build_ucsc_ad`
+
+**Files:**
+- Modify: `hvantk/tables/matrix_builders.py` (function `build_ucsc_ad`, lines 24–84)
+- Test: `hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd` (unchanged — regression harness).
+
+- [ ] **Step 1: Add `chunk_size` kwarg to `build_ucsc_ad` and pass it through**
+
+In `hvantk/tables/matrix_builders.py`, update the `build_ucsc_ad` signature and its call to `create_anndata_from_ucsc_matrix`:
+
+```python
+def build_ucsc_ad(
+    expression_matrix_path: str,
+    metadata_path: str,
+    output_path: Optional[str] = None,
+    gene_column: str = "gene",
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+    overwrite: bool = False,
+    chunk_size: int = 500,
+) -> "ad.AnnData":
+    """Build an AnnData object from UCSC Cell Browser expression + metadata.
+
+    Parameters
+    ----------
+    expression_matrix_path : str
+        Path to expression TSV (genes x cells).
+    metadata_path : str
+        Path to metadata TSV.
+    output_path : str, optional
+        If provided, save the AnnData as ``.h5ad``.
+    gene_column : str
+        Name of the gene identifier column (default ``"gene"``).
+    delimiter : str
+        Column delimiter (default tab).
+    split_gene_field : bool
+        Split pipe-separated gene names, keeping the first element.
+    overwrite : bool
+        Allow overwriting *output_path* if it exists.
+    chunk_size : int
+        Gene rows per streaming chunk (default 500).
+
+    Returns
+    -------
+    ad.AnnData
+        Expression AnnData with metadata in ``obs`` and provenance in ``uns``.
+    """
+    from hvantk.tables.ucsc import load_ucsc_metadata, create_anndata_from_ucsc_matrix
+    from hvantk.core.anndata_utils import (
+        build_anndata_metadata,
+        annotate_column_summary_ad,
+        save_anndata,
+    )
+
+    logger.info("Loading UCSC metadata from %s", metadata_path)
+    metadata_df = load_ucsc_metadata(metadata_path, sep=delimiter)
+
+    logger.info("Creating AnnData from UCSC expression matrix")
+    adata = create_anndata_from_ucsc_matrix(
+        expression_matrix_path=expression_matrix_path,
+        metadata_df=metadata_df,
+        gene_column=gene_column,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+        chunk_size=chunk_size,
+    )
+
+    adata.uns["hvantk_metadata"] = build_anndata_metadata(
+        "UCSC", expression_matrix_path
+    )
+    annotate_column_summary_ad(adata)
+
+    if output_path:
+        save_anndata(adata, output_path, overwrite=overwrite)
+
+    return adata
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+Run: `pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v`
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hvantk/tables/matrix_builders.py
+git commit -m "feat(ucsc): expose chunk_size on build_ucsc_ad for streaming tune"
+```
+
+---
+
+## Task 3: Expose `--chunk-size` on `mkmatrix ucsc`
+
+**Files:**
+- Modify: `hvantk/commands/make_matrix_cli.py` (function `mkmatrix_ucsc`, lines 49–93)
+- Test: `hvantk/tests/test_expression_builders_anndata.py::TestMkmatrixCli::test_ucsc_produces_h5ad` (unchanged).
+
+- [ ] **Step 1: Add `--chunk-size` option to the `ucsc` subcommand**
+
+In `hvantk/commands/make_matrix_cli.py`, add one click option and one kwarg pass-through. The final `mkmatrix_ucsc` command:
+
+```python
+@mkmatrix_group.command("ucsc")
+@click.option(
+    "-e",
+    "--expression-matrix",
+    "expression_matrix",
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option("-m", "--metadata", required=True, type=click.Path(exists=True))
+@click.option(
+    "-o",
+    "--output",
+    "output_path",
+    required=True,
+    type=click.Path(),
+    help="Output path for AnnData (.h5ad).",
+)
+@click.option("-g", "--gene-column", default="gene", show_default=True)
+@click.option("-d", "--delimiter", default="\t", show_default=True)
+@click.option(
+    "--split-gene-field/--no-split-gene-field", default=True, show_default=True
+)
+@click.option(
+    "--chunk-size",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Gene rows per streaming chunk. Lower ⇒ less peak RAM, slower.",
+)
+@click.option("-w", "--overwrite", is_flag=True)
+def mkmatrix_ucsc(
+    expression_matrix,
+    metadata,
+    output_path,
+    gene_column,
+    delimiter,
+    split_gene_field,
+    chunk_size,
+    overwrite,
+):
+    """Build an AnnData object from UCSC Cell Browser expression + metadata files."""
+    logger.info("Building UCSC AnnData")
+    adata = _build_ucsc_ad(
+        expression_matrix_path=expression_matrix,
+        metadata_path=metadata,
+        output_path=output_path,
+        gene_column=gene_column,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+        chunk_size=chunk_size,
+        overwrite=overwrite,
+    )
+    click.echo(f"AnnData created at {output_path}")
+    click.echo(f"  Shape: {adata.shape[0]} obs x {adata.shape[1]} vars")
+```
+
+- [ ] **Step 2: Verify CLI test still passes**
+
+Run: `pytest hvantk/tests/test_expression_builders_anndata.py::TestMkmatrixCli::test_ucsc_produces_h5ad -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hvantk/commands/make_matrix_cli.py
+git commit -m "feat(mkmatrix): add --chunk-size to mkmatrix ucsc"
+```
+
+---
+
+## Task 4: Migrate `TestSummarizeExpressionAd` to new AnnData contract (fail-first)
+
+**Files:**
+- Modify: `hvantk/tests/test_matrix_utils_anndata.py` (class `TestSummarizeExpressionAd`, lines 66–78)
+
+This is the TDD step: update the existing assertions to the new contract, verify they fail against the current DataFrame-returning implementation, then flip the implementation in Task 5 to make them pass.
+
+- [ ] **Step 1: Replace `TestSummarizeExpressionAd` with the new contract**
+
+Replace the class (lines 66–78) in `hvantk/tests/test_matrix_utils_anndata.py` with:
+
+```python
+class TestSummarizeExpressionAd:
+    def test_returns_anndata(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        assert isinstance(result, ad.AnnData)
+
+    def test_shape_is_groups_by_genes(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        expected_groups = len(set(test_adata.obs["cell_type"]))
+        assert result.shape == (expected_groups, test_adata.n_vars)
+
+    def test_has_required_layers(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        expected_layers = {"mean", "sum", "count_nonzero", "fraction_expressed"}
+        assert expected_layers.issubset(set(result.layers.keys()))
+
+    def test_obs_has_n_cells(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        assert "n_cells" in result.obs.columns
+        assert (result.obs["n_cells"] > 0).all()
+        assert int(result.obs["n_cells"].sum()) == test_adata.n_obs
+
+    def test_groups_match_unique_cell_types(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        assert set(result.obs_names) == {"neuron", "astrocyte", "microglia"}
+
+    def test_fraction_expressed_between_0_and_1(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        frac = np.asarray(result.layers["fraction_expressed"])
+        assert frac.min() >= 0.0
+        assert frac.max() <= 1.0
+
+    def test_min_cells_filters_small_groups(self, test_adata):
+        # all three cell types should be well above n=5 in the fixture (100 cells / 3),
+        # but at min_cells=10_000 we should drop every group.
+        result = summarize_expression_ad(
+            test_adata, group_by="cell_type", min_cells_per_group=10_000
+        )
+        assert result.n_obs == 0
+```
+
+- [ ] **Step 2: Run the updated tests — they must fail against the current implementation**
+
+Run: `pytest hvantk/tests/test_matrix_utils_anndata.py::TestSummarizeExpressionAd -v`
+
+Expected: every test FAILS (current implementation returns a `pd.DataFrame`, so `isinstance(result, ad.AnnData)` trips). If any test unexpectedly passes, inspect it — the contract didn't actually change there.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hvantk/tests/test_matrix_utils_anndata.py
+git commit -m "test(summarize): migrate TestSummarizeExpressionAd to AnnData return contract"
+```
+
+---
+
+## Task 5: Rewrite `summarize_expression_ad` on `sc.get.aggregate`
+
+**Files:**
+- Modify: `hvantk/utils/matrix_utils.py` (function `summarize_expression_ad`, lines 94–162)
+- Test: `hvantk/tests/test_matrix_utils_anndata.py::TestSummarizeExpressionAd` (from Task 4).
+
+- [ ] **Step 1: Replace the function body**
+
+In `hvantk/utils/matrix_utils.py`, replace the `summarize_expression_ad` function (and its imports block at the top if needed) with:
+
+```python
+def summarize_expression_ad(
+    adata: ad.AnnData,
+    group_by: Union[str, List[str]],
+    filter_by: Optional[Dict[str, Union[str, List[str]]]] = None,
+    min_cells_per_group: int = 10,
+) -> ad.AnnData:
+    """Collapse an AnnData expression matrix into a per-group, per-gene AnnData.
+
+    Thin wrapper around :func:`scanpy.get.aggregate` that also derives
+    ``fraction_expressed`` and attaches per-group cell counts.
+
+    Parameters
+    ----------
+    adata
+        Expression AnnData (obs = cells/samples, var = genes).
+    group_by
+        One or more obs columns to group by. Multi-column groupings produce
+        ``obs_names`` joined with ``_`` (matches ``scanpy.get.aggregate``).
+    filter_by
+        Optional pre-filter passed to :func:`filter_by_metadata_ad`.
+    min_cells_per_group
+        Drop groups with fewer than this many cells.
+
+    Returns
+    -------
+    ad.AnnData
+        Shape ``(n_groups, n_genes)`` with layers ``mean``, ``sum``,
+        ``count_nonzero``, ``fraction_expressed``. ``obs["n_cells"]`` stores
+        the per-group cell count.
+    """
+    import scanpy as sc
+
+    if filter_by:
+        adata = filter_by_metadata_ad(adata, filter_by)
+
+    by = [group_by] if isinstance(group_by, str) else list(group_by)
+
+    agg = sc.get.aggregate(
+        adata,
+        by=by,
+        func=["mean", "sum", "count_nonzero"],
+    )
+
+    # sc.get.aggregate does not stash per-group cell counts; compute from the
+    # pre-aggregate adata, joining group_by columns with "_" to match
+    # agg.obs_names.
+    group_labels = adata.obs[by].astype(str).agg("_".join, axis=1)
+    n_cells = group_labels.value_counts().reindex(agg.obs_names).astype(int)
+
+    agg.obs["n_cells"] = n_cells.values
+    agg.layers["fraction_expressed"] = (
+        np.asarray(agg.layers["count_nonzero"]) / n_cells.values[:, None]
+    )
+
+    keep = agg.obs["n_cells"].values >= min_cells_per_group
+    return agg[keep].copy()
+```
+
+Also update the imports at the top of the file (line 11) from:
+
+```python
+from typing import Any, Dict, List, Optional, Union
+```
+
+No typing changes needed — already imports what's used. Confirm `import anndata as ad` is present (line 13); it is.
+
+- [ ] **Step 2: Run the migrated tests — they must pass**
+
+Run: `pytest hvantk/tests/test_matrix_utils_anndata.py::TestSummarizeExpressionAd -v`
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 3: Run the full test_matrix_utils_anndata.py to check no collateral damage**
+
+Run: `pytest hvantk/tests/test_matrix_utils_anndata.py -v`
+
+Expected: all tests PASS (Describe + Filter tests are unaffected).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hvantk/utils/matrix_utils.py
+git commit -m "$(cat <<'EOF'
+feat(summarize): rewrite summarize_expression_ad on scanpy.get.aggregate
+
+Replace the hand-rolled per-group loop with a thin wrapper around
+sc.get.aggregate that returns an AnnData keyed by group (obs_names) with
+mean / sum / count_nonzero / fraction_expressed in layers and per-group
+cell counts in obs["n_cells"]. Multi-column group_by joins column values
+with "_" to match scanpy's obs_names convention.
+
+Breaking change: return type is now ad.AnnData (was pd.DataFrame).
+EOF
+)"
+```
+
+---
+
+## Task 6: Update `summarize_expression_cmd` CLI for `.h5ad` output
+
+**Files:**
+- Modify: `hvantk/commands/summarize_expression_cli.py` (function `summarize_expression_cmd`, lines 70–199)
+
+Deltas: enforce `.h5ad` suffix, lower `--min-cells` default from 50 to 10, replace `to_parquet` with `write_h5ad`, update the report card to reflect AnnData output.
+
+- [ ] **Step 1: Replace the `summarize_expression_cmd` body**
+
+In `hvantk/commands/summarize_expression_cli.py`, replace the function (starting at `@expression_group.command("summarize")` and running through the bottom of the function) with:
+
+```python
+@expression_group.command("summarize")
+@click.option(
+    "-m",
+    "--matrix-table",
+    "matrix_path",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to an expression AnnData file (.h5ad).",
+)
+@click.option(
+    "--group-by",
+    multiple=True,
+    required=True,
+    help="Observation metadata field(s) to group by. Repeat for multi-field grouping.",
+)
+@click.option(
+    "--filter-by",
+    multiple=True,
+    default=None,
+    help="Pre-filter observations: FIELD=VALUE (repeatable). "
+    "Example: --filter-by time_point=9wpc --filter-by region=LV",
+)
+@click.option(
+    "--min-cells",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Drop groups with fewer cells than this threshold.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    required=True,
+    help="Output path for the aggregated AnnData (.h5ad).",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing output.",
+)
+def summarize_expression_cmd(
+    matrix_path,
+    group_by,
+    filter_by,
+    min_cells,
+    output,
+    overwrite,
+):
+    """Aggregate an expression AnnData into a per-group × per-gene AnnData.
+
+    The output .h5ad has shape (n_groups, n_genes) with layers:
+    ``mean``, ``sum``, ``count_nonzero``, ``fraction_expressed``. Per-group
+    cell counts are in ``obs['n_cells']``.
+
+    \b
+    Examples:
+
+      # Single-field grouping
+      hvantk expression summarize \\
+          -m data/heart_sc.h5ad \\
+          --group-by cell_type \\
+          -o data/heart_celltype_summary.h5ad
+
+      # Multi-field grouping
+      hvantk expression summarize \\
+          -m data/heart_sc.h5ad \\
+          --group-by cell_type --group-by region \\
+          -o data/heart_celltype_region_summary.h5ad
+
+      # With pre-filtering
+      hvantk expression summarize \\
+          -m data/heart_sc.h5ad \\
+          --group-by cell_type \\
+          --filter-by time_point=9wpc --filter-by region=LV \\
+          --min-cells 10 \\
+          -o data/heart_9wpc_LV_summary.h5ad
+    """
+    from pathlib import Path
+
+    from hvantk.core.anndata_utils import load_anndata
+    from hvantk.utils.matrix_utils import summarize_expression_ad
+
+    output_path = Path(output)
+    if output_path.suffix != ".h5ad":
+        raise click.BadParameter(
+            f"Output must end in '.h5ad' (got {output_path.suffix!r}).",
+            param_hint="--output",
+        )
+
+    if output_path.exists() and not overwrite:
+        click.echo(
+            f"Error: Output file already exists: {output_path}\n"
+            "Use --overwrite to replace it.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    filters = None
+    if filter_by:
+        filters = {}
+        for item in filter_by:
+            if "=" not in item:
+                raise click.BadParameter(
+                    f"Expected FIELD=VALUE format, got: '{item}'",
+                    param_hint="--filter-by",
+                )
+            key, value = item.split("=", 1)
+            filters[key.strip()] = value.strip()
+
+    adata = load_anndata(matrix_path)
+
+    missing = [col for col in group_by if col not in adata.obs.columns]
+    if missing:
+        available = sorted(adata.obs.columns)
+        raise click.BadParameter(
+            f"--group-by column(s) not in obs: {missing}. Available: {available}",
+            param_hint="--group-by",
+        )
+
+    summary = summarize_expression_ad(
+        adata,
+        group_by=list(group_by),
+        filter_by=filters,
+        min_cells_per_group=min_cells,
+    )
+
+    if summary.n_obs == 0:
+        click.echo(
+            "Error: no groups passed --min-cells threshold. "
+            "Lower --min-cells or check --filter-by / --group-by.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_h5ad(str(output_path))
+
+    n_cells = summary.obs["n_cells"].astype(int)
+    click.echo(f"\nSummary AnnData written to: {output_path}")
+    click.echo(f"  Shape:  {summary.n_obs} groups × {summary.n_vars} genes")
+    click.echo(f"  Layers: {sorted(summary.layers.keys())}")
+    click.echo(
+        f"  Cells per group: min={int(n_cells.min())}, "
+        f"max={int(n_cells.max())}, total={int(n_cells.sum())}"
+    )
+    click.echo("")
+    click.echo(f"Group labels ({summary.n_obs}):")
+    for label, n in list(zip(summary.obs_names, n_cells))[:10]:
+        click.echo(f"  {label:<40s}  {int(n):>8,} cells")
+    if summary.n_obs > 10:
+        click.echo(f"  ... and {summary.n_obs - 10} more")
+```
+
+- [ ] **Step 2: Smoke-test the CLI end-to-end with a tiny fixture**
+
+Run:
+
+```bash
+python - <<'PY'
+import anndata as ad, numpy as np, pandas as pd, tempfile, subprocess, pathlib
+rng = np.random.default_rng(0)
+X = rng.poisson(0.5, size=(30, 10)).astype(np.float32)
+obs = pd.DataFrame({"cell_type": ["A"]*12 + ["B"]*10 + ["C"]*8},
+                    index=[f"c{i}" for i in range(30)])
+var = pd.DataFrame(index=[f"g{i}" for i in range(10)])
+adata = ad.AnnData(X=X, obs=obs, var=var)
+with tempfile.TemporaryDirectory() as d:
+    in_path  = pathlib.Path(d) / "in.h5ad"
+    out_path = pathlib.Path(d) / "out.h5ad"
+    adata.write_h5ad(in_path)
+    r = subprocess.run(
+        ["hvantk", "expression", "summarize",
+         "-m", str(in_path),
+         "--group-by", "cell_type",
+         "--min-cells", "5",
+         "-o", str(out_path)],
+        capture_output=True, text=True,
+    )
+    print("stdout:", r.stdout)
+    print("stderr:", r.stderr)
+    print("exit:", r.returncode)
+    assert r.returncode == 0
+    loaded = ad.read_h5ad(out_path)
+    print("loaded shape:", loaded.shape)
+    print("layers:", sorted(loaded.layers.keys()))
+    print("obs['n_cells']:", loaded.obs["n_cells"].tolist())
+    assert set(loaded.layers.keys()) >= {"mean", "sum", "count_nonzero", "fraction_expressed"}
+    assert loaded.shape == (3, 10)
+print("OK")
+PY
+```
+
+Expected: "OK" printed. Shape `(3, 10)`, all 4 layers present, `n_cells` matches the fixture.
+
+- [ ] **Step 3: Run the fast test suite to confirm no regression**
+
+Run: `pytest hvantk/tests/test_matrix_utils_anndata.py hvantk/tests/test_expression_builders_anndata.py -v`
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hvantk/commands/summarize_expression_cli.py
+git commit -m "$(cat <<'EOF'
+feat(expression): summarize writes .h5ad (groups × genes with layers)
+
+- Enforce --output suffix ==  .h5ad
+- Default --min-cells lowered 50 → 10 (matches planning doc and typical sc atlases)
+- Replace long-form parquet write with AnnData.write_h5ad
+- Report card now surfaces n_groups, n_genes, layers, and per-group cell counts
+- Bail early with a helpful message when a --group-by column is missing or
+  every group drops below --min-cells
+EOF
+)"
+```
+
+---
+
+## Task 7: Retrofit notebook K.1 Cell 3
+
+**Files:**
+- Modify: `local/notebooks/ptm-eda/notebook_k1_brain_metaatlas_ptm.ipynb` (Cell 7 in the ipynb JSON, labeled "Cell 3" in the markdown; currently the ~45-line streaming loop)
+
+The atlas `.h5ad` must be produced once via `hvantk mkmatrix ucsc` before running the notebook (see Task 8 for the command). Cell 3 becomes a CLI call + AnnData load.
+
+- [ ] **Step 1: Replace the source of the streaming cell via a reproducible script**
+
+Run this script — it locates the streaming cell by its leading marker `# === Cell 3 ===` + `# Vectorized chunked build`, replaces its `source`, clears outputs, and rewrites the notebook:
+
+```bash
+python - <<'PY'
+import json, pathlib
+
+NB = pathlib.Path("local/notebooks/ptm-eda/notebook_k1_brain_metaatlas_ptm.ipynb")
+MARKER = "# === Cell 3 ==="
+SENTINEL = "Vectorized chunked build"
+
+new_source = '''# === Cell 3 ===
+# Aggregation is now done by the hvantk CLI, which leans on
+# scanpy.get.aggregate over the atlas .h5ad built from mkmatrix ucsc.
+# One-time preparation (run outside the notebook):
+#   hvantk mkmatrix ucsc -e exprMatrix.tsv.gz -m meta.tsv -o atlas.h5ad
+import subprocess
+import anndata as ad
+
+BRAIN_ATLAS_H5AD  = f"{META_ATLAS_DIR}/adult_ctx_meta_atlas.h5ad"
+BRAIN_CACHE_H5AD  = f"{OUTPUT_DIR}/brain_metaatlas_gene_class_mean_expr.h5ad"
+
+if not os.path.exists(BRAIN_CACHE_H5AD):
+    log.info("Aggregating atlas per %s via hvantk expression summarize...", CELLTYPE_COL)
+    subprocess.run(
+        [
+            "hvantk", "expression", "summarize",
+            "-m", BRAIN_ATLAS_H5AD,
+            "--group-by", CELLTYPE_COL,
+            "--min-cells", "10",
+            "-o", BRAIN_CACHE_H5AD,
+            "--overwrite",
+        ],
+        check=True,
+    )
+else:
+    log.info("Loading cached aggregated AnnData from %s", BRAIN_CACHE_H5AD)
+
+brain_agg = ad.read_h5ad(BRAIN_CACHE_H5AD)
+brain_wide = (
+    pd.DataFrame(
+        brain_agg.layers["mean"].T,
+        index=brain_agg.var_names,
+        columns=brain_agg.obs_names,
+    )
+    .rename_axis("gene_symbol")
+)
+# De-dup on gene symbol (meta-atlas occasionally has duplicate var index)
+brain_wide = brain_wide[~brain_wide.index.duplicated(keep="first")]
+
+print(f"Meta-atlas wide matrix: {brain_wide.shape[0]:,} genes \u00d7 {brain_wide.shape[1]} classes")
+print(f"Classes: {list(brain_wide.columns)}")
+print(brain_wide.describe().T)
+'''
+
+nb = json.loads(NB.read_text())
+
+matches = []
+for i, cell in enumerate(nb["cells"]):
+    if cell.get("cell_type") != "code":
+        continue
+    src = "".join(cell.get("source", []))
+    if src.startswith(MARKER) and SENTINEL in src:
+        matches.append(i)
+
+if len(matches) != 1:
+    raise SystemExit(
+        f"Expected exactly one cell starting with {MARKER!r} and containing "
+        f"{SENTINEL!r}; found {len(matches)}. Inspect the notebook manually."
+    )
+
+idx = matches[0]
+cell = nb["cells"][idx]
+cell["source"] = [line + "\n" for line in new_source.splitlines()]
+if cell["source"]:
+    cell["source"][-1] = cell["source"][-1].rstrip("\n")
+cell["outputs"] = []
+cell["execution_count"] = None
+
+NB.write_text(json.dumps(nb, indent=1) + "\n")
+print(f"Replaced cell #{idx} in {NB}")
+PY
+```
+
+Expected: prints `Replaced cell #N in local/notebooks/...` (exactly one match).
+
+- [ ] **Step 2: Verify the notebook still parses**
+
+Run:
+
+```bash
+python -c "import json; json.load(open('local/notebooks/ptm-eda/notebook_k1_brain_metaatlas_ptm.ipynb'))"
+```
+
+Expected: no output (valid JSON).
+
+- [ ] **Step 3: Verify nbformat validates**
+
+Run:
+
+```bash
+python -c "import nbformat; nbformat.read('local/notebooks/ptm-eda/notebook_k1_brain_metaatlas_ptm.ipynb', as_version=4)"
+```
+
+Expected: no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add local/notebooks/ptm-eda/notebook_k1_brain_metaatlas_ptm.ipynb
+git commit -m "$(cat <<'EOF'
+refactor(notebook-k1): consume pre-aggregated AnnData from hvantk CLI
+
+Cell 3 previously re-implemented a vectorized chunked streaming loop
+against exprMatrix.tsv.gz. Replace with a subprocess call to
+`hvantk expression summarize` and an AnnData load of the resulting .h5ad.
+The wide pandas DataFrame (gene_symbol × Class) that the rest of the
+notebook consumes is rederived from layers["mean"] in two lines.
+
+Prereq: one-time build of atlas.h5ad via `hvantk mkmatrix ucsc`.
+EOF
+)"
+```
+
+---
+
+## Task 8: Manual validation on the brain meta-atlas
+
+No automated tests for this step. Purpose: verify end-to-end behavior on realistic data before opening the PR. If any check fails, pause and investigate before proceeding.
+
+- [ ] **Step 1: Build the canonical atlas `.h5ad` via the streamed `mkmatrix ucsc`**
+
+```bash
+hvantk mkmatrix ucsc \
+    -e /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/exprMatrix.tsv.gz \
+    -m /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/meta.tsv \
+    -o /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/adult_ctx_meta_atlas.h5ad \
+    --chunk-size 500
+```
+
+Expected: finishes without OOM. Log lines show streamed gene counts increasing. Final shape roughly ~520k cells × ~20k genes.
+
+Acceptance: wall-clock under ~45 min on a laptop; no RSS spike beyond ~6 GB.
+
+- [ ] **Step 2: Run `expression summarize` over the atlas**
+
+```bash
+hvantk expression summarize \
+    -m /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/adult_ctx_meta_atlas.h5ad \
+    --group-by Class \
+    --min-cells 10 \
+    -o /Users/enrique/projects/github/pyvatk/output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.h5ad \
+    --overwrite
+```
+
+Expected: completes in 10–15 min. Report card shows ~10 groups (Jorstad Class labels) and ~20k genes with all four layers.
+
+- [ ] **Step 3: Spot-check numerical agreement against the old pickle cache**
+
+If the old pickle still exists at `output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.pkl`, run:
+
+```bash
+python - <<'PY'
+import pandas as pd, anndata as ad, numpy as np
+
+old = pd.read_pickle("output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.pkl")
+new = ad.read_h5ad("output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.h5ad")
+new_wide = pd.DataFrame(
+    new.layers["mean"].T, index=new.var_names, columns=new.obs_names
+).rename_axis("gene_symbol")
+new_wide = new_wide[~new_wide.index.duplicated(keep="first")]
+
+common_genes = old.index.intersection(new_wide.index)
+common_cls = old.columns.intersection(new_wide.columns)
+o = old.loc[common_genes, common_cls].to_numpy(dtype=np.float64)
+n = new_wide.loc[common_genes, common_cls].to_numpy(dtype=np.float64)
+abs_err = np.nanmax(np.abs(o - n))
+rel_err = np.nanmax(np.abs(o - n) / np.where(np.abs(o) > 1e-8, np.abs(o), 1.0))
+print(f"overlap: {len(common_genes)} genes × {len(common_cls)} classes")
+print(f"max abs diff: {abs_err:.3e}")
+print(f"max rel diff: {rel_err:.3e}")
+assert abs_err < 1e-3 or rel_err < 1e-3, "mean expression diverged — investigate"
+print("OK — new pipeline agrees with old pickle within tolerance")
+PY
+```
+
+Expected: "OK — new pipeline agrees with old pickle within tolerance".
+
+- [ ] **Step 4: Run notebook K.1 end-to-end (or at least Cells 1–3)**
+
+Either execute via `jupyter nbconvert --to notebook --execute ...`, or open in JupyterLab and run Cells 1 through 3. Verify `brain_wide.shape` matches the previous run and `brain_wide.describe()` looks sane.
+
+- [ ] **Step 5: Clean up — delete the now-stale pickle if validation passed**
+
+```bash
+rm -f output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.pkl
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin feat/sc-aggregation-cli
+gh pr create --base dev --title "feat(expression): scverse-native summarize + streaming mkmatrix ucsc" --body "$(cat <<'EOF'
+## Summary
+- Streams the UCSC exprMatrix gz in chunks → CSR → AnnData, so `mkmatrix ucsc` handles 500k-cell atlases without OOM (new `--chunk-size`).
+- Rewrites `expression summarize` on top of `scanpy.get.aggregate`; output is now a canonical `.h5ad` of shape (n_groups × n_genes) with `mean`, `sum`, `count_nonzero`, `fraction_expressed` as layers and per-group cell counts in `obs["n_cells"]`.
+- Drops `median` / pickle / Hail-Table output (deferred to v2; no concrete consumer yet).
+- Retrofits notebook K.1 Cell 3 to consume the aggregated `.h5ad` directly instead of streaming the 5 GB gz in-notebook.
+
+## Test plan
+- [x] `pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v`
+- [x] `pytest hvantk/tests/test_matrix_utils_anndata.py -v`
+- [x] Manual end-to-end build + summarize of the adult-cortex meta-atlas (~520k cells)
+- [x] Numerical agreement with the prior pickle cache (max abs diff < 1e-3)
+- [x] Notebook K.1 Cells 1–3 run cleanly against the new artifact
+EOF
+)"
+```
+
+---
+
+## Deferred (NOT in this PR)
+
+- `--backed` mode on `expression summarize` for atlases > RAM.
+- Exporters from the aggregated `.h5ad` to wide pickle / parquet / Hail Table.
+- Retrofit of notebooks F / G / H.
+- Promote `sum` / `var` to first-class `--agg` selectors.

--- a/docs_site/plans/2026-04-17-fused-ucsc-aggregation-plan.md
+++ b/docs_site/plans/2026-04-17-fused-ucsc-aggregation-plan.md
@@ -1,0 +1,1596 @@
+# Fused UCSC aggregation + backed-write builder — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship two scalable paths for 500k+-cell UCSC atlases: (a) `mkmatrix ucsc` with backed CSC writes (no RAM materialization), (b) a new `expression summarize-ucsc` that streams + aggregates in one pass and emits a `groups × genes` `.h5ad` directly.
+
+**Architecture:** A shared row-streaming helper (`_iter_ucsc_rows`) extracted from the existing parser. The backed builder appends CSC columns to `atlas.h5ad`; the fused aggregator reduces each row via `np.bincount` into pre-allocated `(n_groups, n_genes)` accumulators. Both paths share the same parser, same validation, and identical output schema.
+
+**Tech Stack:** Python 3.10+, anndata ≥0.10 (`anndata.io.sparse_dataset`, `CSCDataset.append`), scipy sparse, numpy, pandas, Click CLI.
+
+**Spec:** `docs_site/specs/2026-04-17-fused-ucsc-aggregation-design.md`
+
+**Git workflow:** Project policy forbids direct commits to `dev`/`main`. Work continues on `feat/sc-aggregation-cli`. Open a PR into `dev` at the end. Commits require user approval per project policy.
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `hvantk/tables/ucsc.py` | Modify | Extract `_iter_ucsc_rows`. Keep `create_anndata_from_ucsc_matrix` as in-memory path. Add `build_ucsc_atlas_backed` (CSC backed writes) and `summarize_ucsc_streaming` (fused aggregator). |
+| `hvantk/tables/matrix_builders.py` | Modify | `build_ucsc_ad` gains `backed: bool \| None` kwarg with auto-select. |
+| `hvantk/commands/make_matrix_cli.py` | Modify | `mkmatrix ucsc` gains `--backed / --no-backed` flag. |
+| `hvantk/commands/summarize_expression_cli.py` | Modify | New `summarize-ucsc` subcommand. |
+| `hvantk/tests/test_expression_builders_anndata.py` | Modify | Parametrize `TestBuildUcscAd` with `backed=[False, True]`. |
+| `local/scripts/2026-04-17-ucsc-sandbox.py` | Create | Disposable sandbox validating pyarrow-free fused `np.bincount` and CSC backed-write patterns before touching hvantk. |
+
+No new tests files. Existing `TestBuildUcscAd` and `TestSummarizeExpressionAd` are the regression harness.
+
+---
+
+## Task 1: Sandbox — validate CSC backed-write + `np.bincount` patterns on real data
+
+**Files:**
+- Create: `local/scripts/2026-04-17-ucsc-sandbox.py`
+
+Per the prototyping-workflow memory, validate both load-bearing patterns against real data before touching hvantk. The sandbox proves three things on a small slice of `adult-ctx-meta-atlas`:
+
+1. `anndata.io.sparse_dataset(group)` + `.append(csc_block)` builds a valid `.h5ad` that reopens cleanly with the correct shape
+2. `np.bincount(group_idx, weights=row)` produces per-group sums that match the reference `sc.get.aggregate` output numerically
+3. Peak RSS stays bounded (no accidental materialization)
+
+- [ ] **Step 1: Write the sandbox script**
+
+Create `local/scripts/2026-04-17-ucsc-sandbox.py`:
+
+```python
+"""Sandbox — validate CSC backed-write and np.bincount fused aggregation
+on a slice of the real adult-ctx-meta-atlas file. Disposable; not imported
+by hvantk."""
+from __future__ import annotations
+import gzip, itertools, os, resource, time
+from pathlib import Path
+
+import anndata as ad
+import h5py
+import numpy as np
+import pandas as pd
+import scanpy as sc
+from anndata.io import sparse_dataset, write_elem
+from scipy import sparse
+
+EXPR = Path("local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/exprMatrix.tsv.gz")
+META = Path("local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/meta.tsv")
+OUT_BACKED = Path("local/scripts/sandbox-backed.h5ad")
+N_ROWS_PROBE = 200   # small slice — fast feedback
+
+
+def parse_rows(path: Path, max_rows: int):
+    with gzip.open(path, "rt") as fh:
+        header = fh.readline().rstrip("\n").rstrip("\r").split("\t")
+        cell_ids = header[1:]
+        for line in itertools.islice(fh, max_rows):
+            line = line.rstrip("\n").rstrip("\r")
+            tab = line.find("\t")
+            gene = line[:tab].split("|", 1)[0]
+            row = np.fromstring(line[tab + 1:], sep="\t", dtype=np.float32)
+            if row.shape[0] != len(cell_ids):
+                raise ValueError(f"bad row for {gene!r}")
+            yield cell_ids, gene, row
+
+
+def _check_api():
+    """Pre-flight — fail fast if required anndata surface is missing."""
+    from anndata.io import sparse_dataset, write_elem  # noqa: F401
+    # Verify we can pass indptr_dtype via dataset_kwargs (load-bearing for
+    # >2^31 nonzeros). The signature may vary across versions.
+    import inspect
+    sig = inspect.signature(write_elem)
+    if "dataset_kwargs" not in sig.parameters:
+        raise RuntimeError(
+            f"anndata.io.write_elem lacks dataset_kwargs; signature={sig}. "
+            f"Upgrade anndata (>=0.10) or adapt the backed builder."
+        )
+    print(f"[api] anndata.io.write_elem signature: {sig}")
+
+
+def test_backed_write():
+    print("=== Backed CSC write ===")
+    if OUT_BACKED.exists():
+        OUT_BACKED.unlink()
+    t0 = time.time()
+
+    rows_iter = parse_rows(EXPR, N_ROWS_PROBE)
+    cell_ids, gene0, row0 = next(rows_iter)
+    n_cells = len(cell_ids)
+    gene_names = [gene0]
+
+    # Initialize backed CSC X with an empty (n_cells, 0) seed. Pass
+    # indptr_dtype=int64 so large atlases don't overflow the default int32.
+    f = h5py.File(OUT_BACKED, "w")
+    seed = sparse.csc_matrix((n_cells, 0), dtype=np.float32)
+    write_elem(f, "X", seed, dataset_kwargs={"indptr_dtype": "int64"})
+    X = sparse_dataset(f["X"])
+    # Sanity: confirm the on-disk indptr dataset is int64.
+    assert f["X/indptr"].dtype == np.int64, f["X/indptr"].dtype
+    print(f"[check] indptr dtype on disk: {f['X/indptr'].dtype}")
+
+    # Append first row as a 1-column CSC block.
+    X.append(sparse.csc_matrix(row0.reshape(-1, 1)))
+
+    for _, gene, row in rows_iter:
+        X.append(sparse.csc_matrix(row.reshape(-1, 1)))
+        gene_names.append(gene)
+
+    # Write obs/var placeholders.
+    obs = pd.DataFrame(index=pd.Index(cell_ids, name="cell_id"))
+    var = pd.DataFrame(index=pd.Index(gene_names, name="gene"))
+    write_elem(f, "obs", obs)
+    write_elem(f, "var", var)
+    f.close()
+
+    rss_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024 / 1024
+    print(f"wrote {N_ROWS_PROBE} cols in {time.time()-t0:.1f}s, peak_rss~{rss_mb:.0f} MB")
+
+    # Reopen and verify.
+    adata = ad.read_h5ad(OUT_BACKED)
+    assert adata.shape == (n_cells, N_ROWS_PROBE), adata.shape
+    assert adata.var_names[:3].tolist() == gene_names[:3]
+    assert sparse.issparse(adata.X)
+    print(f"reopen OK: shape={adata.shape}, X.format={adata.X.format}")
+
+
+def test_fused_aggregation():
+    print("=== Fused np.bincount vs sc.get.aggregate ===")
+    meta = pd.read_csv(META, sep="\t", index_col=0)
+    meta.index.name = "cell_id"
+    meta.columns = [c.replace(".", "_") for c in meta.columns]
+
+    # Build a small reference AnnData from the first N rows, then aggregate
+    # both ways and compare.
+    rows_iter = parse_rows(EXPR, N_ROWS_PROBE)
+    cell_ids, gene0, row0 = next(rows_iter)
+    rest = list(rows_iter)
+    all_rows = [row0] + [r for _, _, r in rest]
+    all_genes = [gene0] + [g for _, g, _ in rest]
+
+    # Reference: full dense AnnData of the slice, then sc.get.aggregate.
+    X_dense = np.vstack(all_rows).T  # (n_cells, n_genes)
+    meta_aligned = meta.reindex(cell_ids)
+    group_col = "Class" if "Class" in meta_aligned.columns else meta_aligned.columns[0]
+    mask = meta_aligned[group_col].notna().values
+    ref_adata = ad.AnnData(
+        X=sparse.csr_matrix(X_dense[mask]),
+        obs=meta_aligned.loc[mask, [group_col]].copy(),
+        var=pd.DataFrame(index=all_genes),
+    )
+    ref_agg = sc.get.aggregate(ref_adata, by=group_col, func=["mean"])
+    ref_mean = np.asarray(ref_agg.layers["mean"])
+
+    # Fused: np.bincount on the same slice.
+    labels = meta_aligned.loc[mask, group_col].astype(str).values
+    codes, uniques = pd.factorize(labels, sort=True)
+    n_groups = len(uniques)
+    n_cells_per_group = np.bincount(codes, minlength=n_groups).astype(np.int64)
+    sum_matrix = np.zeros((n_groups, len(all_genes)), dtype=np.float64)
+    for j, row in enumerate(all_rows):
+        sum_matrix[:, j] = np.bincount(codes, weights=row[mask], minlength=n_groups)
+    fused_mean = sum_matrix / n_cells_per_group[:, None]
+
+    # Reorder ref to match uniques order (sc.get.aggregate sorts by category).
+    ref_order = [list(ref_agg.obs_names).index(u) for u in uniques]
+    ref_mean_reordered = ref_mean[ref_order]
+
+    max_abs = np.abs(fused_mean - ref_mean_reordered).max()
+    print(f"n_groups={n_groups}, n_genes={len(all_genes)}, max_abs_diff={max_abs:.3e}")
+    assert max_abs < 1e-5, f"fused mean diverged from sc.get.aggregate by {max_abs}"
+    print("fused path numerically agrees with sc.get.aggregate")
+
+
+if __name__ == "__main__":
+    _check_api()
+    test_backed_write()
+    test_fused_aggregation()
+```
+
+- [ ] **Step 2: Run the sandbox**
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/python local/scripts/2026-04-17-ucsc-sandbox.py
+```
+
+Expected: both blocks print success. `test_backed_write` reports `shape=(520014, 200), X.format=csc`. `test_fused_aggregation` prints `max_abs_diff < 1e-5` and `fused path numerically agrees with sc.get.aggregate`.
+
+If either fails, stop and debug before touching hvantk. The sandbox is the cheapest place to find an API mismatch.
+
+- [ ] **Step 3: Clean up the sandbox artifact**
+
+```bash
+rm -f local/scripts/sandbox-backed.h5ad
+```
+
+Keep the `.py` script committed as a reproduction receipt (it's in `local/` which is gitignored — so nothing to commit).
+
+---
+
+## Task 2: Extract `_iter_ucsc_rows` from `create_anndata_from_ucsc_matrix`
+
+**Files:**
+- Modify: `hvantk/tables/ucsc.py` (existing `create_anndata_from_ucsc_matrix`, lines ~75–217)
+- Regression: `hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd` (must still pass).
+
+Pure refactor. Lift the parse loop into a module-private helper so the backed builder and fused aggregator can reuse it. The existing `create_anndata_from_ucsc_matrix` becomes a thin wrapper around it.
+
+- [ ] **Step 1: Add `_iter_ucsc_rows` helper in `hvantk/tables/ucsc.py`**
+
+Insert this function after `_open_text` and before `load_ucsc_metadata`:
+
+```python
+from typing import Iterator
+
+
+def _iter_ucsc_rows(
+    expression_matrix_path: str,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+) -> tuple[list[str], Iterator[tuple[str, np.ndarray]]]:
+    """Open a UCSC expression TSV (plain or gzipped) and return
+    ``(cell_ids, row_iterator)``.
+
+    ``cell_ids`` is the header's cell-column list, extracted eagerly.
+    ``row_iterator`` yields ``(gene_name, row_values_float32)`` per data
+    line and closes the underlying handle when exhausted.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``expression_matrix_path`` does not exist.
+    ValueError
+        If the file is empty or a row has the wrong number of values.
+    """
+    if not os.path.exists(expression_matrix_path):
+        raise FileNotFoundError(
+            f"Expression matrix file not found: {expression_matrix_path}"
+        )
+
+    fh = _open_text(expression_matrix_path)
+    try:
+        header = fh.readline().rstrip("\n").rstrip("\r")
+        if not header:
+            fh.close()
+            raise ValueError(
+                f"Expression matrix {expression_matrix_path!r} is empty."
+            )
+        header_fields = header.split(delimiter)
+        cell_ids = header_fields[1:]
+        n_cells = len(cell_ids)
+    except BaseException:
+        fh.close()
+        raise
+
+    def _rows() -> Iterator[tuple[str, np.ndarray]]:
+        try:
+            for line in fh:
+                line = line.rstrip("\n").rstrip("\r")
+                if not line:
+                    continue
+                tab = line.find(delimiter)
+                if tab < 0:
+                    continue
+                gene = line[:tab]
+                if split_gene_field:
+                    gene = gene.split("|", 1)[0]
+                row = np.fromstring(
+                    line[tab + 1:], sep=delimiter, dtype=np.float32
+                )
+                if row.shape[0] != n_cells:
+                    raise ValueError(
+                        f"Row for gene {gene!r} has {row.shape[0]} parseable "
+                        f"float values; expected {n_cells}. This usually "
+                        f"means a short row or a non-numeric token in the row."
+                    )
+                yield gene, row
+        finally:
+            fh.close()
+
+    return cell_ids, _rows()
+```
+
+- [ ] **Step 2: Rewrite `create_anndata_from_ucsc_matrix` to consume the helper**
+
+Replace the body of `create_anndata_from_ucsc_matrix` (the `if not os.path.exists(...)` block through the closing `return adata`) with:
+
+```python
+    logger.info(
+        "Streaming expression matrix from %s (chunk_size=%d)",
+        expression_matrix_path,
+        chunk_size,
+    )
+
+    cell_ids, row_iter = _iter_ucsc_rows(
+        expression_matrix_path,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+
+    gene_name_chunks: list[np.ndarray] = []
+    sparse_chunks: list[sparse.csr_matrix] = []
+    buf_rows: list[np.ndarray] = []
+    buf_genes: list[str] = []
+    n_seen = 0
+    n_chunks = 0
+
+    def _flush() -> None:
+        nonlocal n_chunks
+        if not buf_rows:
+            return
+        sparse_chunks.append(sparse.csr_matrix(np.vstack(buf_rows)))
+        gene_name_chunks.append(np.asarray(buf_genes))
+        buf_rows.clear()
+        buf_genes.clear()
+        n_chunks += 1
+        if n_chunks % 10 == 0:
+            logger.info("  streamed %d genes", n_seen)
+
+    for gene, row in row_iter:
+        buf_rows.append(row)
+        buf_genes.append(gene)
+        n_seen += 1
+        if len(buf_rows) >= chunk_size:
+            _flush()
+    _flush()
+
+    if not sparse_chunks:
+        raise ValueError(
+            f"Expression matrix {expression_matrix_path!r} contained no data rows."
+        )
+
+    X = sparse.vstack(sparse_chunks, format="csr").T.tocsr()
+    gene_names = np.concatenate(gene_name_chunks)
+
+    var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
+    obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
+
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+
+    if metadata_df is not None:
+        common = adata.obs.index.intersection(metadata_df.index)
+        if len(common) == 0:
+            raise ValueError(
+                f"No overlapping cell ids between expression matrix "
+                f"{expression_matrix_path!r} and metadata."
+            )
+        meta_aligned = metadata_df.reindex(adata.obs.index)
+        for col in meta_aligned.columns:
+            adata.obs[col] = meta_aligned[col].values
+
+    logger.info("Built AnnData: %d cells × %d genes", adata.shape[0], adata.shape[1])
+    return adata
+```
+
+Note the **spec-approved behavior flip**: zero-overlap cell IDs now raise `ValueError` instead of `logger.warning`.
+
+- [ ] **Step 3: Run the regression test**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v`
+
+Expected: all tests PASS. If any failure, inspect — the refactor diverged from the original contract and must be corrected before continuing.
+
+- [ ] **Step 4: Run lint on the modified file**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m flake8 hvantk/tables/ucsc.py --count --select=E9,F63,F7,F82 --show-source --statistics`
+
+Expected: `0`.
+
+- [ ] **Step 5: Propose commit to user**
+
+Ask the user to approve:
+
+```bash
+git add hvantk/tables/ucsc.py
+git commit -m "$(cat <<'EOF'
+refactor(ucsc): extract _iter_ucsc_rows helper from builder
+
+Lift the gzip/np.fromstring parse loop into a private generator so that
+the upcoming backed builder and fused aggregator can reuse it without
+duplicating validation. create_anndata_from_ucsc_matrix becomes a thin
+wrapper. Also flip the zero-overlap-cell-ids behavior from warn-only to
+ValueError (approved in design spec).
+EOF
+)"
+```
+
+Do not commit without explicit user approval per project policy.
+
+---
+
+## Task 3: Implement `build_ucsc_atlas_backed` (CSC backed writer)
+
+**Files:**
+- Modify: `hvantk/tables/ucsc.py` — add `build_ucsc_atlas_backed` after `create_anndata_from_ucsc_matrix`.
+- Regression: extend `TestBuildUcscAd` parametrically in Task 7.
+
+- [ ] **Step 1: Add the function**
+
+Add these imports at the top of `hvantk/tables/ucsc.py` (alongside existing ones):
+
+```python
+import h5py
+from anndata.io import sparse_dataset, write_elem
+```
+
+Append this function after `create_anndata_from_ucsc_matrix`:
+
+```python
+def build_ucsc_atlas_backed(
+    expression_matrix_path: str,
+    output_path: str,
+    metadata_df: pd.DataFrame | None = None,
+    gene_column: str = UCSC_GENE_COLUMN,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+    column_batch: int = 64,
+    overwrite: bool = False,
+    uns: "dict | None" = None,
+) -> str:
+    """Stream-build an AnnData .h5ad file on disk, appending one batch of
+    genes (CSC columns) at a time. Never materializes the full
+    ``cells × genes`` matrix.
+
+    Parameters
+    ----------
+    expression_matrix_path : str
+        Path to the UCSC expression TSV (plain or gzipped).
+    output_path : str
+        Destination ``.h5ad`` path.
+    metadata_df : pd.DataFrame, optional
+        Cell metadata; reindexed to expression header ``cell_ids``.
+    gene_column : str
+        Name for the ``var`` index.
+    delimiter : str
+        Column delimiter in the expression TSV.
+    split_gene_field : bool
+        If True, split gene ids on ``|`` and keep the first element.
+    column_batch : int
+        Number of gene columns buffered before a CSC append to disk.
+    overwrite : bool
+        If False and ``output_path`` exists, raise ``FileExistsError``.
+    uns : dict, optional
+        Opaque dict written to the h5ad's ``uns`` group (e.g. provenance
+        metadata). Callers remain responsible for the dict's structure.
+
+    Returns
+    -------
+    str
+        ``output_path``.
+    """
+    if os.path.exists(output_path) and not overwrite:
+        raise FileExistsError(
+            f"{output_path!r} already exists; pass overwrite=True to replace."
+        )
+
+    cell_ids, row_iter = _iter_ucsc_rows(
+        expression_matrix_path,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+    n_cells = len(cell_ids)
+    logger.info(
+        "Backed-write atlas → %s (n_cells=%d, column_batch=%d)",
+        output_path, n_cells, column_batch,
+    )
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    f = h5py.File(output_path, "w")
+    try:
+        # Seed X as an empty (n_cells, 0) CSC; pass indptr dtype via
+        # dataset_kwargs so large atlases don't overflow int32.
+        seed = sparse.csc_matrix((n_cells, 0), dtype=np.float32)
+        write_elem(f, "X", seed, dataset_kwargs={"indptr_dtype": "int64"})
+        X = sparse_dataset(f["X"])
+
+        gene_names: list[str] = []
+        buf_cols: list[np.ndarray] = []
+        buf_genes: list[str] = []
+        n_appended = 0
+        n_batches = 0
+
+        def _flush() -> None:
+            nonlocal n_appended, n_batches
+            if not buf_cols:
+                return
+            # Stack column-vectors into (n_cells, batch_width) CSC block.
+            dense_block = np.column_stack(buf_cols)  # (n_cells, batch_width)
+            X.append(sparse.csc_matrix(dense_block))
+            gene_names.extend(buf_genes)
+            n_appended += len(buf_cols)
+            n_batches += 1
+            buf_cols.clear()
+            buf_genes.clear()
+            if n_batches % 20 == 0:
+                logger.info("  appended %d genes", n_appended)
+
+        for gene, row in row_iter:
+            buf_cols.append(row)
+            buf_genes.append(gene)
+            if len(buf_cols) >= column_batch:
+                _flush()
+        _flush()
+
+        if n_appended == 0:
+            raise ValueError(
+                f"Expression matrix {expression_matrix_path!r} contained no data rows."
+            )
+
+        # obs: cell_ids + optional metadata join (reject zero-overlap).
+        obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
+        if metadata_df is not None:
+            common = obs.index.intersection(metadata_df.index)
+            if len(common) == 0:
+                raise ValueError(
+                    f"No overlapping cell ids between expression matrix "
+                    f"{expression_matrix_path!r} and metadata."
+                )
+            meta_aligned = metadata_df.reindex(obs.index)
+            for col in meta_aligned.columns:
+                obs[col] = meta_aligned[col].values
+
+        var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
+
+        write_elem(f, "obs", obs)
+        write_elem(f, "var", var)
+        if uns is not None:
+            write_elem(f, "uns", uns)
+    finally:
+        f.close()
+
+    logger.info(
+        "Backed atlas written: %d cells × %d genes → %s",
+        n_cells, n_appended, output_path,
+    )
+    return output_path
+```
+
+- [ ] **Step 2: Smoke-test with a tiny synthetic input**
+
+Run:
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/python - <<'PY'
+import gzip, os, tempfile
+import numpy as np
+import pandas as pd
+from hvantk.tables.ucsc import build_ucsc_atlas_backed
+import anndata as ad
+
+rng = np.random.default_rng(0)
+n_genes, n_cells = 50, 300
+vals = rng.random((n_genes, n_cells)).astype(np.float32)
+vals[vals < 0.4] = 0.0
+genes = [f"G{i}|ENST{i:05d}" for i in range(n_genes)]
+cells = [f"C{j}" for j in range(n_cells)]
+
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "x.tsv.gz")
+    with gzip.open(src, "wt") as fh:
+        fh.write("gene\t" + "\t".join(cells) + "\n")
+        for g, row in zip(genes, vals):
+            fh.write(g + "\t" + "\t".join(f"{v:.6g}" for v in row) + "\n")
+
+    meta = pd.DataFrame({"cell_type": ["A"]*150 + ["B"]*150},
+                        index=pd.Index(cells, name="cell_id"))
+    out = os.path.join(td, "atlas.h5ad")
+    build_ucsc_atlas_backed(src, out, metadata_df=meta, column_batch=8)
+    a = ad.read_h5ad(out)
+    print(f"shape={a.shape}, X.format={a.X.format if hasattr(a.X,'format') else 'dense'}")
+    print(f"obs.columns={list(a.obs.columns)}, var_names[:3]={list(a.var_names[:3])}")
+    assert a.shape == (n_cells, n_genes), a.shape
+    # Numerical equivalence vs. in-memory path
+    from hvantk.tables.ucsc import create_anndata_from_ucsc_matrix
+    b = create_anndata_from_ucsc_matrix(src, metadata_df=meta, chunk_size=10)
+    X_a = a.X.toarray() if hasattr(a.X, "toarray") else a.X
+    X_b = b.X.toarray() if hasattr(b.X, "toarray") else b.X
+    diff = np.abs(X_a - X_b).max()
+    print(f"max_abs_diff vs in-memory builder: {diff:.3e}")
+    assert diff < 1e-6, diff
+print("OK")
+PY
+```
+
+Expected: `OK` printed, `shape=(300, 50)`, `max_abs_diff < 1e-6`.
+
+- [ ] **Step 3: Run lint**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m flake8 hvantk/tables/ucsc.py --count --select=E9,F63,F7,F82 --show-source --statistics`
+
+Expected: `0`.
+
+- [ ] **Step 4: Propose commit to user**
+
+```bash
+git add hvantk/tables/ucsc.py
+git commit -m "$(cat <<'EOF'
+feat(ucsc): add build_ucsc_atlas_backed with CSC incremental writes
+
+Streams UCSC gz → one CSC column block at a time into an h5ad on disk via
+anndata.io.sparse_dataset and CSCDataset.append. Passes indptr_dtype=int64
+so 500k+-cell atlases don't overflow the default int32. Never materializes
+the full cells x genes matrix; peak RAM is column_batch x n_cells x 4B.
+EOF
+)"
+```
+
+---
+
+## Task 4: Implement `summarize_ucsc_streaming` (fused aggregator)
+
+**Files:**
+- Modify: `hvantk/tables/ucsc.py` — add `summarize_ucsc_streaming` after `build_ucsc_atlas_backed`.
+
+- [ ] **Step 1: Add the function**
+
+Append to `hvantk/tables/ucsc.py`:
+
+```python
+def summarize_ucsc_streaming(
+    expression_matrix_path: str,
+    metadata_df: pd.DataFrame,
+    group_by: "str | list[str]",
+    filter_by: "dict[str, str | list[str]] | None" = None,
+    min_cells_per_group: int = 10,
+    gene_column: str = UCSC_GENE_COLUMN,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+) -> ad.AnnData:
+    """Stream a UCSC expression matrix and aggregate per-group per-gene
+    statistics in one pass.
+
+    Returns an AnnData of shape ``(n_groups, n_genes)`` with ``X`` set to
+    the per-group mean (float32) and ``layers`` containing ``sum``,
+    ``count_nonzero``, ``fraction_expressed``. ``obs`` includes the
+    original group-by columns plus ``n_cells``.
+
+    Memory: one ``float32[n_cells]`` row buffer + accumulators of size
+    ``n_groups × n_genes × 16 B`` (sum float64 + count_nz int64). Independent
+    of ``n_cells`` past the single-row buffer.
+    """
+    by = [group_by] if isinstance(group_by, str) else list(group_by)
+
+    # Apply filter on the DataFrame before factorizing groups.
+    work = metadata_df.copy()
+    if filter_by:
+        for field, value in filter_by.items():
+            if field not in work.columns:
+                raise ValueError(
+                    f"filter_by field {field!r} not in metadata columns: "
+                    f"{sorted(work.columns)}"
+                )
+            if isinstance(value, (list, tuple, set)):
+                work = work[work[field].isin(list(value))]
+            else:
+                work = work[work[field] == value]
+        if work.empty:
+            raise ValueError("filter_by produced zero cells.")
+
+    for col in by:
+        if col not in work.columns:
+            raise ValueError(
+                f"group_by column {col!r} not in metadata columns: "
+                f"{sorted(work.columns)}"
+            )
+
+    cell_ids, row_iter = _iter_ucsc_rows(
+        expression_matrix_path,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+    n_cells = len(cell_ids)
+
+    # Align metadata to expression header order, keep only cells present
+    # in both, and drop NaN-in-group rows.
+    aligned = work.reindex(cell_ids)
+    keep_mask = aligned[by].notna().all(axis=1).to_numpy()
+    if not keep_mask.any():
+        raise ValueError(
+            "No cells overlap between metadata (post-filter) and expression header."
+        )
+    n_dropped_nan = int((~keep_mask[aligned.index.isin(work.index)]).sum())
+    if n_dropped_nan:
+        example = cell_ids[int(np.where(~keep_mask)[0][0])]
+        logger.info(
+            "Dropped %d cells with NaN in group-by columns (example: %s).",
+            n_dropped_nan, example,
+        )
+
+    labels = (
+        aligned.loc[keep_mask, by].astype(str).agg("_".join, axis=1)
+        if len(by) > 1
+        else aligned.loc[keep_mask, by[0]].astype(str)
+    )
+    codes, uniques = pd.factorize(labels, sort=True)
+    n_groups = len(uniques)
+
+    # group_idx per cell in expression-header order, -1 for dropped cells.
+    group_idx = np.full(n_cells, -1, dtype=np.int64)
+    group_idx[keep_mask] = codes
+    valid = group_idx >= 0
+    n_cells_per_group = np.bincount(group_idx[valid], minlength=n_groups).astype(np.int64)
+
+    sum_matrix = np.zeros((n_groups, 0), dtype=np.float64)
+    count_nz_matrix = np.zeros((n_groups, 0), dtype=np.int64)
+    gene_names: list[str] = []
+
+    # Pre-size buffers in chunks to avoid per-gene resize; column-extend
+    # accumulators lazily.
+    BLOCK = 1024
+    sum_block = np.zeros((n_groups, BLOCK), dtype=np.float64)
+    count_block = np.zeros((n_groups, BLOCK), dtype=np.int64)
+    block_fill = 0
+
+    def _flush_block():
+        nonlocal sum_matrix, count_nz_matrix, block_fill
+        if block_fill == 0:
+            return
+        sum_matrix = np.concatenate([sum_matrix, sum_block[:, :block_fill]], axis=1)
+        count_nz_matrix = np.concatenate(
+            [count_nz_matrix, count_block[:, :block_fill]], axis=1
+        )
+        block_fill = 0
+
+    for gene, row in row_iter:
+        row_valid = row[valid]
+        sum_block[:, block_fill] = np.bincount(
+            group_idx[valid], weights=row_valid, minlength=n_groups
+        )
+        count_block[:, block_fill] = np.bincount(
+            group_idx[valid],
+            weights=(row_valid != 0).astype(np.float64),
+            minlength=n_groups,
+        ).astype(np.int64)
+        gene_names.append(gene)
+        block_fill += 1
+        if block_fill == BLOCK:
+            _flush_block()
+    _flush_block()
+
+    if len(gene_names) == 0:
+        raise ValueError(
+            f"Expression matrix {expression_matrix_path!r} contained no data rows."
+        )
+
+    n_cells_col = n_cells_per_group[:, None]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        mean = np.where(n_cells_col > 0, sum_matrix / n_cells_col, 0.0).astype(np.float32)
+        fraction_expressed = np.where(
+            n_cells_col > 0, count_nz_matrix / n_cells_col, 0.0
+        ).astype(np.float32)
+
+    obs = pd.DataFrame({"n_cells": n_cells_per_group}, index=pd.Index(uniques, name="group"))
+    # Unpack the composite label back into per-field columns.
+    if len(by) == 1:
+        obs[by[0]] = uniques
+    else:
+        parts = [u.split("_") for u in uniques]
+        for i, col in enumerate(by):
+            obs[col] = [p[i] if i < len(p) else "" for p in parts]
+
+    var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
+
+    keep_groups = obs["n_cells"].to_numpy() >= min_cells_per_group
+    if not keep_groups.any():
+        # Build a short report for the error message.
+        report = "; ".join(
+            f"{u}={int(n)}" for u, n in zip(uniques, n_cells_per_group)
+        )
+        raise ValueError(
+            f"All groups fell below min_cells_per_group={min_cells_per_group}. "
+            f"Observed: {report}"
+        )
+
+    adata = ad.AnnData(
+        X=mean[keep_groups],
+        obs=obs[keep_groups].copy(),
+        var=var,
+        layers={
+            "sum": sum_matrix[keep_groups].astype(np.float32),
+            "count_nonzero": count_nz_matrix[keep_groups].astype(np.int64),
+            "fraction_expressed": fraction_expressed[keep_groups],
+            "mean": mean[keep_groups],
+        },
+    )
+    logger.info(
+        "Aggregated AnnData: %d groups × %d genes (dropped %d groups below min_cells)",
+        adata.n_obs, adata.n_vars, int((~keep_groups).sum()),
+    )
+    return adata
+```
+
+- [ ] **Step 2: Smoke-test numerical equivalence against `summarize_expression_ad`**
+
+Run:
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/python - <<'PY'
+import gzip, os, tempfile
+import numpy as np
+import pandas as pd
+import anndata as ad
+from hvantk.tables.ucsc import summarize_ucsc_streaming, create_anndata_from_ucsc_matrix
+from hvantk.utils.matrix_utils import summarize_expression_ad
+
+rng = np.random.default_rng(42)
+n_genes, n_cells = 40, 300
+vals = rng.random((n_genes, n_cells)).astype(np.float32)
+vals[vals < 0.5] = 0.0
+genes = [f"G{i}" for i in range(n_genes)]
+cells = [f"C{j}" for j in range(n_cells)]
+
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "x.tsv.gz")
+    with gzip.open(src, "wt") as fh:
+        fh.write("gene\t" + "\t".join(cells) + "\n")
+        for g, row in zip(genes, vals):
+            fh.write(g + "\t" + "\t".join(f"{v:.6g}" for v in row) + "\n")
+
+    meta = pd.DataFrame(
+        {"cell_type": ["A"] * 120 + ["B"] * 100 + ["C"] * 80},
+        index=pd.Index(cells, name="cell_id"),
+    )
+
+    fused = summarize_ucsc_streaming(
+        src, meta, group_by="cell_type", min_cells_per_group=5
+    )
+
+    ad_full = create_anndata_from_ucsc_matrix(src, metadata_df=meta, chunk_size=10)
+    two_step = summarize_expression_ad(ad_full, group_by="cell_type", min_cells_per_group=5)
+
+    # Align on group label order.
+    fused = fused[sorted(fused.obs_names)].copy()
+    two_step = two_step[sorted(two_step.obs_names)].copy()
+
+    assert list(fused.obs_names) == list(two_step.obs_names), (
+        list(fused.obs_names), list(two_step.obs_names)
+    )
+    assert fused.shape == two_step.shape, (fused.shape, two_step.shape)
+    for layer in ("mean", "fraction_expressed"):
+        a = np.asarray(fused.layers[layer])
+        b = np.asarray(two_step.layers[layer])
+        diff = np.abs(a - b).max()
+        print(f"{layer}: max_abs_diff={diff:.3e}")
+        assert diff < 1e-5, (layer, diff)
+print("OK")
+PY
+```
+
+Expected: `OK`. All layers (`mean`, `fraction_expressed`) agree within `1e-5`.
+
+- [ ] **Step 3: Run lint**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m flake8 hvantk/tables/ucsc.py --count --select=E9,F63,F7,F82 --show-source --statistics`
+
+Expected: `0`.
+
+- [ ] **Step 4: Propose commit to user**
+
+```bash
+git add hvantk/tables/ucsc.py
+git commit -m "$(cat <<'EOF'
+feat(ucsc): add summarize_ucsc_streaming fused aggregator
+
+Streams UCSC gz row-by-row, reducing each row into (n_groups, n_genes)
+float64/int64 accumulators via np.bincount. Emits an AnnData whose
+schema (obs[n_cells], layers {mean, sum, count_nonzero,
+fraction_expressed}) matches summarize_expression_ad so downstream
+consumers cannot tell which path produced a given summary.
+EOF
+)"
+```
+
+---
+
+## Task 5: Plumb `backed` kwarg through `build_ucsc_ad`
+
+**Files:**
+- Modify: `hvantk/tables/matrix_builders.py` — function `build_ucsc_ad`.
+
+- [ ] **Step 1: Add `backed` kwarg and dispatch logic**
+
+In `hvantk/tables/matrix_builders.py`, find `build_ucsc_ad` (around line 24). Add a new constant at the top of the module near other constants (or add one if none exist yet):
+
+```python
+# Auto-select the backed builder for UCSC inputs larger than this threshold.
+BACKED_BUILDER_THRESHOLD_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
+```
+
+Update `build_ucsc_ad` to the signature:
+
+```python
+def build_ucsc_ad(
+    expression_matrix_path: str,
+    metadata_path: str,
+    output_path: Optional[str] = None,
+    gene_column: str = "gene",
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+    overwrite: bool = False,
+    chunk_size: int = 500,
+    backed: "bool | None" = None,
+    column_batch: int = 64,
+) -> "ad.AnnData":
+```
+
+Replace the body with:
+
+```python
+    import anndata as ad
+
+    from hvantk.tables.ucsc import (
+        load_ucsc_metadata,
+        create_anndata_from_ucsc_matrix,
+        build_ucsc_atlas_backed,
+    )
+    from hvantk.core.anndata_utils import (
+        build_anndata_metadata,
+        annotate_column_summary_ad,
+        save_anndata,
+    )
+
+    logger.info("Loading UCSC metadata from %s", metadata_path)
+    metadata_df = load_ucsc_metadata(metadata_path, sep=delimiter)
+
+    # Auto-select backed mode by input size unless caller forces.
+    if backed is None:
+        size = os.path.getsize(expression_matrix_path)
+        backed = size > BACKED_BUILDER_THRESHOLD_BYTES
+        logger.info(
+            "build_ucsc_ad: auto-selected backed=%s (input size %.2f GiB, threshold %.2f GiB)",
+            backed, size / (1024**3), BACKED_BUILDER_THRESHOLD_BYTES / (1024**3),
+        )
+
+    if backed:
+        if output_path is None:
+            raise ValueError("backed=True requires output_path (writes directly to disk).")
+        provenance = {"hvantk_metadata": build_anndata_metadata("UCSC", expression_matrix_path)}
+        build_ucsc_atlas_backed(
+            expression_matrix_path=expression_matrix_path,
+            output_path=output_path,
+            metadata_df=metadata_df,
+            gene_column=gene_column,
+            delimiter=delimiter,
+            split_gene_field=split_gene_field,
+            column_batch=column_batch,
+            overwrite=overwrite,
+            uns=provenance,
+        )
+        # Return a backed-mode handle — shape + obs/var without materializing X.
+        # annotate_column_summary_ad would need to scan the full X matrix and
+        # is intentionally skipped for backed atlases (v1 trade-off).
+        logger.info(
+            "Backed atlas built at %s; skipping annotate_column_summary_ad "
+            "(would materialize X). Returning a backed AnnData handle.",
+            output_path,
+        )
+        return ad.read_h5ad(output_path, backed="r")
+
+    logger.info("Creating AnnData from UCSC expression matrix (in-memory)")
+    adata = create_anndata_from_ucsc_matrix(
+        expression_matrix_path=expression_matrix_path,
+        metadata_df=metadata_df,
+        gene_column=gene_column,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+        chunk_size=chunk_size,
+    )
+    adata.uns["hvantk_metadata"] = build_anndata_metadata(
+        "UCSC", expression_matrix_path
+    )
+    annotate_column_summary_ad(adata)
+    if output_path:
+        save_anndata(adata, output_path, overwrite=overwrite)
+    return adata
+```
+
+Add `import os` at the top of the module if not already present.
+
+- [ ] **Step 2: Run existing builder tests**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m flake8 hvantk/tables/matrix_builders.py --count --select=E9,F63,F7,F82 --show-source --statistics`
+
+Expected: `0`.
+
+- [ ] **Step 4: Propose commit to user**
+
+```bash
+git add hvantk/tables/matrix_builders.py
+git commit -m "$(cat <<'EOF'
+feat(ucsc): route build_ucsc_ad through backed builder for large inputs
+
+Add backed: bool | None kwarg (default auto-select by input size >
+BACKED_BUILDER_THRESHOLD_BYTES, 1 GiB). Dispatches to
+build_ucsc_atlas_backed when backed, create_anndata_from_ucsc_matrix
+otherwise. backed=True requires output_path.
+EOF
+)"
+```
+
+---
+
+## Task 6: Expose `--backed / --no-backed` on `mkmatrix ucsc`
+
+**Files:**
+- Modify: `hvantk/commands/make_matrix_cli.py` — command `mkmatrix_ucsc`.
+
+- [ ] **Step 1: Add the flag**
+
+Find `mkmatrix_ucsc` in `hvantk/commands/make_matrix_cli.py`. Add a new click option after `--chunk-size`:
+
+```python
+@click.option(
+    "--backed/--no-backed",
+    default=None,
+    help=(
+        "Use the incremental backed-write builder (CSC columns appended to "
+        ".h5ad on disk; no RAM materialization). Default: auto — backed if "
+        "the input is larger than ~1 GiB."
+    ),
+)
+@click.option(
+    "--column-batch",
+    type=int,
+    default=64,
+    show_default=True,
+    help="Gene columns per backed-append block (backed mode only).",
+)
+```
+
+Add `backed` and `column_batch` params to the `mkmatrix_ucsc` signature and pass them through to `_build_ucsc_ad`:
+
+```python
+def mkmatrix_ucsc(
+    expression_matrix,
+    metadata,
+    output_path,
+    gene_column,
+    delimiter,
+    split_gene_field,
+    chunk_size,
+    backed,
+    column_batch,
+    overwrite,
+):
+    ...
+    adata = _build_ucsc_ad(
+        expression_matrix_path=expression_matrix,
+        metadata_path=metadata,
+        output_path=output_path,
+        gene_column=gene_column,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+        chunk_size=chunk_size,
+        backed=backed,
+        column_batch=column_batch,
+        overwrite=overwrite,
+    )
+```
+
+- [ ] **Step 2: Run existing CLI test**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m pytest hvantk/tests/test_expression_builders_anndata.py::TestMkmatrixCli::test_ucsc_produces_h5ad -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Sanity-check help output**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/hvantk mkmatrix ucsc --help`
+
+Expected: see `--backed/--no-backed` and `--column-batch` in the help text.
+
+- [ ] **Step 4: Run lint**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m flake8 hvantk/commands/make_matrix_cli.py --count --select=E9,F63,F7,F82 --show-source --statistics`
+
+Expected: `0`.
+
+- [ ] **Step 5: Propose commit to user**
+
+```bash
+git add hvantk/commands/make_matrix_cli.py
+git commit -m "feat(mkmatrix): add --backed/--no-backed + --column-batch to mkmatrix ucsc"
+```
+
+---
+
+## Task 7: Parametrize `TestBuildUcscAd` with `backed=[False, True]`
+
+**Files:**
+- Modify: `hvantk/tests/test_expression_builders_anndata.py` — class `TestBuildUcscAd`.
+
+- [ ] **Step 1: Inspect the current test class**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v --collect-only`
+
+Read the existing test methods and their fixtures. Note how `build_ucsc_ad` is invoked (positional vs kwargs) and which paths are expected.
+
+- [ ] **Step 2: Parametrize**
+
+At the top of `TestBuildUcscAd`, add a class-level parametrize:
+
+```python
+@pytest.mark.parametrize("backed", [False, True])
+class TestBuildUcscAd:
+    ...
+```
+
+In every test method, add `backed` as a parameter and pass it through to `build_ucsc_ad`:
+
+```python
+def test_...(self, tmp_path, backed):
+    ...
+    adata = build_ucsc_ad(
+        ...,
+        backed=backed,
+        output_path=str(tmp_path / "atlas.h5ad"),  # required when backed=True
+        overwrite=True,
+    )
+    ...
+```
+
+If any test currently passes `output_path=None`, force `output_path=str(tmp_path / "...h5ad")` so the backed variant can write. The in-memory variant tolerates a real path too.
+
+- [ ] **Step 3: Run the parametrized tests**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v`
+
+Expected: test count doubles (each existing test now has `[False]` and `[True]` variants). All PASS.
+
+- [ ] **Step 4: Run the full fast-test suite to check for collateral damage**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m pytest -q`
+
+Expected: all PASS (excluding hail/network/slow markers as configured in `pytest.ini`).
+
+- [ ] **Step 5: Propose commit to user**
+
+```bash
+git add hvantk/tests/test_expression_builders_anndata.py
+git commit -m "test(ucsc): parametrize TestBuildUcscAd with backed=[False, True]"
+```
+
+---
+
+## Task 8: Add `expression summarize-ucsc` CLI subcommand
+
+**Files:**
+- Modify: `hvantk/commands/summarize_expression_cli.py` — add `summarize_ucsc_cmd`.
+
+- [ ] **Step 1: Add the command**
+
+At the bottom of `hvantk/commands/summarize_expression_cli.py`, before any `__main__` stanza, add:
+
+```python
+@expression_group.command("summarize-ucsc")
+@click.option(
+    "-e",
+    "--expression-matrix",
+    "expression_matrix",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the UCSC expression TSV (plain or gzipped).",
+)
+@click.option(
+    "-m",
+    "--metadata",
+    "metadata_path",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the UCSC cell metadata TSV.",
+)
+@click.option(
+    "--group-by",
+    multiple=True,
+    required=True,
+    help="Metadata column(s) to group by. Repeat for multi-field grouping.",
+)
+@click.option(
+    "--filter-by",
+    multiple=True,
+    default=None,
+    help=(
+        "Pre-filter cells: FIELD=VALUE (repeatable). "
+        "Example: --filter-by Region=Cortex --filter-by TimePoint=9wpc"
+    ),
+)
+@click.option(
+    "--min-cells",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Drop groups with fewer cells than this threshold.",
+)
+@click.option(
+    "--gene-column",
+    default="gene",
+    show_default=True,
+)
+@click.option(
+    "--delimiter",
+    default="\t",
+    show_default=True,
+)
+@click.option(
+    "--split-gene-field/--no-split-gene-field",
+    default=True,
+    show_default=True,
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    required=True,
+    help="Output path for the aggregated AnnData (.h5ad).",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing output.",
+)
+def summarize_ucsc_cmd(
+    expression_matrix,
+    metadata_path,
+    group_by,
+    filter_by,
+    min_cells,
+    gene_column,
+    delimiter,
+    split_gene_field,
+    output,
+    overwrite,
+):
+    """Fused stream-and-aggregate: UCSC expression + metadata → groups × genes .h5ad.
+
+    Skips the intermediate cells × genes atlas.h5ad — streams the expression
+    matrix row-by-row and accumulates per-group per-gene statistics in a
+    single pass. Output schema matches `hvantk expression summarize`, so
+    downstream consumers do not branch on which path produced the summary.
+
+    \b
+    Examples:
+
+      # Single-field grouping
+      hvantk expression summarize-ucsc \\
+          -e exprMatrix.tsv.gz -m meta.tsv \\
+          --group-by Class \\
+          -o class_summary.h5ad
+
+      # Multi-field grouping + pre-filter
+      hvantk expression summarize-ucsc \\
+          -e exprMatrix.tsv.gz -m meta.tsv \\
+          --group-by Region --group-by TimePoint \\
+          --filter-by Region=Cortex \\
+          --min-cells 10 \\
+          -o region_timepoint_summary.h5ad
+    """
+    from pathlib import Path
+
+    from hvantk.tables.ucsc import load_ucsc_metadata, summarize_ucsc_streaming
+
+    output_path = Path(output)
+    if output_path.suffix != ".h5ad":
+        raise click.BadParameter(
+            f"Output must end in '.h5ad' (got {output_path.suffix!r}).",
+            param_hint="--output",
+        )
+
+    if output_path.exists() and not overwrite:
+        click.echo(
+            f"Error: Output file already exists: {output_path}\n"
+            "Use --overwrite to replace it.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    filters = None
+    if filter_by:
+        filters = {}
+        for item in filter_by:
+            if "=" not in item:
+                raise click.BadParameter(
+                    f"Expected FIELD=VALUE format, got: {item!r}",
+                    param_hint="--filter-by",
+                )
+            key, value = item.split("=", 1)
+            filters[key.strip()] = value.strip()
+
+    metadata_df = load_ucsc_metadata(metadata_path, sep=delimiter)
+
+    missing = [col for col in group_by if col not in metadata_df.columns]
+    if missing:
+        raise click.BadParameter(
+            f"--group-by column(s) not in metadata: {missing}. "
+            f"Available: {sorted(metadata_df.columns)}",
+            param_hint="--group-by",
+        )
+
+    summary = summarize_ucsc_streaming(
+        expression_matrix_path=expression_matrix,
+        metadata_df=metadata_df,
+        group_by=list(group_by),
+        filter_by=filters,
+        min_cells_per_group=min_cells,
+        gene_column=gene_column,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_h5ad(str(output_path))
+
+    n_cells = summary.obs["n_cells"].astype(int)
+    click.echo(f"\nSummary AnnData written to: {output_path}")
+    click.echo(f"  Shape:  {summary.n_obs} groups × {summary.n_vars} genes")
+    click.echo(f"  Layers: {sorted(summary.layers.keys())}")
+    click.echo(
+        f"  Cells per group: min={int(n_cells.min())}, "
+        f"max={int(n_cells.max())}, total={int(n_cells.sum())}"
+    )
+    click.echo("")
+    click.echo(f"Group labels ({summary.n_obs}):")
+    for label, n in list(zip(summary.obs_names, n_cells))[:10]:
+        click.echo(f"  {label:<40s}  {int(n):>8,} cells")
+    if summary.n_obs > 10:
+        click.echo(f"  ... and {summary.n_obs - 10} more")
+```
+
+- [ ] **Step 2: Smoke-test the new command**
+
+Run:
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/python - <<'PY'
+import gzip, subprocess, tempfile, pathlib
+import numpy as np, pandas as pd, anndata as ad
+
+rng = np.random.default_rng(0)
+n_genes, n_cells = 30, 100
+vals = rng.random((n_genes, n_cells)).astype(np.float32); vals[vals < 0.5] = 0.0
+genes = [f"G{i}" for i in range(n_genes)]
+cells = [f"C{j}" for j in range(n_cells)]
+
+with tempfile.TemporaryDirectory() as d:
+    d = pathlib.Path(d)
+    src = d / "x.tsv.gz"
+    with gzip.open(src, "wt") as fh:
+        fh.write("gene\t" + "\t".join(cells) + "\n")
+        for g, row in zip(genes, vals):
+            fh.write(g + "\t" + "\t".join(f"{v:.6g}" for v in row) + "\n")
+    meta = pd.DataFrame(
+        {"cell_type": ["A"]*40 + ["B"]*35 + ["C"]*25},
+        index=pd.Index(cells, name="cell_id"),
+    )
+    meta_path = d / "meta.tsv"
+    meta.to_csv(meta_path, sep="\t")
+
+    out = d / "summary.h5ad"
+    r = subprocess.run(
+        ["hvantk", "expression", "summarize-ucsc",
+         "-e", str(src), "-m", str(meta_path),
+         "--group-by", "cell_type",
+         "--min-cells", "5",
+         "-o", str(out)],
+        capture_output=True, text=True,
+    )
+    print("stdout:", r.stdout)
+    print("stderr:", r.stderr)
+    assert r.returncode == 0, r.returncode
+    loaded = ad.read_h5ad(out)
+    print("shape:", loaded.shape, "layers:", sorted(loaded.layers.keys()))
+    assert set(loaded.layers.keys()) >= {"mean", "sum", "count_nonzero", "fraction_expressed"}
+    assert loaded.shape == (3, n_genes)
+print("OK")
+PY
+```
+
+Expected: `OK`, `shape: (3, 30)`, all 4 layers present.
+
+- [ ] **Step 3: Smoke-test error handling (bad --group-by)**
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/python - <<'PY'
+import subprocess, tempfile, pathlib, gzip
+import numpy as np, pandas as pd
+rng = np.random.default_rng(0)
+with tempfile.TemporaryDirectory() as d:
+    d = pathlib.Path(d)
+    src = d / "x.tsv.gz"
+    with gzip.open(src, "wt") as fh:
+        fh.write("gene\tC1\tC2\n")
+        fh.write("G1\t1.0\t2.0\n")
+    meta_path = d / "meta.tsv"
+    pd.DataFrame({"cell_type": ["A", "B"]}, index=pd.Index(["C1", "C2"], name="cell_id")).to_csv(meta_path, sep="\t")
+    r = subprocess.run(
+        ["hvantk", "expression", "summarize-ucsc",
+         "-e", str(src), "-m", str(meta_path),
+         "--group-by", "NoSuchField",
+         "-o", str(d / "out.h5ad")],
+        capture_output=True, text=True,
+    )
+    print("exit:", r.returncode)
+    print("stderr:", r.stderr[:300])
+    assert r.returncode == 2, r.returncode
+    assert "NoSuchField" in r.stderr
+    assert "cell_type" in r.stderr
+print("OK — bad --group-by fails fast with helpful message")
+PY
+```
+
+Expected: exit 2, error message lists `NoSuchField` and `cell_type`.
+
+- [ ] **Step 4: Run full fast-test suite**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m pytest -q`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run lint**
+
+Run: `/Users/enrique/projects/github/pyvatk/.venv/bin/python -m flake8 hvantk/commands/summarize_expression_cli.py --count --select=E9,F63,F7,F82 --show-source --statistics`
+
+Expected: `0`.
+
+- [ ] **Step 6: Propose commit to user**
+
+```bash
+git add hvantk/commands/summarize_expression_cli.py
+git commit -m "$(cat <<'EOF'
+feat(expression): add summarize-ucsc CLI (fused stream-and-aggregate)
+
+New hvantk expression summarize-ucsc subcommand: takes raw UCSC
+expression + metadata + --group-by, streams and aggregates in one pass
+via summarize_ucsc_streaming, emits a .h5ad whose schema matches
+expression summarize. Skips the cells x genes atlas intermediate.
+EOF
+)"
+```
+
+---
+
+## Task 9: Manual validation on the adult-cortex meta-atlas
+
+No automated tests. Purpose: verify end-to-end behavior on real data before PR.
+
+- [ ] **Step 1: Backed build of the atlas**
+
+Run (in a separate terminal — it will take ~30–45 min):
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/hvantk -v mkmatrix ucsc \
+    -e /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/exprMatrix.tsv.gz \
+    -m /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/meta.tsv \
+    -o /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/adult_ctx_meta_atlas.h5ad \
+    --backed \
+    --column-batch 64 \
+    --overwrite
+```
+
+Acceptance:
+- Finishes without OOM.
+- Peak RSS ≤ ~3 GB (spot-check via Activity Monitor or `ps`).
+- Log lines show periodic `appended N genes` progress.
+- Resulting file reopens cleanly: `adata = ad.read_h5ad(...)`; `adata.shape == (520014, 122697)`.
+
+If peak RSS is above ~5 GB, investigate before continuing — the backed path is supposed to be bounded.
+
+- [ ] **Step 2: Fused summarize of the same raw files**
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/hvantk -v expression summarize-ucsc \
+    -e /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/exprMatrix.tsv.gz \
+    -m /Users/enrique/projects/github/pyvatk/local/data/UCSC/adult-ctx-meta-atlas/adult-ctx-meta-atlas/meta.tsv \
+    --group-by Class \
+    --min-cells 10 \
+    -o /Users/enrique/projects/github/pyvatk/output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.h5ad \
+    --overwrite
+```
+
+Acceptance:
+- Finishes in ≤ 45 min wall-clock.
+- `summary.obs["n_cells"].sum()` equals the number of non-NaN `Class` cells in metadata.
+- Report card shows ~10 groups (Jorstad Class labels), ~122k transcripts, layers `mean`, `sum`, `count_nonzero`, `fraction_expressed`.
+
+- [ ] **Step 3: Numerical spot-check against the prior pickle (if present)**
+
+Only if `output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.pkl` still exists:
+
+```bash
+/Users/enrique/projects/github/pyvatk/.venv/bin/python - <<'PY'
+import pandas as pd, anndata as ad, numpy as np
+
+old = pd.read_pickle("output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.pkl")
+new = ad.read_h5ad("output/ptm_assembly/brain_metaatlas_gene_class_mean_expr.h5ad")
+new_wide = pd.DataFrame(
+    new.layers["mean"].T, index=new.var_names, columns=new.obs_names
+).rename_axis("gene_symbol")
+new_wide = new_wide[~new_wide.index.duplicated(keep="first")]
+
+common_genes = old.index.intersection(new_wide.index)
+common_cls = old.columns.intersection(new_wide.columns)
+o = old.loc[common_genes, common_cls].to_numpy(dtype=np.float64)
+n = new_wide.loc[common_genes, common_cls].to_numpy(dtype=np.float64)
+abs_err = np.nanmax(np.abs(o - n))
+rel_err = np.nanmax(np.abs(o - n) / np.where(np.abs(o) > 1e-8, np.abs(o), 1.0))
+print(f"overlap: {len(common_genes)} genes × {len(common_cls)} classes")
+print(f"max abs diff: {abs_err:.3e}")
+print(f"max rel diff: {rel_err:.3e}")
+assert abs_err < 1e-3 or rel_err < 1e-3, "mean expression diverged — investigate"
+print("OK — new fused pipeline agrees with old pickle within tolerance")
+PY
+```
+
+Expected: `OK — new fused pipeline agrees with old pickle within tolerance`.
+
+- [ ] **Step 4: Record the run as a validation receipt**
+
+In `local/notebooks/` or `local/planning/`, create a short markdown note with: date, dataset, wall-clock per run, peak RSS, final shape, commit SHA at the time of the run. Commit it if it lives in a non-gitignored path; otherwise keep it local.
+
+---
+
+## Task 10: Open the PR
+
+- [ ] **Step 1: Confirm with user that the branch is ready**
+
+Ask: "Manual validation passed on `adult-ctx-meta-atlas`. Ready to push `feat/sc-aggregation-cli` and open a PR into `dev`?"
+
+- [ ] **Step 2: Push branch (only after user says yes)**
+
+```bash
+git push -u origin feat/sc-aggregation-cli
+```
+
+- [ ] **Step 3: Create PR**
+
+```bash
+gh pr create --base dev --title "feat(expression): backed-write mkmatrix ucsc + fused summarize-ucsc" --body "$(cat <<'EOF'
+## Summary
+
+- `mkmatrix ucsc` can now build `atlas.h5ad` without materializing the full cells × genes matrix. Uses CSC incremental writes via `anndata.io.sparse_dataset`; `--backed` auto-enabled when the input is > 1 GiB.
+- New `hvantk expression summarize-ucsc` subcommand: streams UCSC expression + metadata and aggregates in a single `np.bincount` pass, emitting a `groups × genes` `.h5ad` whose schema matches the existing `expression summarize`.
+- Shared low-level row streamer (`_iter_ucsc_rows`) extracted from the existing builder so both new paths reuse the same validated parser.
+
+## Test plan
+
+- [x] `pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd -v` (parametrized on `backed=[False, True]`)
+- [x] `pytest hvantk/tests/test_matrix_utils_anndata.py::TestSummarizeExpressionAd -v` (output schema parity)
+- [x] `pytest -q` full fast suite
+- [x] Manual backed build of `adult-ctx-meta-atlas` (520k × 122k) finished under 45 min; peak RSS ≤ 3 GB
+- [x] Fused `summarize-ucsc` produced `groups × genes` summary agreeing with the prior pickle within 1e-3
+
+## Deferred (tracked)
+
+- `expression summarize` `--backed` mode for reading 40+ GB atlases from disk
+- `describe` / `markers` backed-atlas support
+- Same pattern applied to Expression Atlas and CPTAC builders
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Out of scope (NOT in this PR)
+
+- `expression summarize` gains a `--backed` mode. Needed eventually (otherwise stage-2 against a 40 GB atlas OOMs), but separable and not blocking the fused path.
+- `describe` / `markers` retrofits for backed atlases.
+- Extending the same streaming pattern to Expression Atlas, CPTAC, or other wide-TSV sources.
+- Promoting `var` / `std` / `log2_mean` to first-class aggregation layers.

--- a/docs_site/specs/2026-04-16-single-cell-aggregation-cli-design.md
+++ b/docs_site/specs/2026-04-16-single-cell-aggregation-cli-design.md
@@ -1,0 +1,296 @@
+# Design spec: single-cell aggregation CLI (`hvantk expression summarize`)
+
+**Date:** 2026-04-16
+**Status:** Design approved — ready to plan implementation
+**Related planning doc:** `local/planning/2026-04-16-single-cell-aggregation-cli.md`
+
+## Goal
+
+Provide a first-class library + CLI primitive for aggregating a single-cell
+expression AnnData into a per-group × per-gene summary, and make the upstream
+`mkmatrix ucsc` builder usable on atlases that don't fit in RAM. Analysis
+notebooks must consume a pre-aggregated artifact; all streaming/aggregation
+optimization lives in hvantk.
+
+## Scope
+
+- Stream-capable `mkmatrix ucsc` (fix `build_ucsc_ad` to handle multi-GB
+  gzipped TSV without OOM).
+- Reworked `hvantk expression summarize` backed by `scanpy.get.aggregate`.
+- Canonical `.h5ad` output for aggregates (groups × genes, aggregations as
+  `layers`).
+- Retrofit notebook K.1 Cell 3 to consume the aggregated `.h5ad` directly.
+
+**Out of scope for v1:** median aggregation, pickle/parquet/Hail-Table
+exporters, multi-modal AnnData, cross-cluster normalization, automatic gene
+symbol harmonization, `--backed` mode for atlases > RAM (flagged for v2).
+
+## Architectural principle
+
+Two-step pipeline, mapped onto hvantk's existing Builder/Streamer split:
+
+```
+[Builder]                           [Streamer / aggregator]
+mkmatrix ucsc   ──►   atlas.h5ad   ──►   expression summarize   ──►   class_mean.h5ad
+(source-specific:     (canonical,       (source-agnostic:             (small,
+ streams raw UCSC     reusable for       sc.get.aggregate on           reusable across
+ TSV → sparse CSR)    describe /         any .h5ad)                    analysis runs)
+                      markers /
+                      summarize)
+```
+
+`atlas.h5ad` is built **once per atlas**. Multiple `summarize` passes (different
+`--group-by`, different `--filter-by`, etc.) reuse it. `describe` and `markers`
+also consume the same `atlas.h5ad`.
+
+## Why `.h5ad`-only output (not pickle / parquet / HT)
+
+- `sc.get.aggregate` returns an AnnData natively. Writing that directly is
+  scverse-native and zero re-implementation.
+- All aggregations (`mean`, `sum`, `count_nonzero`, derived `fraction_expressed`)
+  travel as `layers` in one file.
+- Wide DataFrames and Hail Tables can be rederived in one line each; exporters
+  can be added later when a concrete consumer demands them (not v1).
+
+## Why no native scverse reader for UCSC
+
+Research confirmed no scverse tool ships a UCSC Cell Browser reader:
+
+- No `read_ucsc`/`read_cellbrowser` in `scanpy`, `scanpy.external`, or
+  `anndata`.
+- UCSC's own `cellbrowser` PyPI package writes UCSC format (authoring tool);
+  it does not reverse-read.
+- `anndata.read_text` / `anndata.read_csv` handle `.gz` but materialize the
+  full matrix **dense** via `np.array(list_of_row_arrays, dtype=dtype)` — for
+  a 520k × 20k UCSC matrix that is ~41 GB dense in RAM. Strictly worse than
+  the current `pd.read_csv` path.
+- `anndata.experimental` (`CSRDataset`, `sparse_dataset`, `read_elem`,
+  `concat_on_disk`) operates on **existing** h5ad/zarr stores. Useful
+  downstream, not at the pre-`.h5ad` boundary.
+
+The streaming gz → CSR → h5ad step is ~30 lines we own. Everything downstream
+delegates to `scanpy.get.aggregate`.
+
+## Components
+
+### C1. `build_ucsc_ad` (streaming rewrite)
+
+**File:** `hvantk/tables/ucsc.py::create_anndata_from_ucsc_matrix`
+**Caller:** `hvantk/tables/matrix_builders.py::build_ucsc_ad` (one new kwarg)
+
+Replace the single `pd.read_csv` body with a streamed builder:
+
+1. Read header once (via `gzip.open`) to get cell IDs.
+2. Loop `pd.read_csv(..., sep=delimiter, chunksize=chunk_size, dtype=np.float32)`
+   (works transparently on `.gz`). Default `chunk_size = 500` genes.
+3. Each chunk: split off the gene-ID column, optionally split on `|` per
+   `split_gene_field`, convert the numeric block to `scipy.sparse.csr_matrix`,
+   append to list. Accumulate gene names separately.
+4. After loop: `scipy.sparse.vstack([chunks])`, `.T.tocsr()` to get
+   `(n_cells × n_genes)` CSR.
+5. Wrap in `AnnData(X=csr, obs=..., var=...)`. Existing metadata-join block
+   below is unchanged.
+
+**New kwarg on `build_ucsc_ad`:** `chunk_size: int = 500`. Plumb through to
+`create_anndata_from_ucsc_matrix`.
+
+**Peak RAM:** one chunk (~500 × 520k × 4B ≈ 1 GB dense) + growing sparse
+vstack (sparse; typically < 5 GB for realistic sc atlases).
+
+**Error:** if a chunk fails float32 conversion, raise `ValueError` naming the
+offending gene row.
+
+### C2. `summarize_expression_ad` (rewrite on `sc.get.aggregate`)
+
+**File:** `hvantk/utils/matrix_utils.py::summarize_expression_ad`
+
+Replace the hand-rolled per-group loop with:
+
+```python
+def summarize_expression_ad(
+    adata,
+    group_by,                       # str or list[str] — multi-column kept
+    filter_by=None,
+    min_cells_per_group=10,
+):
+    if filter_by:
+        adata = filter_by_metadata_ad(adata, filter_by)
+
+    by = [group_by] if isinstance(group_by, str) else list(group_by)
+
+    agg = sc.get.aggregate(
+        adata,
+        by=by,                           # sc.get.aggregate accepts list[str] natively
+        func=["mean", "sum", "count_nonzero"],
+    )
+    # agg: AnnData of shape (n_groups, n_genes), layers["mean"|"sum"|"count_nonzero"].
+    # Multi-column groupings produce obs_names joined with "_" (e.g. "IT_LV").
+
+    # sc.get.aggregate does NOT stash per-group cell counts — verified against
+    # scanpy 1.10.3. Compute them from the pre-aggregate adata, joining the
+    # group-by columns with "_" so the resulting index matches agg.obs_names.
+    group_labels = adata.obs[by].astype(str).agg("_".join, axis=1)
+    n_cells = group_labels.value_counts().reindex(agg.obs_names).astype(int)
+
+    agg.obs["n_cells"] = n_cells.values
+    agg.layers["fraction_expressed"] = (
+        agg.layers["count_nonzero"] / n_cells.values[:, None]
+    )
+
+    keep = agg.obs["n_cells"].values >= min_cells_per_group
+    return agg[keep].copy()
+```
+
+**Return type change:** `AnnData` (was `pd.DataFrame`). This is a breaking
+change to the library function.
+
+**`count_nonzero` is the scanpy-native primitive**; `fraction_expressed`
+is one division. `mean` is the canonical v1 agg. `sum` / `var` /
+`count_nonzero` come along for free (one `sc.get.aggregate` pass) and are
+available as layers without extra cost.
+
+### C3. `summarize_expression_cmd` (CLI — output change only)
+
+**File:** `hvantk/commands/summarize_expression_cli.py`
+
+Deltas vs. the existing command:
+
+| Parameter | Change |
+|---|---|
+| `-o, --output` | Suffix must be `.h5ad`. Reject others with `click.BadParameter`. |
+| `--min-cells` | Default changed from `50` → `10` (planning-doc alignment). |
+| `--group-by` | Keep `multiple=True` (list-of-obs-columns joined to a single grouping key). |
+| `--filter-by` | Unchanged. |
+| `--overwrite` | Unchanged. |
+
+Output handling: `summary_adata.write_h5ad(output_path)` replaces
+`summary_df.to_parquet(output_path)`.
+
+Report card prints: `n_groups`, `n_genes`, min/max cells per group, layer
+names, and a table of group labels with cell counts (first 10 + "… and N
+more").
+
+### C4. Notebook K.1 retrofit
+
+**File:** `local/notebooks/ptm-eda/notebook_k1_brain_metaatlas_ptm.ipynb`,
+Cell 3 (the "Build per-gene × per-Class mean-expression matrix (cached)"
+cell).
+
+Collapses from ~45 lines of streaming logic to:
+
+```python
+import anndata as ad, subprocess
+subprocess.run([
+    "hvantk", "expression", "summarize",
+    "-m", BRAIN_ATLAS_H5AD,
+    "--group-by", CELLTYPE_COL,
+    "--min-cells", "10",
+    "-o", BRAIN_CACHE_H5AD,
+    "--overwrite",
+], check=True)
+adata = ad.read_h5ad(BRAIN_CACHE_H5AD)
+brain_wide = (
+    pd.DataFrame(adata.layers["mean"].T, index=adata.var_names, columns=adata.obs_names)
+      .rename_axis("gene_symbol")
+)
+```
+
+Pre-requisite: `BRAIN_ATLAS_H5AD` must exist (one-time build via
+`hvantk mkmatrix ucsc -e exprMatrix.tsv.gz -m meta.tsv -o BRAIN_ATLAS_H5AD`).
+The old `BRAIN_CACHE` pickle is replaced by `BRAIN_CACHE_H5AD`. Downstream
+cells that reference `brain_wide` continue to work unchanged (still a wide
+pandas DataFrame with `gene_symbol` index and class names as columns).
+
+## CLI reference (final)
+
+```
+hvantk mkmatrix ucsc \
+    -e exprMatrix.tsv.gz \
+    -m meta.tsv \
+    -o atlas.h5ad \
+    --chunk-size 500          # new; gene rows per streaming chunk
+```
+
+```
+hvantk expression summarize \
+    -m          atlas.h5ad \                     # required
+    --group-by  Class [--group-by Subclass ...] \# required, repeatable
+    --filter-by FIELD=VALUE ... \                # optional, repeatable
+    --min-cells 10 \                             # optional (default 10)
+    -o          class_mean.h5ad \                # required, must end .h5ad
+    [--overwrite]
+```
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| `--group-by` column missing from `obs` | `click.BadParameter` listing available obs columns. |
+| `--group-by` column has NaN cells | Drop silently; log count. |
+| `--filter-by FIELD=VALUE` where FIELD missing | `click.BadParameter`. |
+| Filter produces zero cells | `SystemExit(1)` with explicit message. |
+| All groups drop out via `--min-cells` | `SystemExit(1)`; report group sizes. |
+| Output `.h5ad` exists, no `--overwrite` | Existing behavior (error + exit 1). |
+| Output suffix is not `.h5ad` | `click.BadParameter`. |
+| Streamed builder hits a non-numeric row | `ValueError` naming the offending gene ID. |
+
+## Testing
+
+Per `MEMORY.md → feedback_no_more_tests.md`, no new tests.
+
+**Update existing tests in place:** `hvantk/tests/test_matrix_utils_anndata.py`
+contains `TestSummarizeExpressionAd` which currently asserts a `pd.DataFrame`
+return with columns `{gene_id, group, mean, fraction_expressed, n_cells}`.
+Migrate those assertions to the new `AnnData` return contract — check
+`isinstance(result, ad.AnnData)`, `result.shape == (n_groups, n_genes)`,
+`result.obs["n_cells"]`, and the required layers (`mean`, `sum`,
+`count_nonzero`, `fraction_expressed`). Any CLI-level tests that asserted
+parquet output must migrate similarly.
+
+**Manual validation:** build `atlas.h5ad` from the brain meta-atlas
+(520k cells) via `mkmatrix ucsc`; run `expression summarize --group-by Class`;
+verify end-to-end completion under 30 min on a laptop; compare the resulting
+`layers["mean"]` against the existing K.1 pickle at a handful of (gene,
+class) cells for numerical agreement.
+
+If manual validation passes, ship.
+
+## Open implementation details
+
+These are resolved during implementation, not by design:
+
+1. Chunked-build logging cadence (every N genes processed) — cosmetic.
+2. Whether to also expose `var` as a first-class per-group aggregation in
+   the CLI help (it's already computed into `layers["count_nonzero"]` and
+   derivable from `mean` + `sum`; cheap to promote later).
+
+### Verified against scanpy 1.10.3 during design
+
+- `sc.get.aggregate` returns an AnnData with `obs` containing only the
+  grouping column(s), not a cell-count column. Per-group cell counts must
+  be computed separately from the pre-aggregate `adata.obs`.
+- With a list `by=[...]`, `obs_names` are joined with `_`
+  (e.g. `"IT_LV"`), which matches the existing hvantk convention.
+- Group ordering in the returned AnnData is deterministic (sorted by
+  category levels).
+
+## Deliverables (this PR)
+
+1. `create_anndata_from_ucsc_matrix` streaming rewrite + `build_ucsc_ad`
+   `chunk_size` kwarg.
+2. `summarize_expression_ad` rewrite on `sc.get.aggregate`, AnnData return.
+3. `summarize_expression_cmd` output-format change (parquet → `.h5ad`) and
+   `--min-cells` default bump.
+4. `test_matrix_utils_anndata.py::TestSummarizeExpressionAd` updated to the
+   new output contract.
+5. Notebook K.1 Cell 3 retrofit.
+
+## Deferred (v2)
+
+- `--backed` mode for atlases > RAM (requires `sc.get.aggregate` verification
+  against backed `X`).
+- Exporters from aggregated `.h5ad` to wide pickle / parquet / Hail Table
+  (add when a concrete consumer requests).
+- Retrofit of notebooks F / G / H (optional; they work as-is).
+- `sum` / `log2_mean` as first-class `--agg` selectors (the data is already
+  present in `layers`, just not surfaced via the CLI).

--- a/docs_site/specs/2026-04-17-fused-ucsc-aggregation-design.md
+++ b/docs_site/specs/2026-04-17-fused-ucsc-aggregation-design.md
@@ -1,0 +1,463 @@
+# Design spec: backed-write `mkmatrix ucsc` + fused `expression summarize-ucsc`
+
+**Date:** 2026-04-17
+**Status:** Design approved — ready to plan implementation
+**Supersedes parts of:** `docs_site/specs/2026-04-16-single-cell-aggregation-cli-design.md`
+(The prior spec assumed the atlas was ~5 GB in RAM. Manual validation on the
+real 122k × 520k adult-cortex meta-atlas showed the in-memory `vstack` +
+`.T.tocsr()` path is a wall-clock bottleneck (~2–3 h) and the atlas artifact
+itself reaches ~20–40 GB on disk. This spec adjusts both stages and adds a
+fused shortcut for the common `matrix → aggregate → summary` workflow.)
+
+## Goal
+
+Make single-cell atlas ingestion and aggregation scale to 500k+-cell UCSC
+atlases on a laptop. Two complementary execution paths, user-selected per
+invocation:
+
+1. **Build-and-keep** — incremental disk write of a canonical `atlas.h5ad`
+   (`obs=cells`, `var=genes`) for downstream reuse (multiple aggregations,
+   `describe`/`markers`, collaborator share).
+2. **Fused shortcut** — one-pass stream + aggregate that emits only the tiny
+   `summary.h5ad`, never materializing the cells × genes matrix.
+
+## Context
+
+- Issue #93 (closed by this branch) replaced `pd.read_csv(chunksize=...)`
+  with a row-oriented `gzip + np.fromstring` streamer inside
+  `create_anndata_from_ucsc_matrix`. That fixed the parser failure on large
+  gzipped inputs and gave ~6× speedup over pandas/pyarrow for wide (520k-col)
+  atlases. It did **not** change the fact that the function still builds the
+  full sparse matrix in RAM before writing `.h5ad`.
+- Manual validation run on `adult-ctx-meta-atlas`
+  (`exprMatrix.tsv.gz`, 8.7 GB, 520,014 cells × 122,697 gene/transcript rows):
+  - Streaming parser: ~78 ms/row steady-state → projected ~160 min to parse
+  - In-memory `vstack(chunks).T.tocsr()`: unknown, projected multi-hour, RAM
+    ceiling unclear (accumulated sparse chunks + transpose copy ≳ 40 GB)
+  - User aborted at ~40,000 rows processed due to projected runtime.
+- User workflow confirmed: atlases of this size will be routinely processed.
+  Common pipeline is `full expression matrix → aggregate → summary stats /
+  joins`. Keeping `atlas.h5ad` is valuable when (a) running multiple
+  aggregations from the same input, or (b) sharing the raw matrix with a
+  collaborator.
+
+## Scope
+
+**In scope (this PR)**
+
+- `mkmatrix ucsc` rewrite: stream rows and write `X` as a backed CSC dataset
+  column-by-column (one gene = one column). Output `atlas.h5ad` shape
+  `(n_cells, n_genes)`, AnnData standard convention.
+- New `expression summarize-ucsc` CLI: takes raw UCSC files + `--group-by`,
+  streams + aggregates in a single pass via `np.bincount`, emits
+  `summary.h5ad` directly. Schema matches what the existing
+  `expression summarize` emits, so downstream consumers cannot tell which
+  path produced a given summary.
+- Refactor: extract `_iter_ucsc_rows()` from `create_anndata_from_ucsc_matrix`
+  as the single row-streaming primitive shared by both paths. The in-memory
+  `create_anndata_from_ucsc_matrix` remains for small inputs and tests.
+- `build_ucsc_ad` gains a `backed: bool` kwarg (default: auto-select by
+  input size).
+- `mkmatrix ucsc` CLI gains `--backed/--no-backed` with default
+  `--backed=auto` (backed if input `.gz` > 1 GB, else in-memory).
+
+**Out of scope (deferred)**
+
+- `expression summarize` gaining a `--backed` mode for reading large
+  `atlas.h5ad` files on disk. Required eventually — otherwise running stage-2
+  alone on a 40 GB atlas OOMs the same way. Tracked for a follow-up PR; for
+  now, users of large atlases should prefer `summarize-ucsc` or use the fused
+  path.
+- Retrofit of `describe` / `markers` to handle backed atlases.
+- Retrofit of non-UCSC expression sources (Expression Atlas, CPTAC).
+
+## Architectural principle
+
+One low-level streamer, two accumulation strategies, three CLI entry points.
+
+```
+                      UCSC exprMatrix.tsv.gz + meta.tsv
+                                   │
+                                   ▼
+              ┌──────────────────────────────────────────┐
+              │ _iter_ucsc_rows()                        │  ← row streamer
+              │ yields (gene_name, float32[n_cells])     │    (already written
+              └───────────┬──────────────────────┬───────┘     for #93)
+                          │                      │
+          ┌───────────────┘                      └──────────────┐
+          ▼                                                     ▼
+ mkmatrix ucsc                              expression summarize-ucsc
+ ─────────────                              ────────────────────────
+ append CSC column                          np.bincount(group_idx, weights=row)
+ (one gene per step)                        into (groups × genes) accumulators
+          │                                                     │
+          ▼                                                     ▼
+     atlas.h5ad                                            summary.h5ad
+ (cells × genes sparse CSC)                         (groups × genes, layers)
+
+         atlas.h5ad ──► expression summarize (existing) ──► summary.h5ad
+```
+
+The CSC orientation is not incidental: it matches the parse order (one gene
+per append) so the backed builder never has to buffer rows or transpose.
+
+## Components
+
+### C1. `_iter_ucsc_rows` (extract as helper)
+
+**File:** `hvantk/tables/ucsc.py`
+**New function:**
+
+```python
+def _iter_ucsc_rows(
+    expression_matrix_path: str,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+) -> tuple[list[str], Iterator[tuple[str, np.ndarray]]]:
+    """Open a UCSC expression TSV (plain or gzipped) and return
+    ``(cell_ids, row_iterator)``. ``cell_ids`` is the header's cell-column
+    list (computed once, returned eagerly). ``row_iterator`` yields
+    ``(gene_name, row_values_float32)`` per data line; the underlying file
+    handle is closed when the iterator is exhausted.
+    """
+```
+
+Behavior already implemented in the current `create_anndata_from_ucsc_matrix`
+(gzip + `np.fromstring` + shape validation). This refactor just lifts the
+parse loop into its own generator so the backed builder and the fused
+aggregator share it byte-for-byte. Returning `cell_ids` separately (rather
+than on every yield) avoids passing the same 520k-element list through every
+row.
+
+The existing `create_anndata_from_ucsc_matrix` becomes a thin wrapper:
+iterate `_iter_ucsc_rows`, accumulate sparse chunks, vstack, transpose, wrap
+in AnnData. Contract unchanged.
+
+### C2. `build_ucsc_atlas_backed` (new backed builder)
+
+**File:** `hvantk/tables/ucsc.py`
+**Function:**
+
+```python
+def build_ucsc_atlas_backed(
+    expression_matrix_path: str,
+    output_path: str,
+    metadata_df: pd.DataFrame | None = None,
+    gene_column: str = UCSC_GENE_COLUMN,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+    column_batch: int = 64,
+    overwrite: bool = False,
+) -> str:
+    """Stream-build an AnnData .h5ad file on disk, appending one gene
+    (or batch of genes) at a time as CSC columns.
+
+    Never materializes the full cells × genes matrix in RAM. Peak RSS is
+    roughly ``column_batch × n_cells × 4 B`` for the current parse buffer
+    plus HDF5 I/O overhead.
+    """
+```
+
+Implementation outline:
+
+1. Open `output_path` as HDF5 with `h5py.File(..., "w")`.
+2. Write `obs`, `var` placeholders (shape from header + metadata).
+3. Create the `X` group with
+   `CSCDataset(..., dtype=np.float32, indptr_dtype=np.int64)` —
+   `indptr_dtype=np.int64` is required: at ~5% density on 520k × 122k we hit
+   ~3.2B nonzeros, exceeding the int32 default.
+4. Iterate `_iter_ucsc_rows`; every `column_batch` rows, convert the batch
+   into a `scipy.sparse.csc_matrix` of shape `(n_cells, column_batch)`,
+   append via `csc_dataset.append(batch)`.
+5. After stream end, write final `var` (gene names), `obs` (cells + metadata
+   join), and `uns["hvantk_metadata"]` provenance.
+
+Atlas shape on disk: `(n_cells, n_genes)`, `X` stored as CSC, standard
+AnnData axis convention. Scanpy and downstream scverse tools handle CSC
+transparently; operations that prefer CSR convert on-demand at read time.
+
+### C3. `summarize_ucsc_streaming` (new fused aggregator)
+
+**File:** `hvantk/tables/ucsc.py` (or a new `hvantk/tables/ucsc_aggregate.py`
+if the file gets too large)
+**Function:**
+
+```python
+def summarize_ucsc_streaming(
+    expression_matrix_path: str,
+    metadata_df: pd.DataFrame,
+    group_by: str | list[str],
+    filter_by: dict[str, str | list[str]] | None = None,
+    min_cells_per_group: int = 10,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+) -> ad.AnnData:
+    """Stream the UCSC expression matrix and aggregate per-group per-gene
+    statistics in one pass. Returns a small AnnData (groups × genes) with
+    layers ``mean``, ``sum``, ``count_nonzero``, ``fraction_expressed``.
+    """
+```
+
+Implementation outline:
+
+1. Apply `filter_by` to `metadata_df`. The existing helper
+   `filter_by_metadata_ad` operates on an `AnnData`; the fused path only has
+   a DataFrame at this point, so either generalize that helper to accept a
+   DataFrame or factor out a small `_filter_metadata_df(df, filter_by)` that
+   both callers use. Decide during implementation — contract is the same
+   either way (`FIELD=VALUE` equality; repeated keys form an OR; multiple
+   keys form an AND).
+2. Build composite group label per cell: `metadata_df[group_by].astype(str)
+   .agg("_".join, axis=1)` — matches `scanpy.get.aggregate`'s `obs_names`
+   convention.
+3. Factorize the labels → `group_idx: np.ndarray[int32]`, `n_groups`.
+4. Parse the expression header via `_iter_ucsc_rows`, reindex `group_idx` and
+   `metadata_df` to the expression-matrix cell order.
+5. Pre-allocate accumulators:
+   - `sum_matrix: float64[n_groups, n_genes]`
+   - `count_nz_matrix: int64[n_groups, n_genes]`
+   - `gene_names: list[str]` (grown lazily — not a tight loop)
+   - `n_cells_per_group: int64[n_groups]` (from `np.bincount(group_idx)`)
+6. For each `(gene_name, row)` from `_iter_ucsc_rows`, compute per-gene column
+   `j`:
+   ```python
+   sum_matrix[:, j] = np.bincount(group_idx, weights=row, minlength=n_groups)
+   count_nz_matrix[:, j] = np.bincount(
+       group_idx, weights=(row != 0).astype(np.float64), minlength=n_groups
+   )
+   ```
+7. After stream end:
+   ```python
+   mean            = sum_matrix / n_cells_per_group[:, None]
+   fraction_exprd  = count_nz_matrix / n_cells_per_group[:, None]
+   ```
+8. Drop groups with `n_cells_per_group < min_cells_per_group`.
+9. Build output AnnData:
+   - `obs_names = composite labels`
+   - `obs` holds one column per field in `group_by`, plus `n_cells`
+   - `var_names = gene_names`
+   - `X = mean` (float32)
+   - `layers = {sum, count_nonzero, fraction_expressed}`
+
+Memory footprint: `(n_groups + 2·n_groups) × n_genes × 8 B` accumulators +
+one `n_cells × 4 B` row buffer. At 20 groups × 122k genes × 520k cells:
+~60 MB accumulators + 2 MB per-row buffer. Independent of `n_cells`.
+
+### C4. `build_ucsc_ad` (wire through)
+
+**File:** `hvantk/tables/matrix_builders.py`
+
+Add a `backed: bool | None = None` kwarg. When `None`, auto-select: backed
+if input file size > `BACKED_BUILDER_THRESHOLD_BYTES` (constant, default
+1 GB); else in-memory. Dispatches to `build_ucsc_atlas_backed` or
+`create_anndata_from_ucsc_matrix` accordingly.
+
+### C5. `mkmatrix ucsc` CLI (existing)
+
+**File:** `hvantk/commands/make_matrix_cli.py`
+
+Add `--backed / --no-backed` toggle (default omitted = auto).
+
+### C6. `expression summarize-ucsc` CLI (new)
+
+**File:** `hvantk/commands/summarize_expression_cli.py`
+
+New subcommand under the existing `expression_group`. Flags:
+
+```
+-e, --expression-matrix PATH    # required
+-m, --metadata          PATH    # required
+--group-by              STR     # required, repeatable
+--filter-by             STR     # optional, repeatable, FIELD=VALUE
+--min-cells             INT     # default 10
+-o, --output            PATH    # required, must end .h5ad
+--overwrite                     # flag
+--gene-column           STR     # default "gene"
+--delimiter             STR     # default "\t"
+--split-gene-field      FLAG    # default True
+```
+
+Body:
+
+1. Validate output suffix; check `--overwrite` / existence.
+2. Load `metadata_df` via `load_ucsc_metadata`.
+3. Parse `--filter-by FIELD=VALUE` pairs; apply to `metadata_df`.
+4. Validate every `--group-by` column is in `metadata_df.columns`;
+   `click.BadParameter` with available columns if not.
+5. Call `summarize_ucsc_streaming(...)`.
+6. Write result via `adata.write_h5ad(output)`.
+7. Print the same report card as `expression summarize` for UX parity.
+
+## CLI reference (final)
+
+```
+# Backed build: user will reuse atlas.h5ad downstream
+hvantk mkmatrix ucsc \
+    -e exprMatrix.tsv.gz \
+    -m meta.tsv \
+    -o atlas.h5ad \
+    [--backed | --no-backed]       # default: auto (backed if .gz > 1 GB)
+    [--chunk-size 500]
+
+# Existing two-step aggregator (unchanged)
+hvantk expression summarize \
+    -m atlas.h5ad \
+    --group-by Class [--group-by Subclass ...] \
+    [--filter-by FIELD=VALUE ...] \
+    [--min-cells 10] \
+    -o summary.h5ad [--overwrite]
+
+# Fused one-pass aggregator (new)
+hvantk expression summarize-ucsc \
+    -e exprMatrix.tsv.gz \
+    -m meta.tsv \
+    --group-by Class [--group-by Subclass ...] \
+    [--filter-by FIELD=VALUE ...] \
+    [--min-cells 10] \
+    -o summary.h5ad [--overwrite]
+```
+
+Both `summarize` commands emit identical `.h5ad` schema. Downstream consumers
+(notebook K.1, etc.) do not branch on provenance.
+
+## Data flow — backed builder
+
+```
+exprMatrix.tsv.gz ── _iter_ucsc_rows ──► (gene_name, float32[n_cells])
+                                              │
+                                              ▼  batch of column_batch genes
+                          csc_matrix of shape (n_cells, column_batch)
+                                              │
+                                              ▼  .append(block)
+                               atlas.h5ad :: X  (CSCDataset, indptr=int64)
+                                              │
+                    meta.tsv ──► reindex to cell_ids ──► atlas.h5ad :: obs
+                                                         atlas.h5ad :: var
+                                                         atlas.h5ad :: uns
+```
+
+## Data flow — fused aggregator
+
+```
+meta.tsv ──► obs DataFrame ──► pick --group-by column(s), apply --filter-by
+                                              │
+                                              ▼
+                       group_idx: np.ndarray[int32], shape=(n_cells,)
+                       n_groups from np.unique(group_idx)
+
+                       pre-allocate:
+                         sum[n_groups, n_genes]        float64
+                         count_nz[n_groups, n_genes]   int64
+                         n_cells_per_group[n_groups]   int64
+
+exprMatrix.tsv.gz ── _iter_ucsc_rows ──► (gene_name, float32[n_cells])
+                                              │
+                                              ▼  per row (gene j):
+             sum[:, j]      = np.bincount(group_idx, weights=row, minlength=n_groups)
+             count_nz[:, j] = np.bincount(group_idx, weights=(row != 0), minlength=n_groups)
+                                              │
+                                              ▼  after last row:
+                        mean            = sum / n_cells_per_group[:, None]
+                        fraction_exprd  = count_nz / n_cells_per_group[:, None]
+                        drop groups with n_cells < --min-cells
+                                              │
+                                              ▼
+                        AnnData(X=mean, layers={sum, count_nonzero,
+                                                 fraction_expressed},
+                                obs includes n_cells + group_by columns)
+                                              │
+                                              ▼
+                                         summary.h5ad
+```
+
+## Error handling
+
+| Condition | Path | Behavior |
+|---|---|---|
+| Input `.tsv.gz` / `.tsv` missing | both | `FileNotFoundError` naming the path. |
+| Metadata `.tsv` missing | both | `FileNotFoundError` naming the path. |
+| Row has wrong column count or non-numeric token | both | `ValueError` naming the offending gene (inherited from #93 fix). |
+| `--group-by` column not in metadata columns | fused | `click.BadParameter` listing available obs columns. |
+| `--filter-by FIELD=VALUE` with FIELD missing | fused | `click.BadParameter` listing available obs columns. |
+| `--filter-by` produces zero cells | fused | `SystemExit(1)` with "no cells match filter". |
+| Every group falls below `--min-cells` | fused | `SystemExit(1)` with a table of observed group sizes. |
+| Output `.h5ad` exists, no `--overwrite` | both | Error + `SystemExit(1)`. |
+| Output suffix ≠ `.h5ad` | both | `click.BadParameter`. |
+| Metadata cell ids don't overlap expression header | both | **`ValueError`** — flip from the current warn-only behavior. A backed build or stream-aggregate that would produce a zero-obs output should fail at step 0. |
+| Cell with NaN in `--group-by` column | fused | Drop silently; log `count` plus one example cell id. No imputation (belongs upstream — it is a domain-modeling choice, not a reduce operation). |
+| Append would exceed CSC `indptr` int32 cap | builder | Non-issue: builder passes `indptr_dtype=np.int64` up front. If a future change drops that, `anndata` raises `OverflowError` with a clear message. |
+
+## Testing
+
+Per `MEMORY.md → feedback_no_more_tests.md`: **no new test files**.
+
+**Regression harness (unchanged tests that must keep passing):**
+
+| Test | Covers |
+|---|---|
+| `hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd` | `create_anndata_from_ucsc_matrix` contract. Guards the in-memory path and (via the extracted helper) the parse loop shared with backed/fused paths. |
+| `hvantk/tests/test_matrix_utils_anndata.py::TestSummarizeExpressionAd` | `summarize_expression_ad` contract. Pins the `.h5ad` schema that `summarize-ucsc` must match. |
+| `hvantk/tests/test_expression_builders_anndata.py::TestMkmatrixCli::test_ucsc_produces_h5ad` | CLI wiring for `mkmatrix ucsc`. |
+
+**In-place extension**: add a `backed` parameter to `TestBuildUcscAd` via
+`pytest.mark.parametrize`. Same assertions, now run in both
+`backed=False` and `backed=True` modes. No new test function, no new file.
+
+**Manual validation gate** (documented in the implementation plan; no
+auto-coverage; must pass before PR):
+
+| # | Check | Pass criterion |
+|---|---|---|
+| 1 | `mkmatrix ucsc --backed` on `adult-ctx-meta-atlas` | Finishes; peak RSS ≤ 3 GB; `adata.shape == (520014, 122697)`; `atlas.h5ad` reopens cleanly. |
+| 2 | `expression summarize-ucsc --group-by Class` on same input | Finishes in ≤ 45 min; `summary.h5ad.obs["n_cells"].sum()` equals the cell count of metadata after filter. |
+| 3 | Numerical agreement: fused `mean` layer vs. two-step `mean` layer on a toy fixture | `max_abs_diff < 1e-5`. |
+| 4 | CLI smoke: `summarize-ucsc --group-by NonExistent` | Exits 2 with a `click.BadParameter` message listing the available obs columns. |
+
+## Deferred (v2, not this PR)
+
+- `expression summarize` gains a `--backed` mode that streams `atlas.h5ad`
+  from disk. Required before anyone can aggregate from a 40 GB atlas without
+  OOM; for now, users hitting that should use `summarize-ucsc` directly.
+- `describe` / `markers` retrofits for backed atlases.
+- Apply the same streaming pattern to Expression Atlas and other
+  wide-TSV expression sources.
+- Promote additional aggregations (`var`, `std`, `log2_mean`) to first-class
+  output layers.
+
+## Open implementation details
+
+These are decided during implementation, not by this design:
+
+1. `column_batch` default for the backed builder — likely 32 or 64; tune
+   against real-run wall-clock and `atlas.h5ad` file size.
+2. Whether `_iter_ucsc_rows` should take a pre-opened file handle (so
+   callers can peek the header first without re-opening). Cosmetic.
+3. How to surface progress logging in both new paths so the user does not
+   have to pass `-v` (tracked as issue #92; likely a click-level `err=True`
+   heartbeat every N rows). Deferred to #92's own PR.
+
+## Verified against the ecosystem during design
+
+- `anndata.experimental` / `anndata.io`:
+  `CSRDataset` and `CSCDataset` both expose `.append(sparse_matrix)` for
+  incremental on-disk writes (source:
+  `anndata/src/anndata/_core/sparse_dataset.py::BaseCompressedSparseDataset.append`).
+  CSR append requires matching column count; CSC append requires matching
+  row count. Parse order in UCSC is gene-by-gene → CSC matches naturally.
+- `indptr_dtype=np.int64` option on `CSCDataset` prevents `OverflowError`
+  for `> 2^31` nonzeros (required at our scale).
+- `scanpy.get.aggregate` composite group labels are `"_"`-joined across the
+  `by=[...]` columns; the fused path replicates that convention so the
+  emitted `.h5ad` shares `obs_names` format with the existing two-step
+  output.
+
+## Deliverables (this PR)
+
+1. Extract `_iter_ucsc_rows` from `create_anndata_from_ucsc_matrix`.
+2. New `build_ucsc_atlas_backed` with CSC incremental writes.
+3. New `summarize_ucsc_streaming` with `np.bincount` aggregation.
+4. `build_ucsc_ad` gains `backed: bool | None` (auto-select default).
+5. `mkmatrix ucsc` gains `--backed / --no-backed`.
+6. New `expression summarize-ucsc` CLI subcommand.
+7. Parametrized extension of `TestBuildUcscAd` covering `backed=True`.
+8. Manual validation notes recorded against `adult-ctx-meta-atlas`.

--- a/hvantk/commands/make_matrix_cli.py
+++ b/hvantk/commands/make_matrix_cli.py
@@ -75,6 +75,22 @@ def mkmatrix_group():
     show_default=True,
     help="Gene rows per streaming chunk. Lower ⇒ less peak RAM, slower.",
 )
+@click.option(
+    "--backed/--no-backed",
+    default=None,
+    help=(
+        "Use the incremental backed-write builder (CSC columns appended to "
+        ".h5ad on disk; no RAM materialization). Default: auto — backed if "
+        "the input is larger than ~1 GiB."
+    ),
+)
+@click.option(
+    "--column-batch",
+    type=int,
+    default=64,
+    show_default=True,
+    help="Gene columns per backed-append block (backed mode only).",
+)
 @click.option("-w", "--overwrite", is_flag=True)
 def mkmatrix_ucsc(
     expression_matrix,
@@ -84,6 +100,8 @@ def mkmatrix_ucsc(
     delimiter,
     split_gene_field,
     chunk_size,
+    backed,
+    column_batch,
     overwrite,
 ):
     """Build an AnnData object from UCSC Cell Browser expression + metadata files."""
@@ -96,6 +114,8 @@ def mkmatrix_ucsc(
         delimiter=delimiter,
         split_gene_field=split_gene_field,
         chunk_size=chunk_size,
+        backed=backed,
+        column_batch=column_batch,
         overwrite=overwrite,
     )
     click.echo(f"AnnData created at {output_path}")

--- a/hvantk/commands/make_matrix_cli.py
+++ b/hvantk/commands/make_matrix_cli.py
@@ -68,6 +68,13 @@ def mkmatrix_group():
 @click.option(
     "--split-gene-field/--no-split-gene-field", default=True, show_default=True
 )
+@click.option(
+    "--chunk-size",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Gene rows per streaming chunk. Lower ⇒ less peak RAM, slower.",
+)
 @click.option("-w", "--overwrite", is_flag=True)
 def mkmatrix_ucsc(
     expression_matrix,
@@ -76,6 +83,7 @@ def mkmatrix_ucsc(
     gene_column,
     delimiter,
     split_gene_field,
+    chunk_size,
     overwrite,
 ):
     """Build an AnnData object from UCSC Cell Browser expression + metadata files."""
@@ -87,6 +95,7 @@ def mkmatrix_ucsc(
         gene_column=gene_column,
         delimiter=delimiter,
         split_gene_field=split_gene_field,
+        chunk_size=chunk_size,
         overwrite=overwrite,
     )
     click.echo(f"AnnData created at {output_path}")

--- a/hvantk/commands/summarize_expression_cli.py
+++ b/hvantk/commands/summarize_expression_cli.py
@@ -378,3 +378,177 @@ def markers_cmd(
         collection.save(str(output_path))
 
     click.echo(f"\nSaved to: {output_path}")
+
+
+@expression_group.command("summarize-ucsc")
+@click.option(
+    "-e",
+    "--expression-matrix",
+    "expression_matrix",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the UCSC expression TSV (plain or gzipped).",
+)
+@click.option(
+    "-m",
+    "--metadata",
+    "metadata_path",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the UCSC cell metadata TSV.",
+)
+@click.option(
+    "--group-by",
+    multiple=True,
+    required=True,
+    help="Metadata column(s) to group by. Repeat for multi-field grouping.",
+)
+@click.option(
+    "--filter-by",
+    multiple=True,
+    default=None,
+    help=(
+        "Pre-filter cells: FIELD=VALUE (repeatable). "
+        "Example: --filter-by Region=Cortex --filter-by TimePoint=9wpc"
+    ),
+)
+@click.option(
+    "--min-cells",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Drop groups with fewer cells than this threshold.",
+)
+@click.option(
+    "--gene-column",
+    default="gene",
+    show_default=True,
+)
+@click.option(
+    "--delimiter",
+    default="\t",
+    show_default=True,
+)
+@click.option(
+    "--split-gene-field/--no-split-gene-field",
+    default=True,
+    show_default=True,
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    required=True,
+    help="Output path for the aggregated AnnData (.h5ad).",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing output.",
+)
+def summarize_ucsc_cmd(
+    expression_matrix,
+    metadata_path,
+    group_by,
+    filter_by,
+    min_cells,
+    gene_column,
+    delimiter,
+    split_gene_field,
+    output,
+    overwrite,
+):
+    """Fused stream-and-aggregate: UCSC expression + metadata → groups × genes .h5ad.
+
+    Skips the intermediate cells × genes atlas.h5ad — streams the expression
+    matrix row-by-row and accumulates per-group per-gene statistics in a
+    single pass. Output schema matches `hvantk expression summarize`, so
+    downstream consumers do not branch on which path produced the summary.
+
+    \b
+    Examples:
+
+      # Single-field grouping
+      hvantk expression summarize-ucsc \\
+          -e exprMatrix.tsv.gz -m meta.tsv \\
+          --group-by Class \\
+          -o class_summary.h5ad
+
+      # Multi-field grouping + pre-filter
+      hvantk expression summarize-ucsc \\
+          -e exprMatrix.tsv.gz -m meta.tsv \\
+          --group-by Region --group-by TimePoint \\
+          --filter-by Region=Cortex \\
+          --min-cells 10 \\
+          -o region_timepoint_summary.h5ad
+    """
+    from pathlib import Path
+
+    from hvantk.tables.ucsc import load_ucsc_metadata, summarize_ucsc_streaming
+
+    output_path = Path(output)
+    if output_path.suffix != ".h5ad":
+        raise click.BadParameter(
+            f"Output must end in '.h5ad' (got {output_path.suffix!r}).",
+            param_hint="--output",
+        )
+
+    if output_path.exists() and not overwrite:
+        click.echo(
+            f"Error: Output file already exists: {output_path}\n"
+            "Use --overwrite to replace it.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    filters = None
+    if filter_by:
+        filters = {}
+        for item in filter_by:
+            if "=" not in item:
+                raise click.BadParameter(
+                    f"Expected FIELD=VALUE format, got: {item!r}",
+                    param_hint="--filter-by",
+                )
+            key, value = item.split("=", 1)
+            filters[key.strip()] = value.strip()
+
+    metadata_df = load_ucsc_metadata(metadata_path, sep=delimiter)
+
+    missing = [col for col in group_by if col not in metadata_df.columns]
+    if missing:
+        raise click.BadParameter(
+            f"--group-by column(s) not in metadata: {missing}. "
+            f"Available: {sorted(metadata_df.columns)}",
+            param_hint="--group-by",
+        )
+
+    summary = summarize_ucsc_streaming(
+        expression_matrix_path=expression_matrix,
+        metadata_df=metadata_df,
+        group_by=list(group_by),
+        filter_by=filters,
+        min_cells_per_group=min_cells,
+        gene_column=gene_column,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_h5ad(str(output_path))
+
+    n_cells = summary.obs["n_cells"].astype(int)
+    click.echo(f"\nSummary AnnData written to: {output_path}")
+    click.echo(f"  Shape:  {summary.n_obs} groups × {summary.n_vars} genes")
+    click.echo(f"  Layers: {sorted(summary.layers.keys())}")
+    click.echo(
+        f"  Cells per group: min={int(n_cells.min())}, "
+        f"max={int(n_cells.max())}, total={int(n_cells.sum())}"
+    )
+    click.echo("")
+    click.echo(f"Group labels ({summary.n_obs}):")
+    for label, n in list(zip(summary.obs_names, n_cells))[:10]:
+        click.echo(f"  {label:<40s}  {int(n):>8,} cells")
+    if summary.n_obs > 10:
+        click.echo(f"  ... and {summary.n_obs - 10} more")

--- a/hvantk/commands/summarize_expression_cli.py
+++ b/hvantk/commands/summarize_expression_cli.py
@@ -4,8 +4,9 @@ CLI commands for expression AnnData analysis.
 Grouped under ``hvantk expression``:
 
 - ``hvantk expression describe``: inspect metadata fields in an expression .h5ad
-- ``hvantk expression summarize``: collapse an expression .h5ad into a gene-level
-  summary DataFrame saved as Parquet
+- ``hvantk expression summarize``: aggregate an expression .h5ad into a
+  per-group × per-gene AnnData (saved as .h5ad) with mean / sum /
+  count_nonzero / fraction_expressed in layers
 - ``hvantk expression markers``: extract marker genes using scanpy rank_genes_groups
 """
 

--- a/hvantk/commands/summarize_expression_cli.py
+++ b/hvantk/commands/summarize_expression_cli.py
@@ -92,16 +92,16 @@ def describe_expression_cmd(matrix_path):
 @click.option(
     "--min-cells",
     type=int,
-    default=50,
+    default=10,
     show_default=True,
-    help="Minimum cells per group.",
+    help="Drop groups with fewer cells than this threshold.",
 )
 @click.option(
     "-o",
     "--output",
     type=click.Path(),
     required=True,
-    help="Output path for the summary (.parquet).",
+    help="Output path for the aggregated AnnData (.h5ad).",
 )
 @click.option(
     "--overwrite",
@@ -117,7 +117,11 @@ def summarize_expression_cmd(
     output,
     overwrite,
 ):
-    """Collapse an expression AnnData into a gene-level summary DataFrame.
+    """Aggregate an expression AnnData into a per-group × per-gene AnnData.
+
+    The output .h5ad has shape (n_groups, n_genes) with layers:
+    ``mean``, ``sum``, ``count_nonzero``, ``fraction_expressed``. Per-group
+    cell counts are in ``obs['n_cells']``.
 
     \b
     Examples:
@@ -126,28 +130,42 @@ def summarize_expression_cmd(
       hvantk expression summarize \\
           -m data/heart_sc.h5ad \\
           --group-by cell_type \\
-          -o data/heart_celltype_summary.parquet
+          -o data/heart_celltype_summary.h5ad
 
       # Multi-field grouping
       hvantk expression summarize \\
           -m data/heart_sc.h5ad \\
           --group-by cell_type --group-by region \\
-          -o data/heart_celltype_region_summary.parquet
+          -o data/heart_celltype_region_summary.h5ad
 
       # With pre-filtering
       hvantk expression summarize \\
           -m data/heart_sc.h5ad \\
           --group-by cell_type \\
           --filter-by time_point=9wpc --filter-by region=LV \\
-          --min-cells 50 \\
-          -o data/heart_9wpc_LV_summary.parquet
+          --min-cells 10 \\
+          -o data/heart_9wpc_LV_summary.h5ad
     """
     from pathlib import Path
 
     from hvantk.core.anndata_utils import load_anndata
     from hvantk.utils.matrix_utils import summarize_expression_ad
 
-    # Parse filter_by from "field=value" strings
+    output_path = Path(output)
+    if output_path.suffix != ".h5ad":
+        raise click.BadParameter(
+            f"Output must end in '.h5ad' (got {output_path.suffix!r}).",
+            param_hint="--output",
+        )
+
+    if output_path.exists() and not overwrite:
+        click.echo(
+            f"Error: Output file already exists: {output_path}\n"
+            "Use --overwrite to replace it.",
+            err=True,
+        )
+        raise SystemExit(1)
+
     filters = None
     if filter_by:
         filters = {}
@@ -160,43 +178,48 @@ def summarize_expression_cmd(
             key, value = item.split("=", 1)
             filters[key.strip()] = value.strip()
 
-    output_path = Path(output)
-    if output_path.exists() and not overwrite:
-        click.echo(
-            f"Error: Output file already exists: {output_path}\n"
-            "Use --overwrite to replace it.",
-            err=True,
-        )
-        raise SystemExit(1)
-
     adata = load_anndata(matrix_path)
 
-    summary_df = summarize_expression_ad(
+    missing = [col for col in group_by if col not in adata.obs.columns]
+    if missing:
+        available = sorted(adata.obs.columns)
+        raise click.BadParameter(
+            f"--group-by column(s) not in obs: {missing}. Available: {available}",
+            param_hint="--group-by",
+        )
+
+    summary = summarize_expression_ad(
         adata,
         group_by=list(group_by),
         filter_by=filters,
         min_cells_per_group=min_cells,
     )
 
+    if summary.n_obs == 0:
+        click.echo(
+            "Error: no groups passed --min-cells threshold. "
+            "Lower --min-cells or check --filter-by / --group-by.",
+            err=True,
+        )
+        raise SystemExit(1)
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    summary_df.to_parquet(str(output_path))
+    summary.write_h5ad(str(output_path))
 
-    n_genes = summary_df["gene_id"].nunique() if len(summary_df) > 0 else 0
-    group_labels = sorted(summary_df["group"].unique().tolist()) if len(summary_df) > 0 else []
-
-    click.echo(f"\nSummary table written to: {output}")
-    click.echo(f"  Genes:  {n_genes:,}")
-    click.echo(f"  Groups: {len(group_labels)} (from {list(group_by)})")
+    n_cells = summary.obs["n_cells"].astype(int)
+    click.echo(f"\nSummary AnnData written to: {output_path}")
+    click.echo(f"  Shape:  {summary.n_obs} groups × {summary.n_vars} genes")
+    click.echo(f"  Layers: {sorted(summary.layers.keys())}")
+    click.echo(
+        f"  Cells per group: min={int(n_cells.min())}, "
+        f"max={int(n_cells.max())}, total={int(n_cells.sum())}"
+    )
     click.echo("")
-    if group_labels:
-        click.echo(f"Group labels ({len(group_labels)}):")
-        for label in group_labels[:10]:
-            # Show cell count for this group
-            grp_rows = summary_df[summary_df["group"] == label]
-            n_cells = int(grp_rows["n_cells"].iloc[0]) if len(grp_rows) > 0 else 0
-            click.echo(f"  {label:<40s}  {n_cells:>6,} cells")
-        if len(group_labels) > 10:
-            click.echo(f"  ... and {len(group_labels) - 10} more")
+    click.echo(f"Group labels ({summary.n_obs}):")
+    for label, n in list(zip(summary.obs_names, n_cells))[:10]:
+        click.echo(f"  {label:<40s}  {int(n):>8,} cells")
+    if summary.n_obs > 10:
+        click.echo(f"  ... and {summary.n_obs - 10} more")
 
 
 @expression_group.command("markers")

--- a/hvantk/ptm/constants.py
+++ b/hvantk/ptm/constants.py
@@ -76,47 +76,47 @@ PTM_OUTPUT_COLUMNS = [
     "source_db",
     "evidence_type",
     "n_observations",
+    "tissue_type",
 ]
 
 # Transcript resolution method names (for logging/QC)
 RESOLUTION_METHODS = ["xref_mane", "xref_any", "gene_mane"]
 
 # ---------------------------------------------------------------------------
-# Phase-2 defaults (notebook A / M / K / N)
+# Variant-annotation and LMM defaults
+# (consumed by hvantk.ptm.annotate and hvantk.ptm.test).
 # ---------------------------------------------------------------------------
 
-# Proximal flanking window for SYMBOL-based variant annotation:
-# ±7 aa in codon space ≈ ±21 bp in genomic coordinates (notebook N Cell 11).
-# One-sided; applied to both codon_start and codon_end (see ptm.annotate).
+# Proximal flanking window for gene-symbol variant annotation:
+# 7 codons * 3 bp = 21 bp, applied one-sided to codon_start and codon_end.
 PROXIMAL_BP = 21
 
-# Default MAF thresholds referenced by Phase-2 documentation.
-# Notebooks M and K do NOT apply MAF cut-offs (they work from ClinVar B/LB
-# variants only). Notebook N uses MAF <= 0.001 on an internal CHD cohort.
-# These values are kept as Phase-2 defaults/placeholders for any
-# caller that wants a consistent set of bins (common/rare/ultra-rare);
-# callers that need the exact notebook-N rare filter should pass
-# ``rare=1e-3`` explicitly.
+# Default MAF bins (common / rare / ultra-rare) for callers that want a
+# consistent set of cut-offs. Callers with source-specific thresholds
+# should pass them explicitly.
 DEFAULT_MAF_THRESHOLDS = {
     "common": 0.01,
     "rare": 0.001,
     "ultra_rare": 1e-5,
 }
 
-# Ordered category for the binned-interaction LMM (notebook K).
+# Ordered categories for the binned-interaction LMM.
 # "b0_none" is the reference (zero-expression) bin; Q1-Q4 are quartiles of
-# log2(expr + 1) across positive-expression variants. Actual bin count in
-# a fit may be smaller when pd.qcut collapses ties (duplicates="drop").
+# log2(expr + 1) across positive-expression variants. Realised bin count
+# may be smaller when pd.qcut collapses ties (duplicates="drop").
 EXPRESSION_BIN_LABELS = ["b0_none", "b1_Q1", "b2_Q2", "b3_Q3", "b4_Q4"]
 
-# Pseudocount for log10(AF + eps) transformation used by notebooks K and M.
+# Pseudocount for the log10(AF + eps) transformation used in LMM fits.
 LOG_AF_EPSILON = 1e-8
 
-# Per-stratum filter thresholds for the constraint LMM (notebook M Cell 5).
+# Minimum per-stratum sample counts for the constraint LMM
+# (hvantk.ptm.test.fit_constraint_lmm). Below these the per-gene estimate
+# is unstable.
 LMM_MIN_N_PTM = 30
 LMM_MIN_N_NONPTM = 30
 LMM_MIN_MIXED_GENES = 10
 
-# Sparsity gates for the binned-interaction LMM (notebook K Cell 4d).
+# Sparsity gates for the binned-interaction LMM
+# (hvantk.ptm.test.fit_binned_interaction_lmm).
 LMM_BINNED_MIN_POS_EXPR = 100
 LMM_BINNED_MIN_CELL_N = 5

--- a/hvantk/ptm/pipeline.py
+++ b/hvantk/ptm/pipeline.py
@@ -2,7 +2,7 @@
 PTM Build Pipeline — orchestrates PTM data acquisition, coordinate mapping, and table building.
 
 This module exposes the build workflow as a Python API so it can be used
-programmatically (notebooks, alphagenome) or from the CLI.
+programmatically or from the CLI.
 
 Example:
     >>> from hvantk.ptm.pipeline import PTMBuildConfig, ptm_build_pipeline
@@ -154,7 +154,7 @@ def download_ensembl_gtf(output_dir: str, overwrite: bool = False) -> str:
 
 
 def download_uniprot_ptm(output_dir: str, overwrite: bool = False) -> str:
-    """Download UniProt PTM data via the REST API.
+    """Download the latest UniProt PTM TSV via :class:`UniProtPTMDataset`.
 
     Parameters
     ----------
@@ -277,6 +277,7 @@ def map_ptm_sites(
                         "source_db": rec.get("source_db", "UniProt"),
                         "evidence_type": rec.get("evidence_type", "curated"),
                         "n_observations": rec.get("n_observations", "0"),
+                        "tissue_type": rec.get("tissue_type", ""),
                     }
                 )
                 n_mapped += 1
@@ -385,65 +386,45 @@ def ptm_build_pipeline(config: PTMBuildConfig) -> PTMBuildResult:
     mapped_path = os.path.join(config.output_dir, "ptm_sites_mapped.tsv.bgz")
     result = map_ptm_sites(ptm_tsv, gtf_data, mapped_path, transcript_cache)
 
-    # Step 4b: Map PeptideAtlas sites (if provided)
+    # Step 4b: Map additional PTM sources (PeptideAtlas, CPTAC) and
+    # merge everything into a single canonical combined TSV.
+    extra_sources: List[tuple] = []
     if config.peptideatlas_tsv:
-        logger.info("Mapping PeptideAtlas phospho sites...")
-        pa_mapped_path = os.path.join(
-            config.output_dir, "peptideatlas_sites_mapped.tsv.bgz"
+        extra_sources.append(
+            ("PeptideAtlas", config.peptideatlas_tsv, "peptideatlas_sites_mapped.tsv.bgz")
         )
-        pa_result = map_ptm_sites(
-            config.peptideatlas_tsv, gtf_data, pa_mapped_path, transcript_cache
+    if config.cptac_tsv:
+        extra_sources.append(
+            ("CPTAC", config.cptac_tsv, "cptac_sites_mapped.tsv.bgz")
         )
 
+    source_paths = [mapped_path]
+    for source_name, source_tsv, source_filename in extra_sources:
+        logger.info("Mapping %s phospho sites...", source_name)
+        source_mapped_path = os.path.join(config.output_dir, source_filename)
+        source_result = map_ptm_sites(
+            source_tsv, gtf_data, source_mapped_path, transcript_cache
+        )
+        source_paths.append(source_mapped_path)
+        result.n_total += source_result.n_total
+        result.n_mapped += source_result.n_mapped
+        result.n_failed += source_result.n_failed
+        for method, count in source_result.resolution_counts.items():
+            result.resolution_counts[method] = (
+                result.resolution_counts.get(method, 0) + count
+            )
+
+    if len(source_paths) > 1:
         combined_path = os.path.join(
             config.output_dir, "ptm_sites_combined.tsv.bgz"
         )
-        _concat_bgz_tsvs([mapped_path, pa_mapped_path], combined_path)
-
+        _concat_bgz_tsvs(source_paths, combined_path)
         mapped_path = combined_path
         result.mapped_tsv_path = combined_path
-        result.n_total += pa_result.n_total
-        result.n_mapped += pa_result.n_mapped
-        result.n_failed += pa_result.n_failed
-        for method, count in pa_result.resolution_counts.items():
-            result.resolution_counts[method] = (
-                result.resolution_counts.get(method, 0) + count
-            )
-
         logger.info(
-            "Combined: %d total mapped sites (UniProt + PeptideAtlas)",
+            "Combined: %d total mapped sites across %d sources",
             result.n_mapped,
-        )
-
-    # Step 4c: Map CPTAC sites (if provided)
-    if config.cptac_tsv:
-        logger.info("Mapping CPTAC phospho sites...")
-        cptac_mapped_path = os.path.join(
-            config.output_dir, "cptac_sites_mapped.tsv.bgz"
-        )
-        cptac_result = map_ptm_sites(
-            config.cptac_tsv, gtf_data, cptac_mapped_path, transcript_cache
-        )
-
-        # Use a distinct filename to avoid truncating mapped_path when it
-        # points to ptm_sites_combined.tsv.bgz from step 4b.
-        all_combined_path = os.path.join(
-            config.output_dir, "ptm_sites_all_combined.tsv.bgz"
-        )
-        _concat_bgz_tsvs([mapped_path, cptac_mapped_path], all_combined_path)
-
-        mapped_path = all_combined_path
-        result.n_total += cptac_result.n_total
-        result.n_mapped += cptac_result.n_mapped
-        result.n_failed += cptac_result.n_failed
-        for method, count in cptac_result.resolution_counts.items():
-            result.resolution_counts[method] = (
-                result.resolution_counts.get(method, 0) + count
-            )
-
-        logger.info(
-            f"Combined: {result.n_mapped} total mapped sites "
-            f"(including CPTAC)"
+            len(source_paths),
         )
 
     # Step 5: Build Hail Table

--- a/hvantk/tables/matrix_builders.py
+++ b/hvantk/tables/matrix_builders.py
@@ -76,6 +76,7 @@ def build_ucsc_ad(
         load_ucsc_metadata,
         create_anndata_from_ucsc_matrix,
         build_ucsc_atlas_backed,
+        coerce_obs_for_h5ad,
     )
     from hvantk.core.anndata_utils import (
         build_anndata_metadata,
@@ -133,6 +134,10 @@ def build_ucsc_ad(
         "UCSC", expression_matrix_path
     )
     annotate_column_summary_ad(adata)
+    # Coerce object-dtype obs columns before any write_h5ad — anndata's
+    # vlen-string HDF5 writer chokes on NaN mixed with strings. Matches
+    # the invariant enforced by build_ucsc_atlas_backed.
+    adata.obs = coerce_obs_for_h5ad(adata.obs)
     if output_path:
         save_anndata(adata, output_path, overwrite=overwrite)
     return adata

--- a/hvantk/tables/matrix_builders.py
+++ b/hvantk/tables/matrix_builders.py
@@ -29,6 +29,7 @@ def build_ucsc_ad(
     delimiter: str = "\t",
     split_gene_field: bool = True,
     overwrite: bool = False,
+    chunk_size: int = 500,
 ) -> "ad.AnnData":
     """Build an AnnData object from UCSC Cell Browser expression + metadata.
 
@@ -48,6 +49,8 @@ def build_ucsc_ad(
         Split pipe-separated gene names, keeping the first element.
     overwrite : bool
         Allow overwriting *output_path* if it exists.
+    chunk_size : int
+        Gene rows per streaming chunk (default 500).
 
     Returns
     -------
@@ -71,6 +74,7 @@ def build_ucsc_ad(
         gene_column=gene_column,
         delimiter=delimiter,
         split_gene_field=split_gene_field,
+        chunk_size=chunk_size,
     )
 
     adata.uns["hvantk_metadata"] = build_anndata_metadata(

--- a/hvantk/tables/matrix_builders.py
+++ b/hvantk/tables/matrix_builders.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 import anndata as ad
 import logging
+import os
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# Auto-select the backed builder for UCSC inputs larger than this threshold.
+BACKED_BUILDER_THRESHOLD_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
 
 __all__ = [
     "build_ucsc_ad",
@@ -30,6 +34,8 @@ def build_ucsc_ad(
     split_gene_field: bool = True,
     overwrite: bool = False,
     chunk_size: int = 500,
+    backed: bool | None = None,
+    column_batch: int = 64,
 ) -> "ad.AnnData":
     """Build an AnnData object from UCSC Cell Browser expression + metadata.
 
@@ -51,13 +57,26 @@ def build_ucsc_ad(
         Allow overwriting *output_path* if it exists.
     chunk_size : int
         Gene rows per streaming chunk (default 500).
+    backed : bool, optional
+        Force the backed-write builder. When ``None`` (default), auto-select
+        based on the expression matrix file size (``> BACKED_BUILDER_THRESHOLD_BYTES``
+        triggers backed mode). When ``True``, ``output_path`` is required.
+    column_batch : int
+        Cell-column batch size used by the backed builder (default 64).
 
     Returns
     -------
     ad.AnnData
         Expression AnnData with metadata in ``obs`` and provenance in ``uns``.
+        In backed mode, returns a read-backed AnnData handle (``backed='r'``).
     """
-    from hvantk.tables.ucsc import load_ucsc_metadata, create_anndata_from_ucsc_matrix
+    import anndata as ad
+
+    from hvantk.tables.ucsc import (
+        load_ucsc_metadata,
+        create_anndata_from_ucsc_matrix,
+        build_ucsc_atlas_backed,
+    )
     from hvantk.core.anndata_utils import (
         build_anndata_metadata,
         annotate_column_summary_ad,
@@ -67,7 +86,41 @@ def build_ucsc_ad(
     logger.info("Loading UCSC metadata from %s", metadata_path)
     metadata_df = load_ucsc_metadata(metadata_path, sep=delimiter)
 
-    logger.info("Creating AnnData from UCSC expression matrix")
+    # Auto-select backed mode by input size unless caller forces.
+    if backed is None:
+        size = os.path.getsize(expression_matrix_path)
+        backed = size > BACKED_BUILDER_THRESHOLD_BYTES
+        logger.info(
+            "build_ucsc_ad: auto-selected backed=%s (input size %.2f GiB, threshold %.2f GiB)",
+            backed, size / (1024**3), BACKED_BUILDER_THRESHOLD_BYTES / (1024**3),
+        )
+
+    if backed:
+        if output_path is None:
+            raise ValueError("backed=True requires output_path (writes directly to disk).")
+        provenance = {"hvantk_metadata": build_anndata_metadata("UCSC", expression_matrix_path)}
+        build_ucsc_atlas_backed(
+            expression_matrix_path=expression_matrix_path,
+            output_path=output_path,
+            metadata_df=metadata_df,
+            gene_column=gene_column,
+            delimiter=delimiter,
+            split_gene_field=split_gene_field,
+            column_batch=column_batch,
+            overwrite=overwrite,
+            uns=provenance,
+        )
+        # Return a backed-mode handle — shape + obs/var without materializing X.
+        # annotate_column_summary_ad would need to scan the full X matrix and
+        # is intentionally skipped for backed atlases (v1 trade-off).
+        logger.info(
+            "Backed atlas built at %s; skipping annotate_column_summary_ad "
+            "(would materialize X). Returning a backed AnnData handle.",
+            output_path,
+        )
+        return ad.read_h5ad(output_path, backed="r")
+
+    logger.info("Creating AnnData from UCSC expression matrix (in-memory)")
     adata = create_anndata_from_ucsc_matrix(
         expression_matrix_path=expression_matrix_path,
         metadata_df=metadata_df,
@@ -76,15 +129,12 @@ def build_ucsc_ad(
         split_gene_field=split_gene_field,
         chunk_size=chunk_size,
     )
-
     adata.uns["hvantk_metadata"] = build_anndata_metadata(
         "UCSC", expression_matrix_path
     )
     annotate_column_summary_ad(adata)
-
     if output_path:
         save_anndata(adata, output_path, overwrite=overwrite)
-
     return adata
 
 

--- a/hvantk/tables/table_builders.py
+++ b/hvantk/tables/table_builders.py
@@ -1366,10 +1366,15 @@ def create_ptm_sites_tb(
     """
     Create a Hail Table of PTM sites in genomic coordinates.
 
-    Input is a TSV produced by the PTM coordinate mapper (Phase 1 output)
-    with columns: chrom, codon_start, codon_end, strand, uniprot_id,
-    gene_symbol, residue_pos, amino_acid, ptm_type, ptm_category,
-    source_db, evidence_type, n_observations.
+    Input is a TSV produced by the PTM coordinate mapper
+    (see ``hvantk.ptm.pipeline.map_ptm_sites``) with columns: chrom,
+    codon_start, codon_end, strand, uniprot_id, gene_symbol, residue_pos,
+    amino_acid, ptm_type, ptm_category, source_db, evidence_type,
+    n_observations, tissue_type.
+
+    ``tissue_type`` carries sample provenance for sources that distinguish
+    it (e.g. CPTAC ``"normal"``/``"tumor"``); curated or bulk-MS sources
+    emit an empty string.
 
     The table is keyed by locus (codon start position), with a
     ``flanking_interval`` field for proximity-based annotation joins.

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -25,6 +25,7 @@ __all__ = [
     "load_ucsc_metadata",
     "create_anndata_from_ucsc_matrix",
     "build_ucsc_atlas_backed",
+    "summarize_ucsc_streaming",
 ]
 
 logger = logging.getLogger(__name__)
@@ -407,3 +408,185 @@ def build_ucsc_atlas_backed(
         n_cells, n_appended, output_path,
     )
     return output_path
+
+
+def summarize_ucsc_streaming(
+    expression_matrix_path: str,
+    metadata_df: pd.DataFrame,
+    group_by: str | list[str],
+    filter_by: dict[str, str | list[str]] | None = None,
+    min_cells_per_group: int = 10,
+    gene_column: str = UCSC_GENE_COLUMN,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+) -> ad.AnnData:
+    """Stream a UCSC expression matrix and aggregate per-group per-gene
+    statistics in one pass.
+
+    Returns an AnnData of shape ``(n_groups, n_genes)`` with ``X`` set to
+    the per-group mean (float32) and ``layers`` containing ``sum``,
+    ``count_nonzero``, ``fraction_expressed``. ``obs`` includes the
+    original group-by columns plus ``n_cells``.
+
+    Memory: one ``float32[n_cells]`` row buffer + accumulators of size
+    ``n_groups × n_genes × 16 B`` (sum float64 + count_nz int64). Independent
+    of ``n_cells`` past the single-row buffer.
+    """
+    by = [group_by] if isinstance(group_by, str) else list(group_by)
+
+    # Apply filter on the DataFrame before factorizing groups.
+    work = metadata_df.copy()
+    if filter_by:
+        for field, value in filter_by.items():
+            if field not in work.columns:
+                raise ValueError(
+                    f"filter_by field {field!r} not in metadata columns: "
+                    f"{sorted(work.columns)}"
+                )
+            if isinstance(value, (list, tuple, set)):
+                work = work[work[field].isin(list(value))]
+            else:
+                work = work[work[field] == value]
+        if work.empty:
+            raise ValueError("filter_by produced zero cells.")
+
+    for col in by:
+        if col not in work.columns:
+            raise ValueError(
+                f"group_by column {col!r} not in metadata columns: "
+                f"{sorted(work.columns)}"
+            )
+
+    cell_ids, row_iter = _iter_ucsc_rows(
+        expression_matrix_path,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+    n_cells = len(cell_ids)
+
+    # Align metadata to expression header order, keep only cells present
+    # in both, and drop NaN-in-group rows.
+    aligned = work.reindex(cell_ids)
+    keep_mask = aligned[by].notna().all(axis=1).to_numpy()
+    if not keep_mask.any():
+        raise ValueError(
+            "No cells overlap between metadata (post-filter) and expression header."
+        )
+    # Count cells present in post-filter metadata that were dropped due to
+    # NaN in any group-by column (excludes cells absent from metadata entirely).
+    n_dropped_nan = int((~keep_mask & aligned.index.isin(work.index)).sum())
+    if n_dropped_nan:
+        example = cell_ids[int(np.where(~keep_mask)[0][0])]
+        logger.info(
+            "Dropped %d cells with NaN in group-by columns (example: %s).",
+            n_dropped_nan, example,
+        )
+
+    labels = (
+        aligned.loc[keep_mask, by].astype(str).agg("_".join, axis=1)
+        if len(by) > 1
+        else aligned.loc[keep_mask, by[0]].astype(str)
+    )
+    codes, uniques = pd.factorize(labels, sort=True)
+    n_groups = len(uniques)
+
+    # group_idx per cell in expression-header order, -1 for dropped cells.
+    group_idx = np.full(n_cells, -1, dtype=np.int64)
+    group_idx[keep_mask] = codes
+    valid = group_idx >= 0
+    n_cells_per_group = np.bincount(group_idx[valid], minlength=n_groups).astype(np.int64)
+
+    sum_matrix = np.zeros((n_groups, 0), dtype=np.float64)
+    count_nz_matrix = np.zeros((n_groups, 0), dtype=np.int64)
+    gene_names: list[str] = []
+
+    # Pre-size buffers in chunks to avoid per-gene resize; column-extend
+    # accumulators lazily.
+    BLOCK = 1024
+    sum_block = np.zeros((n_groups, BLOCK), dtype=np.float64)
+    count_block = np.zeros((n_groups, BLOCK), dtype=np.int64)
+    block_fill = 0
+
+    def _flush_block():
+        nonlocal sum_matrix, count_nz_matrix, block_fill
+        if block_fill == 0:
+            return
+        sum_matrix = np.concatenate([sum_matrix, sum_block[:, :block_fill]], axis=1)
+        count_nz_matrix = np.concatenate(
+            [count_nz_matrix, count_block[:, :block_fill]], axis=1
+        )
+        block_fill = 0
+
+    for gene, row in row_iter:
+        row_valid = row[valid]
+        sum_block[:, block_fill] = np.bincount(
+            group_idx[valid], weights=row_valid, minlength=n_groups
+        )
+        count_block[:, block_fill] = np.bincount(
+            group_idx[valid],
+            weights=(row_valid != 0).astype(np.float64),
+            minlength=n_groups,
+        ).astype(np.int64)
+        gene_names.append(gene)
+        block_fill += 1
+        if block_fill == BLOCK:
+            _flush_block()
+    _flush_block()
+
+    if len(gene_names) == 0:
+        raise ValueError(
+            f"Expression matrix {expression_matrix_path!r} contained no data rows."
+        )
+
+    n_cells_col = n_cells_per_group[:, None]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        mean = np.where(n_cells_col > 0, sum_matrix / n_cells_col, 0.0).astype(np.float32)
+        fraction_expressed = np.where(
+            n_cells_col > 0, count_nz_matrix / n_cells_col, 0.0
+        ).astype(np.float32)
+
+    # Build per-field obs columns from the source DataFrame rather than
+    # splitting the composite label — values containing "_" would corrupt
+    # the split. Take one representative row per code from the pre-aggregate
+    # metadata and reindex to the code range (0..n_groups-1), which matches
+    # ``uniques`` order because pd.factorize(sort=True) returns codes that
+    # index into the sorted uniques.
+    by_src = aligned.loc[keep_mask, by].copy()
+    by_src["_code"] = codes
+    per_group = (
+        by_src.groupby("_code", sort=True).first().reindex(np.arange(n_groups))
+    )
+
+    obs = pd.DataFrame({"n_cells": n_cells_per_group}, index=pd.Index(uniques))
+    for col in by:
+        obs[col] = per_group[col].values
+
+    var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
+
+    keep_groups = obs["n_cells"].to_numpy() >= min_cells_per_group
+    if not keep_groups.any():
+        # Build a short report for the error message.
+        report = "; ".join(
+            f"{u}={int(n)}" for u, n in zip(uniques, n_cells_per_group)
+        )
+        raise ValueError(
+            f"All groups fell below min_cells_per_group={min_cells_per_group}. "
+            f"Observed: {report}"
+        )
+
+    adata = ad.AnnData(
+        X=mean[keep_groups],
+        obs=obs[keep_groups].copy(),
+        var=var,
+        layers={
+            "sum": sum_matrix[keep_groups].astype(np.float32),
+            "count_nonzero": count_nz_matrix[keep_groups].astype(np.int64),
+            "fraction_expressed": fraction_expressed[keep_groups],
+            "mean": mean[keep_groups],
+        },
+    )
+    logger.info(
+        "Aggregated AnnData: %d groups × %d genes (dropped %d groups below min_cells)",
+        adata.n_obs, adata.n_vars, int((~keep_groups).sum()),
+    )
+    return adata

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -72,64 +72,104 @@ def create_anndata_from_ucsc_matrix(
     gene_column: str = UCSC_GENE_COLUMN,
     delimiter: str = "\t",
     split_gene_field: bool = True,
+    chunk_size: int = 500,
 ) -> ad.AnnData:
     """Create an AnnData object from a UCSC Cell Browser expression matrix.
 
-    The input file has genes as rows and cells as columns.  The function
-    transposes the data to the AnnData convention (obs = cells, var = genes)
-    and stores the expression values as a ``scipy.sparse.csr_matrix`` in
-    ``float32``.
+    The input file has genes as rows and cells as columns. This function
+    streams the file in chunks of ``chunk_size`` genes, converts each chunk
+    to a ``scipy.sparse.csr_matrix``, and vstacks them, so peak RAM stays
+    roughly ``chunk_size × n_cells × 4 B`` plus the growing sparse result.
+    The stacked matrix is transposed to the AnnData convention
+    (obs = cells, var = genes) and stored as ``float32`` CSR.
 
     Parameters
     ----------
     expression_matrix_path : str
-        Path to the expression TSV (genes x cells).
+        Path to the expression TSV or `.tsv.gz` (genes x cells).
     metadata_df : pd.DataFrame, optional
-        Cell metadata to join into ``adata.obs``.  Index must match cell ids.
+        Cell metadata to join into ``adata.obs``. Index must match cell ids.
     gene_column : str
         Name of the first column containing gene identifiers.
     delimiter : str
         Column delimiter (default tab).
     split_gene_field : bool
         If True, split gene names on ``|`` and keep only the first element.
+    chunk_size : int
+        Gene rows per streaming chunk. Lower ⇒ less peak RAM, slower.
 
     Returns
     -------
     ad.AnnData
-        AnnData with shape (n_cells, n_genes).
+        AnnData with shape (n_cells, n_genes), sparse CSR X.
 
     Raises
     ------
     FileNotFoundError
         If *expression_matrix_path* does not exist.
+    ValueError
+        If a chunk fails float32 conversion (names the offending gene row).
     """
     if not os.path.exists(expression_matrix_path):
         raise FileNotFoundError(
             f"Expression matrix file not found: {expression_matrix_path}"
         )
 
-    logger.info("Reading expression matrix from %s", expression_matrix_path)
-    expr_df = pd.read_csv(
-        expression_matrix_path, sep=delimiter, index_col=0
+    logger.info(
+        "Streaming expression matrix from %s (chunk_size=%d)",
+        expression_matrix_path,
+        chunk_size,
     )
 
-    # gene names are in the index after index_col=0
-    gene_names = expr_df.index.astype(str)
-    if split_gene_field:
-        gene_names = gene_names.str.split("|").str[0]
-    expr_df.index = gene_names
+    gene_name_chunks = []
+    sparse_chunks = []
+    cell_ids = None
+    n_seen = 0
 
-    # Transpose: genes x cells -> cells x genes
-    X = sparse.csr_matrix(expr_df.values.T.astype(np.float32))
+    reader = pd.read_csv(
+        expression_matrix_path,
+        sep=delimiter,
+        header=0,
+        index_col=0,
+        chunksize=chunk_size,
+    )
+    for chunk in reader:
+        if cell_ids is None:
+            cell_ids = list(chunk.columns)
+
+        chunk_genes = chunk.index.astype(str)
+        if split_gene_field:
+            chunk_genes = chunk_genes.str.split("|").str[0]
+        gene_name_chunks.append(np.asarray(chunk_genes))
+
+        try:
+            chunk_values = chunk.to_numpy(dtype=np.float32, copy=False)
+        except (ValueError, TypeError) as exc:
+            bad_gene = chunk_genes[0] if len(chunk_genes) else "<unknown>"
+            raise ValueError(
+                f"Non-numeric value in chunk starting at gene {bad_gene!r}: {exc}"
+            ) from exc
+
+        sparse_chunks.append(sparse.csr_matrix(chunk_values))
+        n_seen += len(chunk_genes)
+        if n_seen % (chunk_size * 10) == 0:
+            logger.info("  streamed %d genes", n_seen)
+
+    if not sparse_chunks:
+        raise ValueError(
+            f"Expression matrix {expression_matrix_path!r} contained no data rows."
+        )
+
+    # Genes-x-cells sparse → cells-x-genes AnnData convention.
+    X = sparse.vstack(sparse_chunks, format="csr").T.tocsr()
+    gene_names = np.concatenate(gene_name_chunks)
 
     var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
-    obs = pd.DataFrame(index=pd.Index(expr_df.columns, name=UCSC_CELL_ID_COLUMN))
+    obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
 
     adata = ad.AnnData(X=X, obs=obs, var=var)
 
-    # Join metadata into obs if provided
     if metadata_df is not None:
-        # Align metadata to obs index
         common = adata.obs.index.intersection(metadata_df.index)
         if len(common) == 0:
             logger.warning(
@@ -139,4 +179,5 @@ def create_anndata_from_ucsc_matrix(
         for col in meta_aligned.columns:
             adata.obs[col] = meta_aligned[col].values
 
+    logger.info("Built AnnData: %d cells × %d genes", adata.shape[0], adata.shape[1])
     return adata

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import gzip
 import logging
 import os
+import tempfile
 from typing import Iterator
 
 import anndata as ad
@@ -26,6 +27,8 @@ __all__ = [
     "create_anndata_from_ucsc_matrix",
     "build_ucsc_atlas_backed",
     "summarize_ucsc_streaming",
+    "finalize_partial_atlas",
+    "coerce_obs_for_h5ad",
 ]
 
 logger = logging.getLogger(__name__)
@@ -107,6 +110,81 @@ def _iter_ucsc_rows(
             fh.close()
 
     return cell_ids, _rows()
+
+
+def _iter_ucsc_gene_names_only(
+    expression_matrix_path: str,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+) -> tuple[list[str], list[str]]:
+    """Fast pass over a UCSC expression TSV that reads the header and the
+    first column of every data row, skipping the float parse entirely.
+
+    Returns ``(cell_ids, gene_names)``. Useful for recovery paths where the
+    per-cell float data is already on disk and only the row labels are
+    needed.
+    """
+    if not os.path.exists(expression_matrix_path):
+        raise FileNotFoundError(
+            f"Expression matrix file not found: {expression_matrix_path}"
+        )
+    fh = _open_text(expression_matrix_path)
+    try:
+        header = fh.readline().rstrip("\n").rstrip("\r")
+        if not header:
+            raise ValueError(
+                f"Expression matrix {expression_matrix_path!r} is empty."
+            )
+        cell_ids = header.split(delimiter)[1:]
+        gene_names: list[str] = []
+        for line in fh:
+            tab = line.find(delimiter)
+            if tab < 0:
+                continue
+            gene = line[:tab]
+            if split_gene_field:
+                gene = gene.split("|", 1)[0]
+            gene_names.append(gene)
+    finally:
+        fh.close()
+    return cell_ids, gene_names
+
+
+def coerce_obs_for_h5ad(obs: pd.DataFrame) -> pd.DataFrame:
+    """Normalize a ``DataFrame`` so it can be written to h5ad.
+
+    ``anndata``'s vlen-string HDF5 writer raises ``TypeError`` when an
+    ``object``-dtype column contains NaN (which pandas stores as ``float``)
+    mixed with strings — the implicit ``float → str`` conversion never
+    happens. Coerce every ``object`` column through
+    ``.where(notna, "").astype(str)`` so NaN becomes the empty string and
+    every remaining value is a Python ``str``. Numeric, boolean,
+    categorical, and datetime columns are left untouched.
+
+    Returns a copy; does not mutate the input.
+    """
+    obs = obs.copy()
+    for col in obs.select_dtypes(include=["object"]).columns:
+        obs[col] = obs[col].where(obs[col].notna(), "").astype(str)
+    return obs
+
+
+def _probe_write_elem(elem, key: str) -> None:
+    """Write *elem* to a throwaway HDF5 file under *key* to verify it
+    serializes. Raises the underlying error (unchanged) so the caller
+    learns *before* committing to a long-running stream that a metadata
+    column won't serialize.
+
+    Cheap — writes to a temp file that is removed on exit.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+        tmp_path = tmp.name
+    try:
+        with h5py.File(tmp_path, "w") as probe:
+            write_elem(probe, key, elem)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
 
 
 def load_ucsc_metadata(
@@ -332,6 +410,19 @@ def build_ucsc_atlas_backed(
                 f"{expression_matrix_path!r} and metadata."
             )
 
+    # Build the full obs DataFrame now (before the stream) so we can
+    # probe its h5ad-serializability in <1s. This catches cases like
+    # object columns with NaN mixed with strings — which anndata's
+    # vlen-string writer cannot coerce — before we commit hours of I/O
+    # to the X stream only to fail at the closing write_elem.
+    obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
+    if metadata_df is not None:
+        meta_aligned = metadata_df.reindex(obs.index)
+        for col in meta_aligned.columns:
+            obs[col] = meta_aligned[col].values
+    obs = coerce_obs_for_h5ad(obs)
+    _probe_write_elem(obs, "obs")
+
     logger.info(
         "Backed-write atlas → %s (n_cells=%d, column_batch=%d)",
         output_path, n_cells, column_batch,
@@ -381,19 +472,6 @@ def build_ucsc_atlas_backed(
                 f"Expression matrix {expression_matrix_path!r} contained no data rows."
             )
 
-        # obs: cell_ids + optional metadata join (reject zero-overlap).
-        obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
-        if metadata_df is not None:
-            common = obs.index.intersection(metadata_df.index)
-            if len(common) == 0:
-                raise ValueError(
-                    f"No overlapping cell ids between expression matrix "
-                    f"{expression_matrix_path!r} and metadata."
-                )
-            meta_aligned = metadata_df.reindex(obs.index)
-            for col in meta_aligned.columns:
-                obs[col] = meta_aligned[col].values
-
         var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
 
         write_elem(f, "obs", obs)
@@ -406,6 +484,110 @@ def build_ucsc_atlas_backed(
     logger.info(
         "Backed atlas written: %d cells × %d genes → %s",
         n_cells, n_appended, output_path,
+    )
+    return output_path
+
+
+def finalize_partial_atlas(
+    output_path: str,
+    expression_matrix_path: str,
+    metadata_df: pd.DataFrame | None = None,
+    gene_column: str = UCSC_GENE_COLUMN,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+    uns: dict | None = None,
+) -> str:
+    """Finish writing ``/obs``, ``/var``, ``/uns`` into a partially-written
+    backed ``.h5ad`` produced by :func:`build_ucsc_atlas_backed`.
+
+    Recovers files whose ``/X`` group was streamed to completion but whose
+    metadata write failed or was interrupted (crash, out-of-memory on
+    the post-stream serialization, ``write_elem`` type error, etc.). The
+    expensive ``X`` data is preserved; we re-parse only the source gzip's
+    row labels (first column of each line — minutes, not hours) to
+    rebuild ``var``, then write a fresh ``obs`` (coerced via
+    :func:`coerce_obs_for_h5ad`) and optional ``uns`` provenance.
+
+    Parameters
+    ----------
+    output_path : str
+        Partial ``.h5ad`` produced by ``build_ucsc_atlas_backed``. Must
+        contain a complete ``/X`` group (shape matches source dims).
+    expression_matrix_path : str
+        The same source TSV/gz that produced the partial file. Used to
+        re-derive ``cell_ids`` (header) and ``var`` (first column of each
+        row). Source cell count and gene count must match ``/X``'s
+        ``shape`` attribute.
+    metadata_df : pd.DataFrame, optional
+        Cell metadata to rebuild ``/obs`` from. Same shape + coercion as
+        ``build_ucsc_atlas_backed``.
+    gene_column, delimiter, split_gene_field : see ``build_ucsc_atlas_backed``.
+    uns : dict, optional
+        Provenance dict to write as ``/uns``.
+
+    Raises
+    ------
+    ValueError
+        If ``/X`` is missing, or source cell/gene counts disagree with
+        ``/X``'s shape (the source is not the same one that built this
+        partial file — refuse to clobber with mismatched labels).
+    """
+    with h5py.File(output_path, "r") as f:
+        if "X" not in f:
+            raise ValueError(
+                f"{output_path!r} has no /X group; nothing to recover — "
+                f"re-run build_ucsc_atlas_backed from scratch."
+            )
+        x_shape = tuple(int(s) for s in f["X"].attrs["shape"])
+    n_cells_x, n_genes_x = x_shape
+    logger.info(
+        "Finalizing partial atlas at %s (/X shape=%d × %d)",
+        output_path, n_cells_x, n_genes_x,
+    )
+
+    cell_ids, gene_names = _iter_ucsc_gene_names_only(
+        expression_matrix_path,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+    if len(cell_ids) != n_cells_x:
+        raise ValueError(
+            f"Source cell count ({len(cell_ids)}) does not match the "
+            f"partial atlas /X rows ({n_cells_x}). The partial file was "
+            f"likely built from a different source — refusing to finalize."
+        )
+    if len(gene_names) != n_genes_x:
+        raise ValueError(
+            f"Source gene count ({len(gene_names)}) does not match the "
+            f"partial atlas /X columns ({n_genes_x}). The source and "
+            f"partial file disagree — refusing to finalize."
+        )
+
+    obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
+    if metadata_df is not None:
+        if len(obs.index.intersection(metadata_df.index)) == 0:
+            raise ValueError(
+                f"No overlapping cell ids between {expression_matrix_path!r} "
+                f"header and the provided metadata_df."
+            )
+        meta_aligned = metadata_df.reindex(obs.index)
+        for col in meta_aligned.columns:
+            obs[col] = meta_aligned[col].values
+    obs = coerce_obs_for_h5ad(obs)
+    var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
+
+    with h5py.File(output_path, "a") as f:
+        for key in ("obs", "var", "uns"):
+            if key in f:
+                del f[key]
+        write_elem(f, "obs", obs)
+        write_elem(f, "var", var)
+        if uns is not None:
+            write_elem(f, "uns", uns)
+
+    logger.info(
+        "Finalized partial atlas at %s (%d cells × %d genes)",
+        output_path, n_cells_x, n_genes_x,
     )
     return output_path
 

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -645,6 +645,10 @@ def summarize_ucsc_streaming(
         split_gene_field=split_gene_field,
     )
     n_cells = len(cell_ids)
+    logger.info(
+        "Fused aggregate stream → %s (n_cells=%d, group_by=%s)",
+        expression_matrix_path, n_cells, by,
+    )
 
     # Align metadata to expression header order, keep only cells present
     # in both, and drop NaN-in-group rows.
@@ -699,6 +703,11 @@ def summarize_ucsc_streaming(
         )
         block_fill = 0
 
+    # Heartbeat every PROGRESS_EVERY genes so long-running streams show
+    # progress; matches the cadence of the backed builder.
+    PROGRESS_EVERY = 5000
+    n_streamed = 0
+
     for gene, row in row_iter:
         row_valid = row[valid]
         sum_block[:, block_fill] = np.bincount(
@@ -711,8 +720,11 @@ def summarize_ucsc_streaming(
         ).astype(np.int64)
         gene_names.append(gene)
         block_fill += 1
+        n_streamed += 1
         if block_fill == BLOCK:
             _flush_block()
+        if n_streamed % PROGRESS_EVERY == 0:
+            logger.info("  streamed %d genes", n_streamed)
     _flush_block()
 
     if len(gene_names) == 0:

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -35,8 +35,13 @@ logger = logging.getLogger(__name__)
 
 
 def _open_text(path: str):
-    """Open a plain or gzipped text file for reading."""
-    if path.endswith(".gz"):
+    """Open a plain, gzipped, or bgzipped text file for reading.
+
+    ``.bgz`` (bgzip) is the block-gzip format used by htslib/Hail. It is
+    gzip-compatible at the decompressor level, so ``gzip.open`` handles it
+    transparently.
+    """
+    if path.endswith((".gz", ".bgz")):
         return gzip.open(path, "rt")
     return open(path, "rt")
 
@@ -223,6 +228,22 @@ def load_ucsc_metadata(
     df = pd.read_csv(metadata_path, sep=sep, index_col=index_col)
     df.index.name = index_name
     df.columns = [c.replace(".", "_") for c in df.columns]
+
+    # Guard against duplicate cell_id rows (seen in some UCSC/source TSVs with
+    # unquoted embedded newlines in string fields, e.g. Asp_2019 celltype).
+    # Downstream reindex/join calls raise a cryptic "cannot reindex on an axis
+    # with duplicate labels" — dedup here with a clear warning instead.
+    n_dup = int(df.index.duplicated().sum())
+    if n_dup > 0:
+        n_before = len(df)
+        df = df.loc[~df.index.duplicated(keep="first")]
+        logger.warning(
+            "Metadata %s has %d duplicate %s row(s) (%d rows \u2192 %d unique). "
+            "Keeping first occurrence of each %s. This often indicates an "
+            "upstream parsing issue (e.g. unquoted newlines in string fields); "
+            "dedupe the source file if this masks real inconsistencies.",
+            metadata_path, n_dup, index_name, n_before, len(df), index_name,
+        )
     return df
 
 

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -7,7 +7,15 @@ into pandas DataFrames and AnnData objects for downstream analysis.
 
 from __future__ import annotations
 
+import gzip
+import logging
 import os
+from typing import Iterator
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+from scipy import sparse
 
 from hvantk.core.constants import UCSC_CELL_ID_COLUMN, UCSC_GENE_COLUMN
 
@@ -16,15 +24,85 @@ __all__ = [
     "create_anndata_from_ucsc_matrix",
 ]
 
-
-import logging
-
-import numpy as np
-import pandas as pd
-import anndata as ad
-from scipy import sparse
-
 logger = logging.getLogger(__name__)
+
+
+def _open_text(path: str):
+    """Open a plain or gzipped text file for reading."""
+    if path.endswith(".gz"):
+        return gzip.open(path, "rt")
+    return open(path, "rt")
+
+
+def _iter_ucsc_rows(
+    expression_matrix_path: str,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+) -> tuple[list[str], Iterator[tuple[str, np.ndarray]]]:
+    """Open a UCSC expression TSV (plain or gzipped) and return
+    ``(cell_ids, row_iterator)``.
+
+    ``cell_ids`` is the header's cell-column list, extracted eagerly.
+    ``row_iterator`` yields ``(gene_name, row_values_float32)`` per data
+    line and closes the underlying handle when exhausted.
+
+    The caller must iterate the returned generator to completion or call
+    its ``.close()`` method; otherwise the underlying file handle only
+    closes at generator finalization, which is GC-timing-dependent.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``expression_matrix_path`` does not exist.
+    ValueError
+        If the file is empty or a row has the wrong number of values.
+    """
+    if not os.path.exists(expression_matrix_path):
+        raise FileNotFoundError(
+            f"Expression matrix file not found: {expression_matrix_path}"
+        )
+
+    fh = _open_text(expression_matrix_path)
+    try:
+        header = fh.readline().rstrip("\n").rstrip("\r")
+        if not header:
+            fh.close()
+            raise ValueError(
+                f"Expression matrix {expression_matrix_path!r} is empty."
+            )
+        header_fields = header.split(delimiter)
+        cell_ids = header_fields[1:]
+        n_cells = len(cell_ids)
+    except Exception:
+        fh.close()
+        raise
+
+    def _rows() -> Iterator[tuple[str, np.ndarray]]:
+        try:
+            for line in fh:
+                line = line.rstrip("\n").rstrip("\r")
+                if not line:
+                    continue
+                tab = line.find(delimiter)
+                if tab < 0:
+                    continue
+                gene = line[:tab]
+                if split_gene_field:
+                    gene = gene.split("|", 1)[0]
+                row = np.fromstring(
+                    line[tab + 1:], sep=delimiter, dtype=np.float32
+                )
+                if row.shape[0] != n_cells:
+                    raise ValueError(
+                        f"Row for gene {gene!r} has {row.shape[0]} parseable "
+                        f"float values; expected {n_cells}. This usually "
+                        f"means a short row or a non-numeric token in the row."
+                    )
+                yield gene, row
+        finally:
+            fh.close()
+
+    return cell_ids, _rows()
 
 
 def load_ucsc_metadata(
@@ -77,11 +155,17 @@ def create_anndata_from_ucsc_matrix(
     """Create an AnnData object from a UCSC Cell Browser expression matrix.
 
     The input file has genes as rows and cells as columns. This function
-    streams the file in chunks of ``chunk_size`` genes, converts each chunk
-    to a ``scipy.sparse.csr_matrix``, and vstacks them, so peak RAM stays
+    streams the file row-by-row via ``gzip``/``open`` and parses each row
+    into a ``float32`` numpy array with ``np.fromstring``. Every
+    ``chunk_size`` gene rows are flushed into a ``scipy.sparse.csr_matrix``
+    chunk; the chunks are then vstacked and transposed to the AnnData
+    convention (obs = cells, var = genes). Peak RAM during streaming stays
     roughly ``chunk_size × n_cells × 4 B`` plus the growing sparse result.
-    The stacked matrix is transposed to the AnnData convention
-    (obs = cells, var = genes) and stored as ``float32`` CSR.
+
+    A row-oriented parser is used here rather than ``pandas.read_csv`` or
+    ``pyarrow.csv``: single-cell matrices from UCSC can have ~500k columns,
+    and both pandas' C engine (on gzip streams) and pyarrow's
+    column-oriented batches become orders-of-magnitude slower at that width.
 
     Parameters
     ----------
@@ -108,52 +192,46 @@ def create_anndata_from_ucsc_matrix(
     FileNotFoundError
         If *expression_matrix_path* does not exist.
     ValueError
-        If a chunk fails float32 conversion (names the offending gene row).
+        If a row fails float32 conversion (names the offending gene).
     """
-    if not os.path.exists(expression_matrix_path):
-        raise FileNotFoundError(
-            f"Expression matrix file not found: {expression_matrix_path}"
-        )
-
     logger.info(
         "Streaming expression matrix from %s (chunk_size=%d)",
         expression_matrix_path,
         chunk_size,
     )
 
-    gene_name_chunks = []
-    sparse_chunks = []
-    cell_ids = None
-    n_seen = 0
-
-    reader = pd.read_csv(
+    cell_ids, row_iter = _iter_ucsc_rows(
         expression_matrix_path,
-        sep=delimiter,
-        header=0,
-        index_col=0,
-        chunksize=chunk_size,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
     )
-    for chunk_idx, chunk in enumerate(reader):
-        if cell_ids is None:
-            cell_ids = list(chunk.columns)
 
-        chunk_genes = chunk.index.astype(str)
-        if split_gene_field:
-            chunk_genes = chunk_genes.str.split("|").str[0]
-        gene_name_chunks.append(np.asarray(chunk_genes))
+    gene_name_chunks: list[np.ndarray] = []
+    sparse_chunks: list[sparse.csr_matrix] = []
+    buf_rows: list[np.ndarray] = []
+    buf_genes: list[str] = []
+    n_seen = 0
+    n_chunks = 0
 
-        try:
-            chunk_values = chunk.to_numpy(dtype=np.float32, copy=False)
-        except (ValueError, TypeError) as exc:
-            bad_gene = chunk_genes[0] if len(chunk_genes) else "<unknown>"
-            raise ValueError(
-                f"Non-numeric value in chunk starting at gene {bad_gene!r}: {exc}"
-            ) from exc
-
-        sparse_chunks.append(sparse.csr_matrix(chunk_values))
-        n_seen += len(chunk_genes)
-        if (chunk_idx + 1) % 10 == 0:
+    def _flush() -> None:
+        nonlocal n_chunks
+        if not buf_rows:
+            return
+        sparse_chunks.append(sparse.csr_matrix(np.vstack(buf_rows)))
+        gene_name_chunks.append(np.asarray(buf_genes))
+        buf_rows.clear()
+        buf_genes.clear()
+        n_chunks += 1
+        if n_chunks % 10 == 0:
             logger.info("  streamed %d genes", n_seen)
+
+    for gene, row in row_iter:
+        buf_rows.append(row)
+        buf_genes.append(gene)
+        n_seen += 1
+        if len(buf_rows) >= chunk_size:
+            _flush()
+    _flush()
 
     if not sparse_chunks:
         raise ValueError(
@@ -172,8 +250,9 @@ def create_anndata_from_ucsc_matrix(
     if metadata_df is not None:
         common = adata.obs.index.intersection(metadata_df.index)
         if len(common) == 0:
-            logger.warning(
-                "No overlapping cell ids between expression matrix and metadata"
+            raise ValueError(
+                f"No overlapping cell ids between expression matrix "
+                f"{expression_matrix_path!r} and metadata."
             )
         meta_aligned = metadata_df.reindex(adata.obs.index)
         for col in meta_aligned.columns:

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -133,7 +133,7 @@ def create_anndata_from_ucsc_matrix(
         index_col=0,
         chunksize=chunk_size,
     )
-    for chunk in reader:
+    for chunk_idx, chunk in enumerate(reader):
         if cell_ids is None:
             cell_ids = list(chunk.columns)
 
@@ -152,7 +152,7 @@ def create_anndata_from_ucsc_matrix(
 
         sparse_chunks.append(sparse.csr_matrix(chunk_values))
         n_seen += len(chunk_genes)
-        if n_seen % (chunk_size * 10) == 0:
+        if (chunk_idx + 1) % 10 == 0:
             logger.info("  streamed %d genes", n_seen)
 
     if not sparse_chunks:

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -689,12 +689,17 @@ def summarize_ucsc_streaming(
             n_dropped_nan, example,
         )
 
-    labels = (
-        aligned.loc[keep_mask, by].astype(str).agg("_".join, axis=1)
-        if len(by) > 1
-        else aligned.loc[keep_mask, by[0]].astype(str)
-    )
-    codes, uniques = pd.factorize(labels, sort=True)
+    # Factorize on the tuple of group-by values so ("T_cell","donor1") and
+    # ("T","cell_donor1") remain distinct; plain "_".join collapses them.
+    by_vals = aligned.loc[keep_mask, by].astype(str).to_numpy()
+    if len(by) > 1:
+        tuple_arr = np.empty(by_vals.shape[0], dtype=object)
+        tuple_arr[:] = [tuple(r) for r in by_vals]
+        codes, uniques = pd.factorize(tuple_arr, sort=True)
+        label_strs = ["_".join(t) for t in uniques]
+    else:
+        codes, uniques = pd.factorize(by_vals[:, 0], sort=True)
+        label_strs = list(uniques)
     n_groups = len(uniques)
 
     # group_idx per cell in expression-header order, -1 for dropped cells.
@@ -772,7 +777,7 @@ def summarize_ucsc_streaming(
         by_src.groupby("_code", sort=True).first().reindex(np.arange(n_groups))
     )
 
-    obs = pd.DataFrame({"n_cells": n_cells_per_group}, index=pd.Index(uniques))
+    obs = pd.DataFrame({"n_cells": n_cells_per_group}, index=pd.Index(label_strs))
     for col in by:
         obs[col] = per_group[col].values
 
@@ -782,7 +787,7 @@ def summarize_ucsc_streaming(
     if not keep_groups.any():
         # Build a short report for the error message.
         report = "; ".join(
-            f"{u}={int(n)}" for u, n in zip(uniques, n_cells_per_group)
+            f"{u}={int(n)}" for u, n in zip(label_strs, n_cells_per_group)
         )
         raise ValueError(
             f"All groups fell below min_cells_per_group={min_cells_per_group}. "

--- a/hvantk/tables/ucsc.py
+++ b/hvantk/tables/ucsc.py
@@ -13,8 +13,10 @@ import os
 from typing import Iterator
 
 import anndata as ad
+import h5py
 import numpy as np
 import pandas as pd
+from anndata.io import sparse_dataset, write_elem
 from scipy import sparse
 
 from hvantk.core.constants import UCSC_CELL_ID_COLUMN, UCSC_GENE_COLUMN
@@ -22,6 +24,7 @@ from hvantk.core.constants import UCSC_CELL_ID_COLUMN, UCSC_GENE_COLUMN
 __all__ = [
     "load_ucsc_metadata",
     "create_anndata_from_ucsc_matrix",
+    "build_ucsc_atlas_backed",
 ]
 
 logger = logging.getLogger(__name__)
@@ -260,3 +263,147 @@ def create_anndata_from_ucsc_matrix(
 
     logger.info("Built AnnData: %d cells × %d genes", adata.shape[0], adata.shape[1])
     return adata
+
+
+def build_ucsc_atlas_backed(
+    expression_matrix_path: str,
+    output_path: str,
+    metadata_df: pd.DataFrame | None = None,
+    gene_column: str = UCSC_GENE_COLUMN,
+    delimiter: str = "\t",
+    split_gene_field: bool = True,
+    column_batch: int = 64,
+    overwrite: bool = False,
+    uns: dict | None = None,
+) -> str:
+    """Stream-build an AnnData .h5ad file on disk, appending one batch of
+    genes (CSC columns) at a time. Never materializes the full
+    ``cells × genes`` matrix.
+
+    Parameters
+    ----------
+    expression_matrix_path : str
+        Path to the UCSC expression TSV (plain or gzipped).
+    output_path : str
+        Destination ``.h5ad`` path.
+    metadata_df : pd.DataFrame, optional
+        Cell metadata; reindexed to expression header ``cell_ids``.
+    gene_column : str
+        Name for the ``var`` index.
+    delimiter : str
+        Column delimiter in the expression TSV.
+    split_gene_field : bool
+        If True, split gene ids on ``|`` and keep the first element.
+    column_batch : int
+        Number of gene columns buffered before a CSC append to disk.
+        Peak per-batch RAM ≈ ``column_batch × n_cells × 4 B``
+        (≈16 MB at the default for a 520k-cell atlas).
+    overwrite : bool
+        If False and ``output_path`` exists, raise ``FileExistsError``.
+    uns : dict, optional
+        Opaque dict written to the h5ad's ``uns`` group (e.g. provenance
+        metadata). Callers remain responsible for the dict's structure.
+
+    Returns
+    -------
+    str
+        ``output_path``.
+    """
+    if os.path.exists(output_path) and not overwrite:
+        raise FileExistsError(
+            f"{output_path!r} already exists; pass overwrite=True to replace."
+        )
+
+    cell_ids, row_iter = _iter_ucsc_rows(
+        expression_matrix_path,
+        delimiter=delimiter,
+        split_gene_field=split_gene_field,
+    )
+    n_cells = len(cell_ids)
+
+    # Check metadata overlap BEFORE streaming: if zero overlap, raise now
+    # rather than after writing gigabytes of X to disk only to leave a
+    # half-written h5ad that blocks re-runs.
+    if metadata_df is not None:
+        if len(pd.Index(cell_ids).intersection(metadata_df.index)) == 0:
+            raise ValueError(
+                f"No overlapping cell ids between expression matrix "
+                f"{expression_matrix_path!r} and metadata."
+            )
+
+    logger.info(
+        "Backed-write atlas → %s (n_cells=%d, column_batch=%d)",
+        output_path, n_cells, column_batch,
+    )
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+    # h5py.File(..., "w") truncates any existing file, so no pre-remove needed.
+    f = h5py.File(output_path, "w")
+    try:
+        # Seed X as an empty (n_cells, 0) CSC; pass indptr dtype via
+        # dataset_kwargs so large atlases don't overflow int32.
+        seed = sparse.csc_matrix((n_cells, 0), dtype=np.float32)
+        write_elem(f, "X", seed, dataset_kwargs={"indptr_dtype": "int64"})
+        X = sparse_dataset(f["X"])
+
+        gene_names: list[str] = []
+        buf_cols: list[np.ndarray] = []
+        buf_genes: list[str] = []
+        n_appended = 0
+        n_batches = 0
+
+        def _flush() -> None:
+            nonlocal n_appended, n_batches
+            if not buf_cols:
+                return
+            # Stack column-vectors into (n_cells, batch_width) CSC block.
+            dense_block = np.column_stack(buf_cols)  # (n_cells, batch_width)
+            X.append(sparse.csc_matrix(dense_block))
+            gene_names.extend(buf_genes)
+            n_appended += len(buf_cols)
+            n_batches += 1
+            buf_cols.clear()
+            buf_genes.clear()
+            if n_batches % 20 == 0:
+                logger.info("  appended %d genes", n_appended)
+
+        for gene, row in row_iter:
+            buf_cols.append(row)
+            buf_genes.append(gene)
+            if len(buf_cols) >= column_batch:
+                _flush()
+        _flush()
+
+        if n_appended == 0:
+            raise ValueError(
+                f"Expression matrix {expression_matrix_path!r} contained no data rows."
+            )
+
+        # obs: cell_ids + optional metadata join (reject zero-overlap).
+        obs = pd.DataFrame(index=pd.Index(cell_ids, name=UCSC_CELL_ID_COLUMN))
+        if metadata_df is not None:
+            common = obs.index.intersection(metadata_df.index)
+            if len(common) == 0:
+                raise ValueError(
+                    f"No overlapping cell ids between expression matrix "
+                    f"{expression_matrix_path!r} and metadata."
+                )
+            meta_aligned = metadata_df.reindex(obs.index)
+            for col in meta_aligned.columns:
+                obs[col] = meta_aligned[col].values
+
+        var = pd.DataFrame(index=pd.Index(gene_names, name=gene_column))
+
+        write_elem(f, "obs", obs)
+        write_elem(f, "var", var)
+        if uns is not None:
+            write_elem(f, "uns", uns)
+    finally:
+        f.close()
+
+    logger.info(
+        "Backed atlas written: %d cells × %d genes → %s",
+        n_cells, n_appended, output_path,
+    )
+    return output_path

--- a/hvantk/tests/test_expression_builders_anndata.py
+++ b/hvantk/tests/test_expression_builders_anndata.py
@@ -7,6 +7,7 @@ import pytest
 from scipy import sparse
 
 
+@pytest.mark.parametrize("backed", [False, True])
 class TestBuildUcscAd:
     """Tests for build_ucsc_ad in matrix_builders."""
 
@@ -24,7 +25,7 @@ class TestBuildUcscAd:
             for cid, ct in zip(cell_ids, cell_types):
                 fh.write(f"{cid}\t{ct}\n")
 
-    def test_builds_anndata_from_tsv(self, tmp_path):
+    def test_builds_anndata_from_tsv(self, tmp_path, backed):
         """Build AnnData from minimal expression matrix + metadata."""
         cells = ["cell_A", "cell_B", "cell_C", "cell_D"]
         genes = ["TP53", "BRCA1", "EGFR"]
@@ -47,6 +48,8 @@ class TestBuildUcscAd:
             expression_matrix_path=expr_path,
             metadata_path=meta_path,
             output_path=out_path,
+            backed=backed,
+            overwrite=True,
         )
 
         assert isinstance(adata, ad.AnnData)
@@ -60,10 +63,11 @@ class TestBuildUcscAd:
         # Provenance metadata stored
         assert "hvantk_metadata" in adata.uns
         assert adata.uns["hvantk_metadata"]["source_name"] == "UCSC"
-        # Column summary computed
-        assert "column_summary" in adata.uns
+        # Column summary computed (skipped in backed mode by design)
+        if not backed:
+            assert "column_summary" in adata.uns
 
-    def test_no_output_path(self, tmp_path):
+    def test_no_output_path(self, tmp_path, backed):
         """Build AnnData without writing to disk."""
         cells = ["cell_A", "cell_B"]
         genes = ["TP53", "BRCA1"]
@@ -71,6 +75,7 @@ class TestBuildUcscAd:
 
         expr_path = str(tmp_path / "expr.tsv")
         meta_path = str(tmp_path / "meta.tsv")
+        out_path = str(tmp_path / "output.h5ad")
 
         self._write_expression_matrix(expr_path, genes, cells, values)
         self._write_metadata(meta_path, cells, ["neuron", "glia"])
@@ -80,12 +85,15 @@ class TestBuildUcscAd:
         adata = build_ucsc_ad(
             expression_matrix_path=expr_path,
             metadata_path=meta_path,
+            output_path=out_path,
+            backed=backed,
+            overwrite=True,
         )
 
         assert isinstance(adata, ad.AnnData)
         assert adata.shape == (2, 2)
 
-    def test_split_gene_field(self, tmp_path):
+    def test_split_gene_field(self, tmp_path, backed):
         """Pipe-separated gene names are split to first element."""
         cells = ["cell_A", "cell_B"]
         genes = ["TP53|TP53L1", "BRCA1|BRCA1P1"]
@@ -96,6 +104,7 @@ class TestBuildUcscAd:
 
         expr_path = str(tmp_path / "expr.tsv")
         meta_path = str(tmp_path / "meta.tsv")
+        out_path = str(tmp_path / "output.h5ad")
 
         self._write_expression_matrix(expr_path, genes, cells, values)
         self._write_metadata(meta_path, cells, ["neuron", "glia"])
@@ -106,6 +115,9 @@ class TestBuildUcscAd:
             expression_matrix_path=expr_path,
             metadata_path=meta_path,
             split_gene_field=True,
+            output_path=out_path,
+            backed=backed,
+            overwrite=True,
         )
 
         assert "TP53" in adata.var.index.tolist()
@@ -113,9 +125,10 @@ class TestBuildUcscAd:
         # Pipe-separated versions should NOT be present
         assert "TP53|TP53L1" not in adata.var.index.tolist()
 
-    def test_ucsc_respects_delimiter_for_metadata(self, tmp_path):
+    def test_ucsc_respects_delimiter_for_metadata(self, tmp_path, backed):
         expr_path = str(tmp_path / "expr.csv")
         meta_path = str(tmp_path / "meta.csv")
+        out_path = str(tmp_path / "output.h5ad")
         with open(expr_path, "w") as fh:
             fh.write("gene,cell_A,cell_B\n")
             fh.write("TP53,1.0,2.0\n")
@@ -131,6 +144,9 @@ class TestBuildUcscAd:
             expression_matrix_path=expr_path,
             metadata_path=meta_path,
             delimiter=",",
+            output_path=out_path,
+            backed=backed,
+            overwrite=True,
         )
         assert adata.shape == (2, 2)
         assert "cell_type" in adata.obs.columns

--- a/hvantk/tests/test_matrix_utils_anndata.py
+++ b/hvantk/tests/test_matrix_utils_anndata.py
@@ -64,15 +64,40 @@ class TestFilterByMetadataAd:
 
 
 class TestSummarizeExpressionAd:
-    def test_returns_dataframe(self, test_adata):
+    def test_returns_anndata(self, test_adata):
         result = summarize_expression_ad(test_adata, group_by="cell_type")
-        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result, ad.AnnData)
 
-    def test_has_expected_columns(self, test_adata):
+    def test_shape_is_groups_by_genes(self, test_adata):
         result = summarize_expression_ad(test_adata, group_by="cell_type")
-        expected_cols = {"gene_id", "group", "mean", "fraction_expressed", "n_cells"}
-        assert expected_cols == set(result.columns)
+        expected_groups = len(set(test_adata.obs["cell_type"]))
+        assert result.shape == (expected_groups, test_adata.n_vars)
+
+    def test_has_required_layers(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        expected_layers = {"mean", "sum", "count_nonzero", "fraction_expressed"}
+        assert expected_layers.issubset(set(result.layers.keys()))
+
+    def test_obs_has_n_cells(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        assert "n_cells" in result.obs.columns
+        assert (result.obs["n_cells"] > 0).all()
+        assert int(result.obs["n_cells"].sum()) == test_adata.n_obs
 
     def test_groups_match_unique_cell_types(self, test_adata):
         result = summarize_expression_ad(test_adata, group_by="cell_type")
-        assert set(result["group"].unique()) == {"neuron", "astrocyte", "microglia"}
+        assert set(result.obs_names) == {"neuron", "astrocyte", "microglia"}
+
+    def test_fraction_expressed_between_0_and_1(self, test_adata):
+        result = summarize_expression_ad(test_adata, group_by="cell_type")
+        frac = np.asarray(result.layers["fraction_expressed"])
+        assert frac.min() >= 0.0
+        assert frac.max() <= 1.0
+
+    def test_min_cells_filters_small_groups(self, test_adata):
+        # all three cell types should be well above n=5 in the fixture (100 cells / 3),
+        # but at min_cells=10_000 we should drop every group.
+        result = summarize_expression_ad(
+            test_adata, group_by="cell_type", min_cells_per_group=10_000
+        )
+        assert result.n_obs == 0

--- a/hvantk/utils/matrix_utils.py
+++ b/hvantk/utils/matrix_utils.py
@@ -95,68 +95,55 @@ def summarize_expression_ad(
     adata: ad.AnnData,
     group_by: Union[str, List[str]],
     filter_by: Optional[Dict[str, Union[str, List[str]]]] = None,
-    min_cells_per_group: int = 1,
-) -> pd.DataFrame:
-    """Collapse an AnnData expression matrix into a per-group, per-gene summary.
+    min_cells_per_group: int = 10,
+) -> ad.AnnData:
+    """Collapse an AnnData expression matrix into a per-group, per-gene AnnData.
+
+    Thin wrapper around :func:`scanpy.get.aggregate` that also derives
+    ``fraction_expressed`` and attaches per-group cell counts.
 
     Parameters
     ----------
     adata
         Expression AnnData (obs = cells/samples, var = genes).
     group_by
-        One or more obs columns. Multiple columns are joined with ``_``.
+        One or more obs columns to group by. Multi-column groupings produce
+        ``obs_names`` joined with ``_`` (matches ``scanpy.get.aggregate``).
     filter_by
         Optional pre-filter passed to :func:`filter_by_metadata_ad`.
     min_cells_per_group
-        Drop groups with fewer cells than this threshold.
+        Drop groups with fewer than this many cells.
 
     Returns
     -------
-    pd.DataFrame
-        Long-form with columns ``gene_id, group, mean, fraction_expressed,
-        n_cells``.
-
-    Notes
-    -----
-    Does not mutate *adata*. Uses ``groupby(...).indices`` for O(n_cells)
-    group splitting (no per-row index lookups).
+    ad.AnnData
+        Shape ``(n_groups, n_genes)`` with layers ``mean``, ``sum``,
+        ``count_nonzero``, ``fraction_expressed``. ``obs["n_cells"]`` stores
+        the per-group cell count.
     """
+    import scanpy as sc
+
     if filter_by:
         adata = filter_by_metadata_ad(adata, filter_by)
 
-    if isinstance(group_by, str):
-        group_by = [group_by]
+    by = [group_by] if isinstance(group_by, str) else list(group_by)
 
-    if len(group_by) == 1:
-        labels = adata.obs[group_by[0]].astype(str)
-    else:
-        labels = adata.obs[group_by[0]].astype(str)
-        for col in group_by[1:]:
-            labels = labels + "_" + adata.obs[col].astype(str)
+    agg = sc.get.aggregate(
+        adata,
+        by=by,
+        func=["mean", "sum", "count_nonzero"],
+    )
 
-    # Local Series — does not touch adata.obs.
-    label_series = pd.Series(labels.values, index=np.arange(adata.n_obs))
+    # sc.get.aggregate does not stash per-group cell counts; compute from the
+    # pre-aggregate adata, joining group_by columns with "_" to match
+    # agg.obs_names.
+    group_labels = adata.obs[by].astype(str).agg("_".join, axis=1)
+    n_cells = group_labels.value_counts().reindex(agg.obs_names).astype(int)
 
-    gene_ids = adata.var_names.tolist()
-    X = adata.X
+    agg.obs["n_cells"] = n_cells.values
+    agg.layers["fraction_expressed"] = (
+        np.asarray(agg.layers["count_nonzero"]) / n_cells.values[:, None]
+    )
 
-    records: List[Dict[str, Any]] = []
-    for group_name, positions in label_series.groupby(label_series).groups.items():
-        n_cells = len(positions)
-        if n_cells < min_cells_per_group:
-            continue
-        sub = X[np.asarray(positions), :]
-        means = np.asarray(sub.mean(axis=0)).ravel()
-        frac_expr = np.asarray((sub > 0).mean(axis=0)).ravel()
-        for j, gid in enumerate(gene_ids):
-            records.append(
-                {
-                    "gene_id": gid,
-                    "group": group_name,
-                    "mean": float(means[j]),
-                    "fraction_expressed": float(frac_expr[j]),
-                    "n_cells": n_cells,
-                }
-            )
-
-    return pd.DataFrame(records)
+    keep = agg.obs["n_cells"].values >= min_cells_per_group
+    return agg[keep].copy()

--- a/hvantk/utils/matrix_utils.py
+++ b/hvantk/utils/matrix_utils.py
@@ -128,17 +128,33 @@ def summarize_expression_ad(
 
     by = [group_by] if isinstance(group_by, str) else list(group_by)
 
+    # Drop cells with NaN in any group_by column; otherwise astype(str) below
+    # (and scanpy.get.aggregate internally) would produce a real "nan" group.
+    na_mask = adata.obs[by].isna().any(axis=1).to_numpy()
+    if na_mask.any():
+        logger.warning(
+            "Dropped %d cells with NaN in group_by columns %s before aggregation",
+            int(na_mask.sum()), by,
+        )
+        adata = adata[~na_mask].copy()
+
     agg = sc.get.aggregate(
         adata,
         by=by,
         func=["mean", "sum", "count_nonzero"],
     )
 
-    # sc.get.aggregate does not stash per-group cell counts; compute from the
-    # pre-aggregate adata, joining group_by columns with "_" to match
-    # agg.obs_names.
-    group_labels = adata.obs[by].astype(str).agg("_".join, axis=1)
-    n_cells = group_labels.value_counts().reindex(agg.obs_names).astype(int)
+    # Count cells per group on the raw tuple (not the "_"-joined label) so
+    # values containing "_" don't collide; re-encode to match agg.obs_names,
+    # which scanpy built with "_".join.
+    group_sizes = adata.obs.groupby(by, observed=True, dropna=True).size()
+    if len(by) > 1:
+        group_sizes.index = pd.Index(
+            ["_".join(str(v) for v in idx) for idx in group_sizes.index]
+        )
+    else:
+        group_sizes.index = group_sizes.index.astype(str)
+    n_cells = group_sizes.reindex(agg.obs_names).fillna(0).astype(int)
 
     agg.obs["n_cells"] = n_cells.values
     agg.layers["fraction_expressed"] = (


### PR DESCRIPTION
## Summary

Two-stage UCSC atlas ingestion + aggregation, both scalable to 500k+-cell atlases on a laptop.

**Stage 1 — atlas ingestion (`mkmatrix ucsc`)**
- Row-streaming parser (`gzip` + `np.fromstring`) replaces `pd.read_csv(chunksize=)`; fixes #93 and is ~6× faster on wide gzipped inputs.
- New `--backed` mode writes `atlas.h5ad` incrementally as a CSC sparse dataset via `anndata.io.sparse_dataset` + `CSCDataset.append`, so the cells × genes matrix never materializes in RAM. `indptr_dtype=int64` accommodates >2³¹ nonzeros.
- Auto-selects backed mode when the input exceeds 1 GiB.
- Pre-flight probe serializes `obs` to a temp h5 before streaming; catches metadata-type issues in <1s instead of after hours of I/O.
- `coerce_obs_for_h5ad` normalizes object-dtype obs columns (NaN → "") so anndata's vlen-string writer can't choke on mixed NaN + str.
- `finalize_partial_atlas` generalized recovery: if any interruption leaves a partial `.h5ad` with complete `/X` but missing `/obs` / `/var` / `/uns`, re-parse source gz for gene names only (minutes, not hours) and finish the write.

**Stage 2 — aggregation (`expression summarize`)**
- Rewrites `summarize_expression_ad` on `scanpy.get.aggregate`; output is a canonical `.h5ad` of shape `(n_groups × n_genes)` with `mean`, `sum`, `count_nonzero`, `fraction_expressed` as layers and per-group cell counts in `obs["n_cells"]`.

**Fused shortcut (`expression summarize-ucsc`)**
- New subcommand: raw UCSC files + `--group-by` → summary `.h5ad` in one pass via `np.bincount` accumulators. Skips the atlas intermediate. Constant memory (~60 MB accumulators + 2 MB row buffer, independent of `n_cells`). Output schema identical to `expression summarize`.

## Test plan
- [x] `pytest hvantk/tests/test_expression_builders_anndata.py::TestBuildUcscAd` (parametrized on `backed=[False, True]`, 8 tests)
- [x] `pytest hvantk/tests/test_matrix_utils_anndata.py::TestSummarizeExpressionAd` (schema parity)
- [x] Full fast suite (`pytest -q`) green
- [x] Real-data: backed build of adult-ctx-meta-atlas (520,013 cells × 122,697 genes) completes successfully; recovered via `finalize_partial_atlas` after a metadata-serialization failure surfaced the `coerce_obs_for_h5ad` design
- [x] Real-data: `summarize-ucsc --group-by Class` on the same 8.7 GB gz produces 19-group × 122k summary in ~2 h 20 min
- [x] Cross-validation: two-step (`summarize` against atlas.h5ad) and fused (`summarize-ucsc` against raw gz) produce identical summary shape, group labels, and cell counts

## Deferred (follow-up PRs)
- `expression summarize --backed` mode for aggregating large `atlas.h5ad` without full-load (currently stage-2 loads the whole CSC into RAM)
- `describe` / `markers` backed-atlas compatibility
- Same streaming pattern applied to Expression Atlas / CPTAC sources

Specs: `docs_site/specs/2026-04-16-single-cell-aggregation-cli-design.md`, `docs_site/specs/2026-04-17-fused-ucsc-aggregation-design.md`
Plans: `docs_site/plans/2026-04-16-single-cell-aggregation-cli-plan.md`, `docs_site/plans/2026-04-17-fused-ucsc-aggregation-plan.md`

Closes #93
