### PR TITLE
fix(#123): make --output_ht required in annotate_features

### DIFF
--- a/hvantk/tests/test_annotate_features_cli.py
+++ b/hvantk/tests/test_annotate_features_cli.py
@@ -1,0 +1,24 @@
+"""Regression: --output_ht must be required (issue #123)."""
+import subprocess
+import sys
+
+
+def test_output_ht_is_required():
+    """The CLI must fail with a non-zero exit when --output_ht is omitted.
+
+    Prior to #123 the default was the literal string ``"None/data/features"``,
+    silently producing an oddly-named directory in the working tree.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "hvantk.tools.annotation.annotate_features",
+         "--variant_ht", "/tmp/does-not-matter.ht"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, (
+        "annotate_features should fail without --output_ht; "
+        f"got returncode={result.returncode}, stderr={result.stderr!r}"
+    )
+    assert "output_ht" in result.stderr.lower() or "required" in result.stderr.lower(), (
+        f"Expected argparse to complain about --output_ht; stderr was: {result.stderr!r}"
+    )

--- a/hvantk/tools/annotation/annotate_features.py
+++ b/hvantk/tools/annotation/annotate_features.py
@@ -27,9 +27,6 @@ from hvantk.algorithms.annotation.annotate import (
     annotate_hca,
 )
 
-project_dir = None
-out_path = f"{project_dir}/data/features"
-
 """
 Annotate variant table with features from multiple sources.
 
@@ -155,7 +152,7 @@ if __name__ == "__main__":
         "--output_ht",
         help="Path to output HailTable with features annotations",
         type=str,
-        default=out_path,
+        required=True,
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Deleted the `project_dir = None` / `out_path` lines that produced the literal "None/data/features" default.
- Made `--output_ht` `required=True` in the argparse parser.
- Added a regression test (`hvantk/tests/test_annotate_features_cli.py`) that exec's the CLI without `--output_ht` and asserts a non-zero exit.

Closes #123.

## Test plan
- flake8 (E9/F63/F7/F82): pass
- pytest hvantk/tests/test_annotate_features_cli.py: pass
- pytest -q: pass (modulo 12 pre-existing collection errors in drift-probe tests from missing requests_mock in local env; identical count before/after)