### PR TITLE
refactor(#120): move ENSEMBL_BIOMART_FIELDS to skills/ensembl_gene/shared/constants.py

### DIFF
--- a/docs_site/guide/data-sources.md
+++ b/docs_site/guide/data-sources.md
@@ -194,7 +194,7 @@ hvantk reprocess insider:variants \
 Ensembl gene annotations (gene name, gene ID, biotype, transcript ID).
 URL: https://www.ensembl.org/info/data/ftp/index.html
 
-**Download**: Export from BioMart with the required attributes matching `ENSEMBL_BIOMART_FIELDS` in `hvantk/core/constants.py`. Alternatively, download from the Ensembl FTP:
+**Download**: Export from BioMart with the required attributes matching `ENSEMBL_BIOMART_FIELDS` in `hvantk/skills/ensembl_gene/shared/constants.py`. Alternatively, download from the Ensembl FTP:
 https://www.ensembl.org/info/data/ftp/index.html
 
 **Build**:

--- a/hvantk/core/constants.py
+++ b/hvantk/core/constants.py
@@ -9,21 +9,6 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent
 logger.debug(f"Base directory: {BASE_DIR}")
 
-## Ensembl/biomart constants
-ENSEMBL_BIOMART_FIELDS = {
-    "Gene stable ID": "gene_id",
-    "Transcript stable ID": "transcript_id",
-    "Protein stable ID": "protein_id",
-    "Chromosome/scaffold name": "chromosome",
-    "Gene start (bp)": "gene_start",
-    "Gene end (bp)": "gene_end",
-    "Ensembl Canonical": "canonical",
-    "Gene name": "gene_name",
-    "Gene type": "gene_type",
-    "Gene Synonym": "gene_synonym",
-}
-logger.debug(f"Ensembl biomart fields: {ENSEMBL_BIOMART_FIELDS}")
-
 ## UCSC Cell Browser base URL
 UCSC_CELL_BROWSER_BASE_URL = "https://cells.ucsc.edu"
 logger.debug(f"UCSC Cell Browser base URL: {UCSC_CELL_BROWSER_BASE_URL}")
@@ -249,7 +234,6 @@ ALPHAGENOME_DEFAULT_REQUEST_TIMEOUT = 120
 # Explicit public API for this module
 __all__ = [
     "BASE_DIR",
-    "ENSEMBL_BIOMART_FIELDS",
     "UCSC_CELL_BROWSER_BASE_URL",
     "EXPRESSION_MATRIX_FILE_NAME",
     "METADATA_FILE_NAME",

--- a/hvantk/skills/ensembl_gene/builder.py
+++ b/hvantk/skills/ensembl_gene/builder.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import hail as hl
 
-from hvantk.core.constants import ENSEMBL_BIOMART_FIELDS
+from hvantk.skills.ensembl_gene.shared.constants import ENSEMBL_BIOMART_FIELDS
 
 logger = logging.getLogger(__name__)
 

--- a/hvantk/skills/ensembl_gene/shared/constants.py
+++ b/hvantk/skills/ensembl_gene/shared/constants.py
@@ -1,0 +1,18 @@
+"""Plugin-local constants for the ensembl_gene skill.
+
+Moved from hvantk/core/constants.py per issue #120 (clean-core principle).
+"""
+
+# Ensembl/biomart field-rename map: BioMart export column name -> snake_case
+ENSEMBL_BIOMART_FIELDS = {
+    "Gene stable ID": "gene_id",
+    "Transcript stable ID": "transcript_id",
+    "Protein stable ID": "protein_id",
+    "Chromosome/scaffold name": "chromosome",
+    "Gene start (bp)": "gene_start",
+    "Gene end (bp)": "gene_end",
+    "Ensembl Canonical": "canonical",
+    "Gene name": "gene_name",
+    "Gene type": "gene_type",
+    "Gene Synonym": "gene_synonym",
+}


### PR DESCRIPTION
## Summary
- Moved `ENSEMBL_BIOMART_FIELDS` from `hvantk/core/constants.py` to `hvantk/skills/ensembl_gene/shared/constants.py`.
- Created the `shared/` subdirectory (matching the convention used by 8 sibling plugins).
- Dropped the module-import `logger.debug` dump of the dict (debug noise, not load-bearing).
- Updated the lone external consumer (`skills/ensembl_gene/builder.py`) and the user-facing docs reference.

Closes #120 (one of several PRs).

## Test plan
- flake8 (E9/F63/F7/F82): pass
- pytest -q: pass (modulo 12 pre-existing collection errors in drift-probe tests from missing requests_mock in local env; identical count before/after)