### PR TITLE
refactor(#120): move Expression Atlas constants out, drop dead registry paths

### DIFF
--- a/hvantk/core/constants.py
+++ b/hvantk/core/constants.py
@@ -9,25 +9,6 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent
 logger.debug(f"Base directory: {BASE_DIR}")
 
-## Expression Atlas base URL
-EXPRESSION_ATLAS_BASE_URL = "https://www.ebi.ac.uk/gxa/experiments-content"
-logger.debug(f"Expression Atlas base URL: {EXPRESSION_ATLAS_BASE_URL}")
-
-# Path to the new unified registry system
-REGISTRY_ROOT_PATH = BASE_DIR.parent / "resources" / "registry"
-
-# Backward compatibility - path to transcriptomics datasets (replaces expression_atlas.json)
-TRANSCRIPTOMICS_DATASETS_PATH = REGISTRY_ROOT_PATH / "transcriptomics" / "datasets.json"
-
-# Legacy path for compatibility (deprecated)
-EXPRESSION_ATLAS_JSON_FILE_PATH = (
-    BASE_DIR.parent / "resources" / "expression_atlas.json"
-)
-
-logger.debug(f"Registry root path: {REGISTRY_ROOT_PATH}")
-logger.debug(f"Transcriptomics datasets path: {TRANSCRIPTOMICS_DATASETS_PATH}")
-logger.debug(f"Legacy Expression Atlas path: {EXPRESSION_ATLAS_JSON_FILE_PATH}")
-
 # ClinGen Gene-Disease Validity
 CLINGEN_DOWNLOADS_URL = "https://search.clinicalgenome.org/kb/downloads"
 CLINGEN_BASE_URL = "https://search.clinicalgenome.org/kb/gene-validity/download"
@@ -218,10 +199,6 @@ ALPHAGENOME_DEFAULT_REQUEST_TIMEOUT = 120
 # Explicit public API for this module
 __all__ = [
     "BASE_DIR",
-    "EXPRESSION_ATLAS_BASE_URL",
-    "REGISTRY_ROOT_PATH",
-    "TRANSCRIPTOMICS_DATASETS_PATH",
-    "EXPRESSION_ATLAS_JSON_FILE_PATH",  # Backward compatibility
     "CLINGEN_DOWNLOADS_URL",
     "CLINGEN_BASE_URL",
     "CLINGEN_FILE_PREFIX",

--- a/hvantk/skills/expression_atlas/SKILL.md
+++ b/hvantk/skills/expression_atlas/SKILL.md
@@ -20,7 +20,7 @@ Read `hvantk/skills/_conventions/SKILL.md` first. This skill assumes every conve
 
 - **Provider:** EBI Expression Atlas (<https://www.ebi.ac.uk/gxa>).
 - **Catalog entry:** the per-accession dataset list lives in `hvantk/skills/expression_atlas/catalog/datasets.json` (filterable via `data_source == "Expression_Atlas"`). Browse with `hvantk catalog list --data-source Expression_Atlas` or `hvantk catalog show E-GTEX-8`. A top-level `expression-atlas` provider-level catalog entry remains a TODO; when added, point the plugin manifest's `source.catalog_ref` at it and remove this note.
-- Per-accession download URLs derive from `EXPRESSION_ATLAS_BASE_URL` in `hvantk/core/constants.py` and the FTP prefix `/pub/databases/microarray/data/atlas/experiments/<accession>/`.
+- Per-accession download URLs derive from `EXPRESSION_ATLAS_BASE_URL` in `hvantk/skills/expression_atlas/shared/constants.py` and the FTP prefix `/pub/databases/microarray/data/atlas/experiments/<accession>/`.
 
 ## 3. Backend choice + reasoning
 

--- a/hvantk/skills/expression_atlas/cli.py
+++ b/hvantk/skills/expression_atlas/cli.py
@@ -24,7 +24,7 @@ from tqdm import tqdm
 from hvantk.skills.expression_atlas.shared.datasets import (
     ExpressionAtlasDatasetCollection,
 )
-from hvantk.core.constants import EXPRESSION_ATLAS_JSON_FILE_PATH
+from hvantk.skills.expression_atlas.shared.constants import EXPRESSION_ATLAS_JSON_FILE_PATH
 
 logger = logging.getLogger(__name__)
 

--- a/hvantk/skills/expression_atlas/shared/constants.py
+++ b/hvantk/skills/expression_atlas/shared/constants.py
@@ -1,0 +1,14 @@
+"""Plugin-local constants for the expression_atlas skill.
+
+Moved from hvantk/core/constants.py per issue #120 (clean-core principle).
+"""
+from pathlib import Path
+
+# Base directory of the hvantk package (used to compute legacy JSON path).
+_PACKAGE_DIR = Path(__file__).resolve().parents[3]
+
+# Expression Atlas base URL
+EXPRESSION_ATLAS_BASE_URL = "https://www.ebi.ac.uk/gxa/experiments-content"
+
+# Legacy path for compatibility (deprecated): resources/expression_atlas.json
+EXPRESSION_ATLAS_JSON_FILE_PATH = _PACKAGE_DIR / "resources" / "expression_atlas.json"

--- a/hvantk/skills/expression_atlas/shared/datasets.py
+++ b/hvantk/skills/expression_atlas/shared/datasets.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 logger = logging.getLogger(__name__)
 
 from hvantk.core.utils.file_utils import download_file
-from hvantk.core.constants import EXPRESSION_ATLAS_BASE_URL
+from hvantk.skills.expression_atlas.shared.constants import EXPRESSION_ATLAS_BASE_URL
 
 
 @dataclass

--- a/hvantk/tests/test_expression_dataset_collection.py
+++ b/hvantk/tests/test_expression_dataset_collection.py
@@ -4,7 +4,7 @@ from hvantk.skills.expression_atlas.shared.datasets import (
     ExpressionAtlasDatasetCollection,
     ExpressionAtlasDataset,
 )
-from hvantk.core.constants import EXPRESSION_ATLAS_JSON_FILE_PATH
+from hvantk.skills.expression_atlas.shared.constants import EXPRESSION_ATLAS_JSON_FILE_PATH
 
 
 def test_from_json_creates_dataset_objects(tmp_path):


### PR DESCRIPTION
## Summary
- Moved `EXPRESSION_ATLAS_BASE_URL` and `EXPRESSION_ATLAS_JSON_FILE_PATH` from `hvantk/core/constants.py` to `hvantk/skills/expression_atlas/shared/constants.py`.
- **Deleted** `REGISTRY_ROOT_PATH` and `TRANSCRIPTOMICS_DATASETS_PATH` as dead code — orphan platform-registry placeholders with zero external consumers. User confirmed no in-flight branches depend on them.
- Re-expressed `EXPRESSION_ATLAS_JSON_FILE_PATH` via `parents[3]` resolution (same final target: `hvantk/resources/expression_atlas.json`).
- Dropped 4 `logger.debug` module-import dumps.
- Updated 3 Python consumers (`shared/datasets.py`, `cli.py`, `tests/test_expression_dataset_collection.py`) and the `SKILL.md` path reference.

Closes #120 (one of several PRs).

## Test plan
- flake8 (E9/F63/F7/F82): pass
- pytest -q: pass (12 pre-existing collection errors unchanged; no new failures)
- pytest hvantk/skills/expression_atlas/ hvantk/tests/test_expression_dataset_collection.py: pass