### PR TITLE
docs: scrub gitignored local/ path references (blocks PR #107)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See the full contributing guide at [docs_site/contributing.md](docs_site/contrib
 
 ## Skill maintenance (resource-centric skills)
 
-`hvantk/skills/` contains agent-readable methodology for maintaining stable resources. Pilot scope: ClinVar and UCSC Cell Browser. See `local/planning/2026-05-07-hvantk-resource-skills-design.md` for the full design.
+`hvantk/skills/` contains agent-readable methodology for maintaining stable resources. Each per-resource `SKILL.md` is a design contract (source identity, output schema, builder + CLI + registry wiring, validation contract) that the round-trip test pins down. Shared conventions live in `hvantk/skills/_conventions/SKILL.md` — read that first before any per-resource skill.
 
 ### When you change builder code
 

--- a/docs_site/tools/ptm-constraint.md
+++ b/docs_site/tools/ptm-constraint.md
@@ -3,8 +3,7 @@
 `hvantk ptm constraint` is a stratified depletion analysis that compares gnomAD
 allele-frequency distributions between PTM-proximal and non-PTM variants,
 grouped by tissue, cell type, or any categorical field found in an expression
-dataset. It is the CLI incarnation of the multi-dataset EDA consolidated in
-`local/notebooks/ptm-eda/PTM-EDA_Consolidated_Report.md` (Notebooks E–I).
+dataset.
 
 > **Not a per-variant scorer.** For per-site PTM flags use `hvantk ptm annotate`.
 > This command produces *stratified group-level* statistics.

--- a/hvantk/ptm/constraint.py
+++ b/hvantk/ptm/constraint.py
@@ -2,9 +2,7 @@
 
 Compares gnomAD allele-frequency distributions between PTM-proximal and
 non-PTM variants, stratified by tissue, cell type, or any categorical
-metadata field derived from an expression dataset. The five statistical
-tests mirror the EDA prototyped in Notebooks E through I
-(see ``local/notebooks/ptm-eda/PTM-EDA_Consolidated_Report.md``).
+metadata field derived from an expression dataset.
 
 This module is an **orchestrator**, not a per-variant scorer. For per-site
 PTM flags use :func:`hvantk.ptm.annotate.annotate_variants_with_ptm`.

--- a/hvantk/skills/gtex-eqtl/SKILL.md
+++ b/hvantk/skills/gtex-eqtl/SKILL.md
@@ -21,7 +21,7 @@ Read `hvantk/skills/_conventions/SKILL.md` first. This skill assumes every conve
 
 - **Provider:** GTEx Consortium. **Variant pinned by this skill:** v11 / cis-eQTL / signif_pairs / per-tissue parquet.
 - **Catalog entry:** present. `hvantk/resources/registry/genomics/datasets.json` contains `GTEx_v11_eQTL_signif_pairs`. URLs / cadence / license / citation live in the registry — not here.
-- **Source schema documentation:** `local/data/qtl_data/README_eQTL_v11.txt` (ships with the GTEx v11 release). The skill cites this README as the authoritative format reference; do NOT restate column definitions here.
+- **Source schema documentation:** the `README_eQTL_v11.txt` that GTEx ships inside the v11 cis-QTL release archive (download via the GTEx portal). The skill cites this README as the authoritative format reference; do NOT restate column definitions here.
 
 Stable note (not in catalog): GTEx ships per-tissue parquet files named `<Tissue>.v11.eQTLs.signif_pairs.parquet`. The builder scans a directory and infers tissue from the filename prefix before the first dot (e.g., `Liver.v11.eQTLs.signif_pairs.parquet` → `Liver`). Single-file input is also accepted.
 
@@ -43,7 +43,7 @@ The post-import `transform_func` is shared across all three: variant ID parsing,
 
 ## 4. Raw format & gotchas
 
-The v11 `*.signif_pairs.parquet` actually contains 12 columns. Cite `local/data/qtl_data/README_eQTL_v11.txt` for the canonical schema, but be aware of two README/file drifts (observed when slicing the Liver fixture):
+The v11 `*.signif_pairs.parquet` actually contains 12 columns. Cite the upstream `README_eQTL_v11.txt` (shipped in the GTEx v11 cis-QTL release archive) for the canonical schema, but be aware of two README/file drifts (observed when slicing the Liver fixture):
 
 **Drift 1: column name `start_distance`, not `tss_distance`.** The README documents column 4 as `tss_distance`; the actual parquet column is named `start_distance`. The builder does NOT read this column (only `phenotype_id`, `variant_id`, `slope`, `slope_se`, `pval_nominal`, and optionally `maf` — see Gap 1 below), so the output Hail Table is unaffected. Documentation drift, harmless.
 
@@ -140,7 +140,7 @@ GTEx releases major versions every few years (v8 → v9 → v10 → v11). Per re
 
 Per `_conventions` § 9:
 
-- **fixture:** `hvantk/tests/testdata/raw/gtex-eqtl/Liver.v11.eQTLs.signif_pairs.parquet`. 800 rows sliced from the v11 Liver source via `local/planning/skills-gtex-eqtl-fixture-slicer.py` (gitignored). ~36 KB. Preserves the parquet binary format (deterministic via `pq.Table.slice(0, N)`).
+- **fixture:** `hvantk/tests/testdata/raw/gtex-eqtl/Liver.v11.eQTLs.signif_pairs.parquet`. 800 rows sliced from the v11 Liver source via `pyarrow.parquet.read_table(...).slice(0, 800)` and `pq.write_table` — deterministic because row-group order is preserved. ~36 KB. Keeps the parquet binary format so the test exercises the real `spark.read.parquet → hl.Table.from_spark` ingestion path.
 - **schema_snapshot:** `hvantk/tests/snapshots/gtex-eqtl/schema.json`.
 - **row_snapshot:** `hvantk/tests/snapshots/gtex-eqtl/sample_rows.json`. Triple key `(locus, alleles, gene_id)` is unique-in-table for signif_pairs, so the test inlines a small key list and no `sample_keys.json` is maintained (per `_conventions` § 9 post-#101).
 - **test_command:** `pytest hvantk/tests/test_gtex_eqtl_builder.py -m hail`.

--- a/hvantk/skills/insider/SKILL.md
+++ b/hvantk/skills/insider/SKILL.md
@@ -111,7 +111,7 @@ INSIDER updates are irregular. To onboard a new release:
 
 Per `_conventions` § 9:
 
-- **fixture:** `hvantk/tests/testdata/raw/insider/insider_sample.bed`. 5 PPI tracks (~21 raw data rows; 17 valid after zero-length filtering). ~1.9 KB. Sliced via `local/planning/skills-insider-fixture-slicer.py` (gitignored) which preserves track headers (a custom BED-aware slicer rather than `head -N` to maintain structural integrity).
+- **fixture:** `hvantk/tests/testdata/raw/insider/insider_sample.bed`. 5 PPI tracks (~21 raw data rows; 17 valid after zero-length filtering). ~1.9 KB. Sliced from the full BED by a track-aware sub-sampler (keeps the `browser` directive plus the first N `track` blocks, each header paired with its data rows) — a plain `head -N` would split a track block and produce an invalid BED.
 - **schema_snapshot:** `hvantk/tests/snapshots/insider/schema.json`. Records the `{interval, ppi_ids: array<str>}` shape.
 - **row_snapshot:** `hvantk/tests/snapshots/insider/sample_rows.json`. Intervals are unique-in-table after the aggregation; test inlines 3 sample keys (per `_conventions` § 9 post-#101 rule — unique-key skills inline).
 - **test_command:** `pytest hvantk/tests/test_insider_builder.py -m hail`.

--- a/hvantk/skills/msigdb/SKILL.md
+++ b/hvantk/skills/msigdb/SKILL.md
@@ -87,7 +87,7 @@ MSigDB releases ~annually (versioned `v<year>.<n>`, e.g., `v2026.1`, `v2025.1`).
 
 Per `_conventions` § 9:
 
-- **fixture:** `hvantk/tests/testdata/raw/msigdb/c2.cp-sample.gmt`. 20 gene sets, ~24 KB, sliced from the v2026.1 C2 CP source via `local/planning/skills-tier3.5-msigdb-fixture-slicer.py` (gitignored — see `local/planning/`). Exercises the short edge (size 5: BIOCARTA, SA), medium sets (60-330 genes), a long set (`REACTOME_CELL_CYCLE`, 688 genes), and the extra-long tail (`REACTOME_POST_TRANSLATIONAL_PROTEIN_MODIFICATION`, 1,497 genes). All 20 fixture rows have a `https://www.gsea-msigdb.org/` URL in column 2 (matches the live-file invariant).
+- **fixture:** `hvantk/tests/testdata/raw/msigdb/c2.cp-sample.gmt`. 20 gene sets, ~24 KB, sampled from the v2026.1 C2 CP source by picking representative rows by line index (the GMT format is line-oriented, so a deterministic line subset is a valid sub-GMT). Exercises the short edge (size 5: BIOCARTA, SA), medium sets (60-330 genes), a long set (`REACTOME_CELL_CYCLE`, 688 genes), and the extra-long tail (`REACTOME_POST_TRANSLATIONAL_PROTEIN_MODIFICATION`, 1,497 genes). All 20 fixture rows have a `https://www.gsea-msigdb.org/` URL in column 2 (matches the live-file invariant).
 - **schema_snapshot:** `hvantk/tests/snapshots/msigdb/schema.json`.
 - **row_snapshot:** `hvantk/tests/snapshots/msigdb/sample_rows.json`. `set_name` keys are unique-in-table, so no `sample_keys.json` is maintained per `_conventions` § 9 (post-#101). The round-trip test inlines the small key list.
 - **test_command:** `pytest hvantk/tests/test_msigdb_builder.py -m hail`.


### PR DESCRIPTION
## Summary

**Hygiene fix — blocks PR #107.** Eight reference lines across six committed files leaked paths under `local/` (the gitignored workspace directory) into the public tree. Those references are broken for anyone reading the repository other than the maintainer. This PR scrubs them.

The references existed in part because of the skills-pilot workflow (fixture slicers and design docs lived under `local/planning/`), but the contamination also predated the pilot (PTM-EDA notebook references in `hvantk/ptm/constraint.py` and `docs_site/tools/ptm-constraint.md`).

## Files fixed

| File | What was wrong |
|---|---|
| `CONTRIBUTING.md` | Pointed at `local/planning/2026-05-07-hvantk-resource-skills-design.md` for "the full design". Replaced with self-contained description; also refreshed the outdated "pilot scope: ClinVar and UCSC Cell Browser" line (we now have 7 onboarded skills). |
| `hvantk/ptm/constraint.py` | Module docstring referenced `local/notebooks/ptm-eda/...`. Dropped the parenthetical; implementation is self-documenting. |
| `docs_site/tools/ptm-constraint.md` | Same pattern as above — bibliographic sentence pointing at a local notebook. Dropped. |
| `hvantk/skills/msigdb/SKILL.md` | §9 cited `local/planning/skills-tier3.5-msigdb-fixture-slicer.py`. Replaced with an inline description of how the fixture was sampled. |
| `hvantk/skills/insider/SKILL.md` | §9 cited `local/planning/skills-insider-fixture-slicer.py`. Replaced with an inline description of the track-aware sub-sampling logic. |
| `hvantk/skills/gtex-eqtl/SKILL.md` (3 refs) | §2 / §4 cited `local/data/qtl_data/README_eQTL_v11.txt`; §9 cited `local/planning/skills-gtex-eqtl-fixture-slicer.py`. Replaced with pointer to upstream GTEx `README_eQTL_v11.txt` (shipped in the release archive) and inline pyarrow slicing description. |

## What this PR does NOT touch

- **No code changes.** Documentation-only.
- **The actual slicer scripts** still live under `local/planning/` on the maintainer's machine — they're tooling, not part of the public artifact. The SKILL.md files now describe *what the slicer does* in prose, which is enough for any contributor to reproduce.
- **No changes to the slicer outputs** (committed fixtures, snapshots, tests). All still pass.

## Verification

```
$ grep -rn "local/" \
    --exclude-dir=local --exclude-dir=.git --exclude-dir=node_modules \
    --exclude-dir=.venv --exclude-dir=__pycache__ . \
  | grep -v "Binary" \
  | grep -vE "(CLAUDE\.md|\.gitignore|AGENTS\.md)"
(no output — clean tree)

$ pytest -m hail -k "clinvar or gwas_catalog or msigdb or insider or gtex" -v
=============== 7 passed, 1037 deselected ================
```

`CLAUDE.md` retains the rule itself ("Planning / spec location: All planning docs ... belong under `local/planning/`. The `/local` tree is gitignored...") — that's the canonical place to define the convention and is not contamination.

## Sequencing

**Important:** **PR #107 (dev → main sync) should not merge until this fix lands.** Once this PR merges into `dev`, the open PR #107 will auto-update its diff to include this scrub, and `main` will receive a clean tree.

## Test plan

- [ ] `grep -rn "local/"` audit returns no contamination
- [ ] Per-resource skill tests still pass (no schema or row changes)
- [ ] Read CONTRIBUTING.md, the two PTM files, and the three skill files to confirm the replacements read naturally without depending on the deleted references

## Branch policy

Target is `dev` per `CLAUDE.md`. Single commit, documentation-only. No Claude footer / co-author.
