### PR TITLE
fix(#119): coerce comma-separated --plugin-arg values to list

### DIFF
--- a/hvantk/tests/test_reprocess_cli.py
+++ b/hvantk/tests/test_reprocess_cli.py
@@ -443,3 +443,30 @@ def test_reprocess_phase_b_plugin_uses_run_builder_for_spec(
     # Confirm the artifact was saved (file exists + sidecar manifest exists)
     assert output.exists()
     assert output.with_name(output.name + ".provenance.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #119: comma-list coercion in _coerce_plugin_arg_value
+# ---------------------------------------------------------------------------
+
+from hvantk.tools.plugins.reprocess_cli import _coerce_plugin_arg_value  # noqa: E402
+
+
+def test_coerce_plugin_arg_value_splits_comma_list():
+    assert _coerce_plugin_arg_value("chr1,chr2,chrX") == ["chr1", "chr2", "chrX"]
+
+
+def test_coerce_plugin_arg_value_coerces_each_list_element():
+    assert _coerce_plugin_arg_value("1,2,3") == [1, 2, 3]
+    assert _coerce_plugin_arg_value("true,false") == [True, False]
+
+
+def test_coerce_plugin_arg_value_scalar_paths_unchanged():
+    assert _coerce_plugin_arg_value("true") is True
+    assert _coerce_plugin_arg_value("42") == 42
+    assert _coerce_plugin_arg_value("5e-8") == 5e-8
+    assert _coerce_plugin_arg_value("plain") == "plain"
+
+
+def test_coerce_plugin_arg_value_strips_whitespace_in_list():
+    assert _coerce_plugin_arg_value("chr1, chr2 , chrX") == ["chr1", "chr2", "chrX"]

--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -33,6 +33,19 @@ def _coerce_plugin_arg_value(value: str) -> Any:
     the function has a single exit path per branch and does not swallow
     exceptions silently.
     """
+    # List coercion: if the raw value contains a comma, treat it as a
+    # comma-separated list and recursively coerce each element. Builders
+    # that declare list-typed params (e.g. chromosomes: list[str]) thus
+    # receive a real list instead of the literal "chr1,chr2,chrX" string.
+    # Trade-off: a single element containing a comma cannot be expressed
+    # via --plugin-arg under this scheme; in practice plugin args don't
+    # carry commas in single values (issue #119, Option A).
+    if "," in value:
+        return [
+            _coerce_plugin_arg_value(part.strip())
+            for part in value.split(",")
+            if part.strip()
+        ]
     low = value.lower()
     if low == "true":
         return True


### PR DESCRIPTION
## Summary
- `_coerce_plugin_arg_value` now splits on `,`, strips each element, and recursively coerces.
- Added focused regression tests in `hvantk/tests/test_reprocess_cli.py`.

Closes #119.

## Test plan
- flake8 (E9/F63/F7/F82): pass
- pytest -q: pass
- pytest hvantk/tests/test_reprocess_cli.py: pass