### PR TITLE
Pre-merge cleanup: refresh deep-dive docs (#113) + place resources/ as substrate peer (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,19 @@ hvantk --help
 
 ## Architecture
 
-`hvantk` is organized in four layers with a strict one-way dependency rule
-enforced by tests in [`hvantk/tests/test_dependency_directions.py`](hvantk/tests/test_dependency_directions.py):
+`hvantk` is organized in four code layers (`core/`, `algorithms/`,
+`skills/`, `tools/`) plus a substrate-level data registry (`resources/`).
+A strict one-way dependency rule is enforced by tests in
+[`hvantk/tests/test_dependency_directions.py`](hvantk/tests/test_dependency_directions.py):
 
 <p align="center">
-  <img src="docs_site/images/hvantk-platform-architecture.svg" alt="hvantk four-layer platform architecture: tools/ depends on skills/, algorithms/, and core/; skills/ depends on algorithms/ and core/; algorithms/ depends on core/. Arrows flow downward only." width="860">
+  <img src="docs_site/images/hvantk-platform-architecture.svg" alt="hvantk platform architecture: tools/ depends on skills/, algorithms/, and core/; skills/ depends on algorithms/ and core/; algorithms/ depends on core/. resources/ sits at the substrate level alongside core/ and is consumed by skills/ and tools/. Arrows flow downward only." width="860">
 </p>
 
 **Why the directions matter:** `skills/` adapters can rot when upstream APIs
 change without algorithms breaking; `algorithms/` evolve without churning
-the source-adapter layer. `core/` is the stable substrate everyone depends on.
+the source-adapter layer. `core/` and `resources/` are the stable substrate
+everyone depends on — neither imports upward.
 
 ### Data model
 

--- a/docs_site/architecture.md
+++ b/docs_site/architecture.md
@@ -3,12 +3,23 @@
 ## Overview
 
 `hvantk` is a multi-omics variant annotation toolkit. It is organized as a
-four-layer platform with a strict one-way dependency rule enforced by
+five-package layout — four code layers (`core/`, `algorithms/`, `skills/`,
+`tools/`) plus a substrate-level data registry (`resources/`) — with a
+strict one-way dependency rule enforced by
 [`hvantk/tests/test_dependency_directions.py`](https://github.com/bigbio/hvantk/blob/main/hvantk/tests/test_dependency_directions.py):
 
 <p align="center">
-  <img src="images/hvantk-platform-architecture.svg" alt="hvantk four-layer platform architecture: tools/ depends on skills/, algorithms/, and core/; skills/ depends on algorithms/ and core/; algorithms/ depends on core/. Arrows flow downward only." width="860">
+  <img src="images/hvantk-platform-architecture.svg" alt="hvantk platform architecture: tools/ depends on skills/, algorithms/, and core/; skills/ depends on algorithms/ and core/; algorithms/ depends on core/. resources/ sits at the substrate level alongside core/ and is consumed by skills/ and tools/. Arrows flow downward only." width="860">
 </p>
+
+`resources/` is a peer of `core/` (not a layer above it): both are
+substrate that the code layers depend on, neither imports upward.
+Placement rule: dataset-registry JSON, JSON schemas, and the validator /
+aggregator code that operates on them go in `resources/`. Per-plugin
+catalog JSON (`skills/<provider>/catalog/datasets.json`) stays with its
+plugin and is aggregated by `resources/unified_registry.py`. See the
+[Resources Module](#resources-module-resources) section below for the
+full rule.
 
 Design priorities:
 
@@ -416,12 +427,30 @@ annotated = variants.annotate(
 
 ### Resources Module (`resources/`)
 
-**Purpose**: Data catalog and schema definitions
+**Purpose**: Substrate-level data registry and schema definitions.
+Peer of `core/`, not a layer above it.
 
 **Contents**:
 - `registry/` - Surviving legacy per-domain dataset metadata (genomics only; transcriptomics / proteomics / epigenomics moved into per-plugin `hvantk/skills/<provider>/catalog/datasets.json`)
-- `unified_registry.py` - `HvantkRegistry` aggregator surfaced via `hvantk catalog {list,show,stats,search}`
-- `schemas/` - Schema definitions for validation
+- `unified_registry.py` - `HvantkRegistry` aggregator surfaced via `hvantk catalog {list,show,stats,search}`. Reads both the legacy per-domain registry above and the per-plugin catalog JSON under `skills/<provider>/catalog/`.
+- `schemas/` - JSON schema definitions used by `schema_validator.py` to validate catalog entries.
+- `schema_validator.py` - Validation entry point invoked by the unified registry.
+
+**Placement rule** (what goes here vs. nearby alternatives):
+
+| Lives in | Use for |
+|---|---|
+| `resources/registry/` | Cross-plugin / legacy per-domain catalog JSON that hasn't been migrated to a per-plugin folder. |
+| `resources/schemas/` | JSON schemas that describe catalog / dataset metadata, shared across plugins. |
+| `resources/unified_registry.py` | Code that aggregates per-plugin catalog JSON with the legacy registry. |
+| `skills/<provider>/catalog/datasets.json` | Per-plugin dataset metadata (the canonical location for new providers). |
+| `core/models/` | Artifact types (`AnnotationTable`, `ExpressionMatrix`, `GeneSet`) — runtime data shapes, not catalog metadata. |
+
+**Dependency direction**: `resources/` may be imported by `algorithms/`,
+`skills/`, and `tools/`. It must NOT import from any of those — like
+`core/`, it is substrate. This is enforced by
+`test_resources_does_not_import_upward` in
+[`hvantk/tests/test_dependency_directions.py`](https://github.com/bigbio/hvantk/blob/main/hvantk/tests/test_dependency_directions.py).
 
 ## Testing Strategy
 

--- a/docs_site/examples/clingen.md
+++ b/docs_site/examples/clingen.md
@@ -1,18 +1,18 @@
 # ClinGen Examples
 
-> **Heads up — build example needs refresh.** The Quick Start below references the retired `hvantk mktable clingen` CLI. Use `hvantk reprocess clingen:gene-disease --raw-dir <dir> --output <path>` instead — see the [Usage Guide](../guide/usage.md#1-build-a-dataset-with-hvantk-reprocess). Other ClinGen commands and APIs on this page are unaffected.
-
 Query ClinGen Gene-Disease Validity data, extract gene sets, and categorize diseases using MONDO ontology.
 
 ## Quick Start
 
-```bash
-# Download ClinGen data
-hvantk download clingen --output-dir data/
+The ClinGen plugin has a built-in downloader, so one command downloads today's snapshot into `data/` and builds the Hail Table:
 
-# Build Hail Table
-hvantk mktable clingen --raw-input data/clingen_gene_disease.csv --output-ht clingen.ht
+```bash
+hvantk reprocess clingen:gene-disease \
+  --raw-dir data/ \
+  --output clingen.ht
 ```
+
+If you already downloaded `Clingen-Gene-Disease-Summary-<YYYY-MM-DD>.csv` into `data/`, add `--skip-download` to reuse it.
 
 ## ClinGenStreamer API
 

--- a/docs_site/examples/clinvar.md
+++ b/docs_site/examples/clinvar.md
@@ -1,19 +1,19 @@
 # ClinVar Streaming Examples
 
-> **Heads up — build example needs refresh.** The prerequisite step below references the retired `hvantk mktable clinvar` CLI. Use `hvantk reprocess clinvar:variants --raw-dir <dir> --output <path>` instead — see the [Usage Guide](../guide/usage.md#1-build-a-dataset-with-hvantk-reprocess). The streamer usage below is unaffected.
-
 Stream and filter ClinVar variant annotations using hvantk's `ClinvarDataStreamer`.
 
 ## Prerequisites
 
-Build a ClinVar Hail Table first:
+Build a ClinVar Hail Table first. The ClinVar plugin has a built-in downloader, so this single command downloads the latest VCF into `data/clinvar/` and builds the table in one go:
 
 ```bash
-hvantk mktable clinvar \
-  --raw-input clinvar.vcf.bgz \
-  --output-ht clinvar.ht \
-  --reference-genome GRCh38
+hvantk reprocess clinvar:variants \
+  --raw-dir data/clinvar/ \
+  --output clinvar.ht \
+  --plugin-arg reference_genome=GRCh38
 ```
+
+If you already have `clinvar.vcf.bgz` (or `.vcf.gz`), place it under `data/clinvar/` and add `--skip-download`.
 
 ## Basic Streaming
 

--- a/docs_site/examples/ptm.md
+++ b/docs_site/examples/ptm.md
@@ -1,7 +1,5 @@
 # PTM (Post-Translational Modification) Variant Classification Example
 
-> **Heads up — prerequisite build example needs refresh.** The ClinVar prerequisite below references the retired `hvantk mktable clinvar` CLI. Use `hvantk reprocess clinvar:variants --raw-dir <dir> --output <path>` instead — see the [Usage Guide](../guide/usage.md#1-build-a-dataset-with-hvantk-reprocess). PTM-specific commands (`hvantk ptm ...`) on this page are unaffected.
-
 This page walks through the end-to-end PTM pipeline: building a PTM sites table, annotating variants, running landscape and population analyses, and generating a report.
 
 ## Overview
@@ -19,7 +17,7 @@ eval "$(poetry env activate)"
 
 | Input | Source | How to obtain |
 |-------|--------|---------------|
-| ClinVar Hail Table | NCBI | `hvantk download clinvar` then `hvantk mktable clinvar` |
+| ClinVar Hail Table | NCBI | `hvantk reprocess clinvar:variants --raw-dir data/clinvar/ --output data/clinvar.ht` |
 | gnomAD Hail Table | gnomAD | Manual download (see [Data Sources](../guide/data-sources.md)) |
 | Ensembl GTF | Ensembl | Auto-downloaded by `hvantk ptm build` |
 | UniProt PTM TSV | UniProt | Auto-downloaded by `hvantk ptm build` |

--- a/docs_site/examples/qtlcascade.md
+++ b/docs_site/examples/qtlcascade.md
@@ -1,7 +1,5 @@
 # QTL Cascade Example
 
-> **Heads up — build examples need refresh.** Sections that show `hvantk mktable eqtl` / `hvantk mktable pqtl` reference retired CLIs. The unified replacement is `hvantk reprocess <plugin>:<dataset>` — see the [Usage Guide](../guide/usage.md#1-build-a-dataset-with-hvantk-reprocess).
-
 This page demonstrates the QTL cascade pipeline for tracing variant effects from DNA to RNA (eQTL) to protein (pQTL).
 
 ## Overview
@@ -16,21 +14,25 @@ The QTL cascade pipeline:
 ## Quick Start (CLI)
 
 ```bash
-# Step 1: Build eQTL table from GTEx v11 significant pairs
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v11/signif_pairs/Liver.v11.signif_pairs.parquet \
-  --output-ht /data/tables/eqtl_liver.ht \
-  --source gtex_v11 \
-  --tissue Liver
+# Step 1: Build eQTL table from GTEx v11 significant pairs.
+# Place Liver.v11.signif_pairs.parquet under /data/gtex_v11/signif_pairs/.
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v11/signif_pairs/ \
+  --output /data/tables/eqtl_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v11 \
+  --plugin-arg tissue=Liver
 
-# Step 2: Build pQTL table from Fang et al. allpairs
-hvantk mktable pqtl \
-  --raw-input /data/fang_pqtl/Liver_allpairs.txt.gz \
-  --output-ht /data/tables/pqtl_liver.ht \
-  --source gtex_fang \
-  --tissue Liver \
-  --gene-map-ht /data/tables/ensembl_gene.ht \
-  --p-threshold 5e-8
+# Step 2: Build pQTL table from Fang et al. allpairs.
+# Place Liver_allpairs.txt.gz under /data/fang_pqtl/.
+hvantk reprocess pqtl:metrics \
+  --raw-dir /data/fang_pqtl/ \
+  --output /data/tables/pqtl_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_fang \
+  --plugin-arg tissue=Liver \
+  --plugin-arg hgnc_ht=/data/tables/ensembl_gene.ht \
+  --plugin-arg p_threshold=5e-8
 
 # Step 3: Run the cascade pipeline
 hvantk qtlcascade run \
@@ -83,17 +85,22 @@ print(f"Class counts: {result.class_counts}")
 To distinguish true signal propagation from LD artifacts, provide allpairs tables for coloc:
 
 ```bash
-# Build allpairs tables (set p-threshold to 0 to keep all variants)
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v11/allpairs/Liver/ \
-  --output-ht /data/tables/eqtl_allpairs_liver.ht \
-  --source gtex_v11 --tissue Liver --p-threshold 0
+# Build allpairs tables (set p_threshold to 0 to keep all variants)
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v11/allpairs/Liver/ \
+  --output /data/tables/eqtl_allpairs_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v11 \
+  --plugin-arg tissue=Liver \
+  --plugin-arg p_threshold=0
 
-hvantk mktable pqtl \
-  --raw-input /data/fang_pqtl/Liver_allpairs.txt.gz \
-  --output-ht /data/tables/pqtl_allpairs_liver.ht \
-  --source gtex_fang --tissue Liver \
-  --gene-map-ht /data/tables/ensembl_gene.ht
+hvantk reprocess pqtl:metrics \
+  --raw-dir /data/fang_pqtl/ \
+  --output /data/tables/pqtl_allpairs_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_fang \
+  --plugin-arg tissue=Liver \
+  --plugin-arg hgnc_ht=/data/tables/ensembl_gene.ht
 
 # Run pipeline with coloc
 hvantk qtlcascade run \

--- a/docs_site/guide/data-sources.md
+++ b/docs_site/guide/data-sources.md
@@ -1,14 +1,12 @@
 # Data Sources
 
-> **Heads up — examples below need refresh.** This page references the retired `hvantk mktable` and `hvantk mkmatrix` CLIs. The unified replacement is `hvantk reprocess <plugin>:<dataset>` — see the [Usage Guide](usage.md#1-build-a-dataset-with-hvantk-reprocess) for the current pattern. Download commands on this page are still accurate; the build commands need adapting.
-
 This page covers all annotation and expression data sources supported by hvantk: what they are, where to get them, and how to build datasets from the raw data. Sources are split into two categories: those with **built-in downloaders** (automated) and those that require **manual download** (too large, license-gated, or fragile URLs).
 
-For building datasets from downloaded data, see the [Usage Guide](usage.md).
+Every build on this page goes through the unified `hvantk reprocess <plugin>:<dataset>` entry point — see the [Usage Guide](usage.md#1-build-a-dataset-with-hvantk-reprocess) for the orchestration pattern, lifecycle flags, and `--plugin-arg KEY=VALUE` conventions used below.
 
 ## File format note
 
-Downloaded `.gz` files may be standard gzip (single-threaded in Hail) rather than BGZF (parallel). Use `--auto-convert-bgz` during table or matrix builds, or pre-convert with:
+Downloaded `.gz` files may be standard gzip (single-threaded in Hail) rather than BGZF (parallel). Pre-convert before building:
 
 ```bash
 hvantk utils convert-bgz input.gz
@@ -74,9 +72,16 @@ hvantk download hgnc --output-dir data/hgnc
 **Build Hail Table**:
 
 ```bash
-hvantk mktable hgnc \
-  --raw-input data/hgnc/hgnc_complete_set.tsv \
-  --output-ht hgnc.ht
+# Single command: download into data/hgnc/ then build the table
+hvantk reprocess hgnc:lookup \
+  --raw-dir data/hgnc/ \
+  --output hgnc.ht
+
+# Or, if you already downloaded the TSV into data/hgnc/:
+hvantk reprocess hgnc:lookup \
+  --raw-dir data/hgnc/ \
+  --output hgnc.ht \
+  --skip-download
 ```
 
 ### UCSC Cell Browser
@@ -113,7 +118,7 @@ hvantk download expression-atlas --download_path data/expression_atlas
 
 ## Manual download sources
 
-These sources are too large, require license acceptance, or have complex download procedures. Follow the instructions below, then use `hvantk mktable` to build Hail Tables.
+These sources are too large, require license acceptance, or have complex download procedures. Follow the instructions below, place the raw file(s) in a per-source directory, then build via `hvantk reprocess <plugin>:<dataset> --skip-download`.
 
 ### dbNSFP (~45 GB)
 
@@ -136,21 +141,15 @@ head -1 <(zcat dbNSFP4.9a_variant.chr1.gz) > /tmp/dbnsfp_header.txt
 **Build**:
 
 ```bash
-# Option 1: Pre-converted BGZF (recommended)
-hvantk mktable dbnsfp \
-  --raw-input dbNSFP4.9a_variant.bgz \
-  --output-ht dbnsfp.ht
-
-# Option 2: Auto-convert during build (requires a single already-merged .gz)
-# This only works if you have already concatenated the per-chromosome files
-# into a single gzip file (e.g., dbNSFP4.9a_variant.gz).
-# --auto-convert-bgz re-compresses the single .gz as BGZF; it does NOT
-# assemble per-chromosome files.
-hvantk mktable dbnsfp \
-  --raw-input dbNSFP4.9a_variant.gz \
-  --output-ht dbnsfp.ht \
-  --auto-convert-bgz
+# Place the concatenated BGZF file in data/dbnsfp/ (so the builder sees it),
+# then build. dbNSFP has no plugin downloader; --skip-download is required.
+hvantk reprocess dbnsfp:variants \
+  --raw-dir data/dbnsfp/ \
+  --output dbnsfp.ht \
+  --skip-download
 ```
+
+> **Note:** dbNSFP's builder reads BGZF input. If you only have a single combined `.gz`, pre-convert with `hvantk utils convert-bgz dbNSFP4.9a_variant.gz` before building.
 
 ### gnomAD constraint metrics (~50 MB for gene-level)
 
@@ -166,9 +165,11 @@ wget https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/constrai
 **Build**:
 
 ```bash
-hvantk mktable gnomad-metrics \
-  --raw-input gnomad.v4.1.constraint_metrics.tsv \
-  --output-ht gnomad_metrics.ht
+# Place gnomad.v4.1.constraint_metrics.tsv in data/gnomad_metrics/ then:
+hvantk reprocess gnomad-metrics:metrics \
+  --raw-dir data/gnomad_metrics/ \
+  --output gnomad_metrics.ht \
+  --skip-download
 ```
 
 ### INSIDER interactome (~100 MB)
@@ -181,9 +182,11 @@ URL: http://interactomeinsider.yulab.org/downloads.html
 **Build**:
 
 ```bash
-hvantk mktable interactome \
-  --raw-input insider_interaction_sites.bed.bgz \
-  --output-ht interactome.ht
+# Place insider_interaction_sites.bed.bgz in data/insider/ then:
+hvantk reprocess insider:variants \
+  --raw-dir data/insider/ \
+  --output interactome.ht \
+  --skip-download
 ```
 
 ### Ensembl gene annotations (~800 MB)
@@ -197,9 +200,11 @@ https://www.ensembl.org/info/data/ftp/index.html
 **Build**:
 
 ```bash
-hvantk mktable ensembl-gene \
-  --raw-input biomart_export.tsv.bgz \
-  --output-ht ensembl_gene.ht
+# Place biomart_export.tsv.bgz in data/ensembl_gene/ then:
+hvantk reprocess ensembl-gene:genes \
+  --raw-dir data/ensembl_gene/ \
+  --output ensembl_gene.ht \
+  --skip-download
 ```
 
 ### GeVIR (~20 GB)
@@ -213,9 +218,11 @@ https://www.nature.com/articles/s41588-019-0560-2
 **Build**:
 
 ```bash
-hvantk mktable gevir \
-  --raw-input gevir_metrics.tsv.bgz \
-  --output-ht gevir.ht
+# Place gevir_metrics.tsv.bgz in data/gevir/ then:
+hvantk reprocess gevir:metrics \
+  --raw-dir data/gevir/ \
+  --output gevir.ht \
+  --skip-download
 ```
 
 ### CCR - Coding-Constrained Regions (~50 MB)
@@ -237,9 +244,11 @@ URL: https://cancer.sanger.ac.uk/census
 **Build**:
 
 ```bash
-hvantk mktable cosmic-cgc \
-  --raw-input cancer_gene_census.tsv \
-  --output-ht cosmic_cgc.ht
+# Place cancer_gene_census.tsv in data/cosmic_cgc/ then:
+hvantk reprocess cosmic-cgc:submissions \
+  --raw-dir data/cosmic_cgc/ \
+  --output cosmic_cgc.ht \
+  --skip-download
 ```
 
 ### UniProt PTM Sites
@@ -297,43 +306,48 @@ URL: https://www.gtexportal.org/home/downloads/adult-gtex/qtl
 
 ```bash
 # Download significant pairs (Parquet format, ~50 MB per tissue)
-# Navigate to GTEx Portal → Downloads → Adult GTEx → QTL → eQTL → Significant pairs
+# Navigate to GTEx Portal → Downloads → Adult GTEx → QTL → eQTL → Significant pairs.
+# Place per-tissue files under /data/gtex_v11/signif_pairs/ then:
 
 # Build significant-pairs table
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v11/Liver.v11.signif_pairs.parquet \
-  --output-ht eqtl_liver.ht \
-  --source gtex_v11 \
-  --tissue Liver
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v11/signif_pairs/ \
+  --output eqtl_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v11 \
+  --plugin-arg tissue=Liver
 
 # Build allpairs table for coloc (set p-threshold to 0)
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v11/allpairs/Liver/ \
-  --output-ht eqtl_allpairs_liver.ht \
-  --source gtex_v11 \
-  --tissue Liver \
-  --p-threshold 0
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v11/allpairs/Liver/ \
+  --output eqtl_allpairs_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v11 \
+  --plugin-arg tissue=Liver \
+  --plugin-arg p_threshold=0
 ```
 
 **GTEx v8** (TSV format):
 
 ```bash
-# Download from GTEx Portal v8 archive
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v8/Liver.v8.signif_variant_gene_pairs.txt.gz \
-  --output-ht eqtl_liver_v8.ht \
-  --source gtex_v8
+# Place Liver.v8.signif_variant_gene_pairs.txt.gz under /data/gtex_v8/ then:
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v8/ \
+  --output eqtl_liver_v8.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v8
 ```
 
 **eQTLGen** (blood eQTLs):
 URL: https://www.eqtlgen.org/cis-eqtls.html
 
 ```bash
-# Download cis-eQTL full results (~2 GB)
-hvantk mktable eqtl \
-  --raw-input /data/eqtlgen/cis-eQTLs_full.txt.gz \
-  --output-ht eqtl_blood.ht \
-  --source eqtlgen
+# Place cis-eQTLs_full.txt.gz under /data/eqtlgen/ then:
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/eqtlgen/ \
+  --output eqtl_blood.ht \
+  --skip-download \
+  --plugin-arg source=eqtlgen
 ```
 
 ### Fang et al. (2025) pQTL data
@@ -342,25 +356,28 @@ Protein quantitative trait loci from Fang et al. (2025), covering 5 tissues (Col
 
 URL: Contact authors or GTEx Portal supplementary data.
 
-> **Note:** Fang pQTL data uses gene symbols. Provide a `--gene-map-ht` (Ensembl gene table) for symbol → Ensembl ID mapping.
+> **Note:** Fang pQTL data uses gene symbols. Pass an Ensembl gene-table path via `--plugin-arg hgnc_ht=<path>` for symbol → Ensembl ID mapping (the builder uses an HGNC-style lookup table).
 
 ```bash
 # Build pQTL table with gene mapping
-hvantk mktable pqtl \
-  --raw-input /data/fang_pqtl/Liver_allpairs.txt.gz \
-  --output-ht pqtl_liver.ht \
-  --source gtex_fang \
-  --tissue Liver \
-  --gene-map-ht ensembl_gene.ht \
-  --p-threshold 5e-8
+# Place Liver_allpairs.txt.gz under /data/fang_pqtl/ then:
+hvantk reprocess pqtl:metrics \
+  --raw-dir /data/fang_pqtl/ \
+  --output pqtl_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_fang \
+  --plugin-arg tissue=Liver \
+  --plugin-arg hgnc_ht=ensembl_gene.ht \
+  --plugin-arg p_threshold=5e-8
 
-# Allpairs for coloc (omit p-threshold)
-hvantk mktable pqtl \
-  --raw-input /data/fang_pqtl/Liver_allpairs.txt.gz \
-  --output-ht pqtl_allpairs_liver.ht \
-  --source gtex_fang \
-  --tissue Liver \
-  --gene-map-ht ensembl_gene.ht
+# Allpairs for coloc (omit p_threshold to keep all variants)
+hvantk reprocess pqtl:metrics \
+  --raw-dir /data/fang_pqtl/ \
+  --output pqtl_allpairs_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_fang \
+  --plugin-arg tissue=Liver \
+  --plugin-arg hgnc_ht=ensembl_gene.ht
 ```
 
 ## Expression data sources

--- a/docs_site/guide/usage.md
+++ b/docs_site/guide/usage.md
@@ -2,7 +2,7 @@
 
 This guide covers how to build datasets and run analysis tools in hvantk.
 
-> **Heads up:** hvantk recently retired the `mktable` and `mkmatrix` CLIs. The unified replacement is `hvantk reprocess <plugin>:<dataset>`, which runs the full Phase B pipeline (download → parse → build → drift check → save with provenance). Tutorial pages under `docs_site/guide/` and `docs_site/tools/` that still reference `mktable` / `mkmatrix` are being refreshed; see section 1 below for the current pattern.
+> **Migration note:** hvantk has retired the `mktable` and `mkmatrix` CLIs. The unified replacement is `hvantk reprocess <plugin>:<dataset>`, which runs the full Phase B pipeline (download → parse → build → drift check → save with provenance). See section 1 below for the current pattern.
 
 If you haven't installed hvantk yet, see the main README for install steps.
 
@@ -62,8 +62,6 @@ hvantk reprocess cptac:expression \
   --output /out/cptac_brca.h5ad \
   --plugin-arg cancer_type=brca
 ```
-
-> The deep-dive per-source tutorials under [Data Sources](data-sources.md) and the `tools/` pages still reference the retired `mktable` / `mkmatrix` CLIs; they will be rewritten in a follow-up. Use the patterns above for new work.
 
 ## 2) Ancestry Inference
 
@@ -293,7 +291,7 @@ The command auto-detects whether the file is already BGZF and skips conversion i
 - For JSON vs YAML: JSON works out of the box; YAML recipes require `PyYAML` installed.
 - For UCSC, gene labels may be pipe-delimited (e.g., A|B); `--split-gene-field` defaults to true.
 - MatrixTables typically store sample/cell metadata under `mt.col_key` and cols metadata; inspect with `mt.describe()` in Python or logs from CLI.
-- **gzip vs BGZF**: Hail reads standard gzip files single-threaded, which is significantly slower for large files. Convert to BGZF with `--auto-convert-bgz` or `hvantk utils convert-bgz` for parallel import.
+- **gzip vs BGZF**: Hail reads standard gzip files single-threaded, which is significantly slower for large files. Pre-convert with `hvantk utils convert-bgz <file.gz>` for parallel import before running `hvantk reprocess`.
 
 ## See also
 

--- a/docs_site/tools/psroc.md
+++ b/docs_site/tools/psroc.md
@@ -1,7 +1,5 @@
 # PSROC: Prediction Score ROC Analysis
 
-> **Heads up — build examples need refresh.** Sections that show `hvantk mktable clinvar` / `hvantk mktable dbnsfp` / `hvantk mktable clingen-gene-disease` reference retired CLIs. The unified replacement is `hvantk reprocess <plugin>:<dataset>` — see the [Usage Guide](../guide/usage.md#1-build-a-dataset-with-hvantk-reprocess). PSROC commands on this page (`hvantk psroc ...`) are unaffected.
-
 PSROC is a module within hvantk that evaluates variant pathogenicity prediction scores using ROC (Receiver Operating Characteristic) curve analysis. It compares prediction scores from databases like dbNSFP against ClinVar truth labels to assess their discriminative power.
 
 ![PS-ROC workflow](../images/hvantk-psroc-workflow.svg)
@@ -183,15 +181,18 @@ hvantk genesets prepare -i panels.tsv -o panels.json --hgnc /data/hgnc.ht
 PSROC requires pre-built Hail Tables for ClinVar and dbNSFP:
 
 ```bash
-# Build ClinVar table
-hvantk mktable clinvar \
-  --raw-input /data/clinvar.vcf.bgz \
-  --output-ht /data/clinvar_grch38.ht
+# Build ClinVar table (clinvar plugin has a built-in downloader; raw-dir
+# holds clinvar.vcf.gz + .tbi).
+hvantk reprocess clinvar:variants \
+  --raw-dir /data/clinvar/ \
+  --output /data/clinvar_grch38.ht
 
-# Build dbNSFP table (from concatenated BGZF — see Deployment Guide)
-hvantk mktable dbnsfp \
-  --raw-input /data/dbNSFP4.9a_variant.bgz \
-  --output-ht /data/dbnsfp_grch38.ht
+# Build dbNSFP table from the concatenated BGZF (see Deployment Guide).
+# dbNSFP has no plugin downloader; --skip-download is required.
+hvantk reprocess dbnsfp:variants \
+  --raw-dir /data/dbnsfp/ \
+  --output /data/dbnsfp_grch38.ht \
+  --skip-download
 ```
 
 ### Score Selection
@@ -767,24 +768,27 @@ hvantk download clingen --output-dir /data/clingen
 ### Step 3: Build Hail Tables (Layer 1 — Builders)
 
 ```bash
-# Build ClinVar table
+# Build ClinVar table from the already-downloaded VCF in /data/clinvar/.
 # Note: ClinVar distributes standard gzip (.vcf.gz), which Hail reads
 # single-threaded. For parallel reads, recompress as BGZF first:
-#   gunzip -c clinvar.vcf.gz | bgzip -@ 4 > clinvar.vcf.bgz
-hvantk mktable clinvar \
-  --raw-input /data/clinvar/clinvar.vcf.gz \
-  --output-ht /data/tables/clinvar_grch38.ht
+#   hvantk utils convert-bgz /data/clinvar/clinvar.vcf.gz
+hvantk reprocess clinvar:variants \
+  --raw-dir /data/clinvar/ \
+  --output /data/tables/clinvar_grch38.ht \
+  --skip-download
 
-# Build dbNSFP table (from the concatenated BGZF file prepared in Step 2)
-hvantk mktable dbnsfp \
-  --raw-input /data/dbnsfp/dbNSFP4.9a_variant.bgz \
-  --output-ht /data/tables/dbnsfp_grch38.ht
+# Build dbNSFP table from the concatenated BGZF file prepared in Step 2.
+hvantk reprocess dbnsfp:variants \
+  --raw-dir /data/dbnsfp/ \
+  --output /data/tables/dbnsfp_grch38.ht \
+  --skip-download
 
-# Build ClinGen table (for gene set extraction)
-# The filename includes today's date, e.g., Clingen-Gene-Disease-Summary-2026-03-11.csv
-hvantk mktable clingen-gene-disease \
-  --raw-input /data/clingen/Clingen-Gene-Disease-Summary-*.csv \
-  --output-ht /data/tables/clingen.ht
+# Build ClinGen table (for gene set extraction). raw-dir contains the
+# Clingen-Gene-Disease-Summary-<YYYY-MM-DD>.csv downloaded in Step 2.
+hvantk reprocess clingen:gene-disease \
+  --raw-dir /data/clingen/ \
+  --output /data/tables/clingen.ht \
+  --skip-download
 ```
 
 ### Step 4: Prepare Gene Sets

--- a/docs_site/tools/qtlcascade.md
+++ b/docs_site/tools/qtlcascade.md
@@ -1,7 +1,5 @@
 # QTL Cascade: Molecular QTL Cascade Analysis
 
-> **Heads up — build examples need refresh.** Sections that show `hvantk mktable eqtl` / `hvantk mktable pqtl` reference retired CLIs. The unified replacement is `hvantk reprocess <plugin>:<dataset>` — see the [Usage Guide](../guide/usage.md#1-build-a-dataset-with-hvantk-reprocess). Cascade-specific commands on this page (`hvantk qtlcascade ...`) are unaffected.
-
 QTL Cascade is a module within hvantk that traces variant effects across molecular layers — from DNA to RNA (eQTL) to protein (pQTL) — to identify variants whose transcriptomic effects propagate to the proteome. It integrates colocalization analysis to distinguish true signal propagation from LD artifacts.
 
 ![QTL Cascade workflow](../images/hvantk-qtlcascade-workflow.svg)
@@ -559,60 +557,66 @@ plot_loeuf_by_cascade_class(
 
 ## Building Input Tables
 
-The cascade pipeline requires eQTL and pQTL Hail Tables as input. Build them with `hvantk mktable`:
+The cascade pipeline requires eQTL and pQTL Hail Tables as input. Build them via the unified `hvantk reprocess` entry point (the cascade plugins have no built-in downloader, so `--skip-download` is required after manually placing raw files into the per-source directory passed as `--raw-dir`).
 
 ### eQTL Table
 
 ```bash
-# GTEx v11 (parquet)
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v11/signif_pairs/ \
-  --output-ht /data/eqtl_liver.ht \
-  --source gtex_v11 \
-  --tissue Liver
+# GTEx v11 (parquet directory)
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v11/signif_pairs/ \
+  --output /data/eqtl_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v11 \
+  --plugin-arg tissue=Liver
 
 # GTEx v8 (TSV)
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v8/Liver.v8.signif_variant_gene_pairs.txt.gz \
-  --output-ht /data/eqtl_liver.ht \
-  --source gtex_v8
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v8/ \
+  --output /data/eqtl_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v8
 
 # eQTLGen
-hvantk mktable eqtl \
-  --raw-input /data/eqtlgen/cis-eQTLs_full.txt.gz \
-  --output-ht /data/eqtl_blood.ht \
-  --source eqtlgen
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/eqtlgen/ \
+  --output /data/eqtl_blood.ht \
+  --skip-download \
+  --plugin-arg source=eqtlgen
 
 # Allpairs for coloc (keep all p-values)
-hvantk mktable eqtl \
-  --raw-input /data/gtex_v11/allpairs/ \
-  --output-ht /data/eqtl_allpairs_liver.ht \
-  --source gtex_v11 \
-  --tissue Liver \
-  --p-threshold 0
+hvantk reprocess gtex-eqtl:eqtls \
+  --raw-dir /data/gtex_v11/allpairs/ \
+  --output /data/eqtl_allpairs_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_v11 \
+  --plugin-arg tissue=Liver \
+  --plugin-arg p_threshold=0
 ```
 
 ### pQTL Table
 
 ```bash
 # Fang et al. (2025) pQTL data
-hvantk mktable pqtl \
-  --raw-input /data/fang_pqtl/Liver_allpairs.txt.gz \
-  --output-ht /data/pqtl_liver.ht \
-  --source gtex_fang \
-  --tissue Liver \
-  --gene-map-ht /data/ensembl_gene.ht
+hvantk reprocess pqtl:metrics \
+  --raw-dir /data/fang_pqtl/ \
+  --output /data/pqtl_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_fang \
+  --plugin-arg tissue=Liver \
+  --plugin-arg hgnc_ht=/data/ensembl_gene.ht
 
-# Allpairs for coloc (omit --p-threshold to keep all pairs)
-hvantk mktable pqtl \
-  --raw-input /data/fang_pqtl/Liver_allpairs.txt.gz \
-  --output-ht /data/pqtl_allpairs_liver.ht \
-  --source gtex_fang \
-  --tissue Liver \
-  --gene-map-ht /data/ensembl_gene.ht
+# Allpairs for coloc (omit p_threshold to keep all pairs)
+hvantk reprocess pqtl:metrics \
+  --raw-dir /data/fang_pqtl/ \
+  --output /data/pqtl_allpairs_liver.ht \
+  --skip-download \
+  --plugin-arg source=gtex_fang \
+  --plugin-arg tissue=Liver \
+  --plugin-arg hgnc_ht=/data/ensembl_gene.ht
 ```
 
-> **Note:** Fang pQTL data uses gene symbols. The `--gene-map-ht` option provides a reverse-index table (keyed by `gene_id` with `gene_name` field) for symbol → Ensembl ID mapping. Use the Ensembl gene table built with `hvantk mktable ensembl-gene`.
+> **Note:** Fang pQTL data uses gene symbols. The `hgnc_ht` plugin-arg provides a lookup table (keyed by `gene_id` with `gene_name` field) for symbol → Ensembl ID mapping. Use the Ensembl gene table built with `hvantk reprocess ensembl-gene:genes`.
 
 ## Module Structure
 

--- a/hvantk/tests/test_dependency_directions.py
+++ b/hvantk/tests/test_dependency_directions.py
@@ -1,9 +1,12 @@
-"""Assert that hvantk's four-package layout (core / algorithms / skills / tools)
-honors the one-way dependency rule documented in the design spec:
+"""Assert that hvantk's five-package layout honors the one-way dependency rule:
 
     skills/      ----+
-                     +-->  algorithms/  -->  core/
+                     +-->  algorithms/  -->  core/, resources/
     tools/       ----+
+
+core/ and resources/ are both substrate -- consumed by the code layers above,
+neither imports upward. resources/ holds the data-catalog registry, JSON
+schemas, and the validator/aggregator that operate on them.
 
 Implementation note: each layer-pair is checked independently and gated with
 xfail until the corresponding migration phase fixes the violations. Phases
@@ -66,6 +69,20 @@ def test_algorithms_does_not_import_skills_or_tools():
     bad = _forbidden_matches("algorithms", ["hvantk.skills", "hvantk.tools"])
     assert not bad, (
         "algorithms/ must not import from skills/ or tools/. Offenders:\n"
+        + "\n".join(f"  {p.relative_to(PACKAGE_ROOT)} -> {d}" for p, d in bad)
+    )
+
+
+def test_resources_does_not_import_upward():
+    """resources/ is substrate -- a peer of core/. It must not import from the
+    code layers above it (algorithms/, skills/, tools/). Codifies the
+    placement decision recorded in docs_site/architecture.md."""
+    bad = _forbidden_matches(
+        "resources", ["hvantk.algorithms", "hvantk.skills", "hvantk.tools"]
+    )
+    assert not bad, (
+        "resources/ must not import from algorithms/, skills/, or tools/. "
+        "Offenders:\n"
         + "\n".join(f"  {p.relative_to(PACKAGE_ROOT)} -> {d}" for p, d in bad)
     )
 

--- a/hvantk/tests/test_reprocess_cli.py
+++ b/hvantk/tests/test_reprocess_cli.py
@@ -336,14 +336,16 @@ def test_reprocess_plugin_arg_forwarded_to_download_and_parse(
         ],
     )
     assert result.exit_code == 0, result.output
+    # --plugin-arg values are coerced: 'true'/'false' -> bool, numeric strings
+    # -> int/float. 'brca' stays str because it matches no other type.
     download.assert_called_once_with(
-        raw_dir=str(raw), cancer_type="brca", overwrite="true"
+        raw_dir=str(raw), cancer_type="brca", overwrite=True
     )
     parse.assert_called_once_with(
         raw_dir=str(raw),
         output_path=str(intermediate),
         cancer_type="brca",
-        overwrite="true",
+        overwrite=True,
     )
 
 
@@ -378,15 +380,22 @@ def test_reprocess_phase_b_plugin_uses_run_builder_for_spec(
     tmp_path: Path, monkeypatch
 ):
     """A spec with artifact_type set should route through run_builder_for_spec
-    (which uses BuildContext), not the legacy spec.builder(input, output) shape."""
+    (which uses BuildContext), not the legacy spec.builder(input, output) shape.
+
+    Also guards that --plugin-arg values reach the Phase B builder with type
+    coercion applied — regressing this would silently drop build-time params
+    (reference_genome, p_threshold, tissue, ...) and break the deep-dive docs.
+    """
     import pandas as pd
     from hvantk.core.models import AnnotationTable, BuildContext
 
     # Real Phase B-style builder accepting (parsed, ctx, **params)
     captured_ctx: dict = {}
+    captured_params: dict = {}
 
     def phase_b_builder(parsed, ctx, **params):
         captured_ctx["ctx"] = ctx
+        captured_params.update(params)
         df = pd.DataFrame({"x": [1, 2, 3]})
         return AnnotationTable.from_pandas(
             df, provenance=ctx.provenance(schema_id="test-rows-v1")
@@ -413,6 +422,12 @@ def test_reprocess_phase_b_plugin_uses_run_builder_for_spec(
             "--output",
             str(output),
             "--skip-download",
+            "--plugin-arg",
+            "reference_genome=GRCh38",
+            "--plugin-arg",
+            "p_threshold=5e-8",
+            "--plugin-arg",
+            "overwrite=false",
             "--no-check-drift",
         ],
     )
@@ -421,6 +436,10 @@ def test_reprocess_phase_b_plugin_uses_run_builder_for_spec(
     # Confirm the builder got a real BuildContext (not a string)
     assert isinstance(captured_ctx["ctx"], BuildContext)
     assert captured_ctx["ctx"].source_fingerprint  # nonempty
+    # Confirm --plugin-arg values reached the Phase B builder with coercion
+    assert captured_params["reference_genome"] == "GRCh38"
+    assert captured_params["p_threshold"] == 5e-8
+    assert captured_params["overwrite"] is False
     # Confirm the artifact was saved (file exists + sidecar manifest exists)
     assert output.exists()
     assert output.with_name(output.name + ".provenance.json").exists()

--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -8,9 +8,16 @@ with the `--skip-*` flags.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 import click
+
+
+_INT_RE = re.compile(r"^-?\d+$")
+_FLOAT_RE = re.compile(
+    r"^-?(\d+\.\d*([eE][+-]?\d+)?|\.\d+([eE][+-]?\d+)?|\d+[eE][+-]?\d+)$"
+)
 
 
 def _coerce_plugin_arg_value(value: str) -> Any:
@@ -21,20 +28,20 @@ def _coerce_plugin_arg_value(value: str) -> Any:
     values — e.g. ``overwrite=false`` arrives as the truthy string ``"false"``,
     and ``p_threshold=5e-8`` arrives as the string ``"5e-8"`` which breaks
     numeric comparisons.
+
+    Pattern matching is used (rather than ``try/except ValueError``) so that
+    the function has a single exit path per branch and does not swallow
+    exceptions silently.
     """
     low = value.lower()
     if low == "true":
         return True
     if low == "false":
         return False
-    try:
+    if _INT_RE.match(value):
         return int(value)
-    except ValueError:
-        pass
-    try:
+    if _FLOAT_RE.match(value):
         return float(value)
-    except ValueError:
-        pass
     return value
 
 

--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -8,8 +8,34 @@ with the `--skip-*` flags.
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
+
+
+def _coerce_plugin_arg_value(value: str) -> Any:
+    """Coerce a --plugin-arg string to bool / int / float when it matches.
+
+    Order: bool (``true``/``false``, case-insensitive) -> int -> float -> str.
+    Without coercion, builders that declare typed kwargs receive surprising
+    values — e.g. ``overwrite=false`` arrives as the truthy string ``"false"``,
+    and ``p_threshold=5e-8`` arrives as the string ``"5e-8"`` which breaks
+    numeric comparisons.
+    """
+    low = value.lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
 
 
 @click.command(name="reprocess")
@@ -42,9 +68,11 @@ import click
     multiple=True,
     metavar="KEY=VALUE",
     help=(
-        "Plugin-specific kwarg forwarded to the lifecycle download and parse "
-        "functions (e.g. --plugin-arg cancer_type=brca for cptac:phospho). "
-        "Repeatable. Values are passed as strings; plugins coerce as needed."
+        "Plugin-specific kwarg forwarded to the lifecycle download, parse, "
+        "and Phase B build stages (e.g. --plugin-arg cancer_type=brca for "
+        "cptac:phospho, --plugin-arg reference_genome=GRCh38 for clinvar). "
+        "Repeatable. Values are coerced: 'true'/'false' -> bool, integer "
+        "strings -> int, decimal/scientific -> float, otherwise str."
     ),
 )
 @click.option(
@@ -79,10 +107,12 @@ def reprocess_cmd(
     except KeyError:
         raise click.ClickException(f"unknown dataset: {dataset}")
 
-    # Parse --plugin-arg KEY=VALUE pairs into a kwargs dict forwarded to both
-    # download_fn and parse_fn. Lets operators target plugin-specific options
-    # (e.g. cancer_type for cptac:phospho) without per-plugin reprocess flags.
-    extras: dict[str, str] = {}
+    # Parse --plugin-arg KEY=VALUE pairs into a kwargs dict forwarded to
+    # download_fn, parse_fn, and the Phase B builder. Lets operators target
+    # plugin-specific options (e.g. cancer_type for cptac:phospho,
+    # reference_genome for clinvar, p_threshold for gtex-eqtl) without
+    # per-plugin reprocess flags.
+    extras: dict[str, Any] = {}
     for kv in plugin_args:
         if "=" not in kv:
             raise click.UsageError(
@@ -93,7 +123,7 @@ def reprocess_cmd(
             raise click.UsageError(
                 f"--plugin-arg key must be non-empty; got: {kv!r}"
             )
-        extras[key] = value
+        extras[key] = _coerce_plugin_arg_value(value)
 
     # 1. Download stage
     if not skip_download:
@@ -141,6 +171,7 @@ def reprocess_cmd(
                 parsed_input=parsed_path,
                 output_path=Path(output),
                 plugin_version=spec.plugin_version or "<unknown>",
+                **extras,
             )
 
     # 4. Optional drift check


### PR DESCRIPTION
## Summary

Pre-merge polish on `dev` for the upcoming `dev → main` merge. Closes two of the four follow-up issues from the PR #109 / #110 plugin-system refactor.

### `#113` — Refresh deep-dive docs to `hvantk reprocess` syntax

While walking the doc rewrites I found a gap: `hvantk/tools/plugins/reprocess_cli.py` only forwarded `--plugin-arg` extras to download and parse, dropping them at the Phase B build call. Build-time params (`reference_genome`, `source`, `tissue`, `p_threshold`, ...) never reached the builder — so the QTL / dbNSFP examples in #113 would not have run as written.

Fixed alongside the docs:

* **`hvantk/tools/plugins/reprocess_cli.py`** — forward `**extras` to `run_builder_for_spec`; coerce `'true'`/`'false'` → `bool` and numeric strings → `int`/`float` so typed builder kwargs work without per-builder casts.
* **8 doc pages** translated to `hvantk reprocess <plugin>:<dataset>` form: `docs_site/guide/{data-sources,usage}.md`, `docs_site/tools/{qtlcascade,psroc}.md`, `docs_site/examples/{qtlcascade,clinvar,clingen,ptm}.md`.
* Dropped `--auto-convert-bgz` references (the flag was specific to the retired CLIs) and the stale-page banners that PR #110 left in.

### `#111` — `hvantk/resources/` placement

Decision: **peer of `core/`**, not a fifth code layer. Both are substrate; neither imports upward.

* **`docs_site/architecture.md`** — five-package layout described; Resources Module section gets a placement-rule table (`registry/` vs. `schemas/` vs. `unified_registry.py` vs. per-plugin `skills/<provider>/catalog/datasets.json`) and the dependency direction.
* **`README.md`** — matching one-line summary + SVG alt text.
* **`hvantk/tests/test_dependency_directions.py`** — `test_resources_does_not_import_upward` codifies the rule. Passes today (`resources/` imports zero `hvantk.*` modules).

## Test plan

- [x] `poetry run pytest hvantk/tests/test_reprocess_cli.py` — 11/11 pass; the Phase B test now asserts `--plugin-arg` values reach the builder with coercion applied
- [x] `poetry run pytest hvantk/tests/test_dependency_directions.py` — 4/4 pass (3 existing + new `test_resources_does_not_import_upward`)
- [x] `grep -rn 'mktable\|mkmatrix\|auto-convert-bgz' docs_site/ README.md` returns only the intentional migration note in `usage.md:5`
- [ ] Verify docs render cleanly in Mintlify preview

## Out of scope (post-merge follow-ups)

- `#112` — fresh-agent plugin-author UX validation (pure validation exercise, no code change)
- `#114` — programmatic build API + Phase A retirement (multi-PR, design memo first)

After these issues are resolved, `dev` should be in shape for the `dev → main` merge alongside a small housekeeping PR (prune `/private/tmp/hvantk-pr109` worktree, decide `incomplete-features-backup` branch, optionally drop the deprecated enrichex aliases).