### PR TITLE
refactor(#120): move clingen/gencc/cosmic-cgc constants to per-plugin shared/constants.py

### DIFF
--- a/hvantk/core/constants.py
+++ b/hvantk/core/constants.py
@@ -9,112 +9,6 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent
 logger.debug(f"Base directory: {BASE_DIR}")
 
-# ClinGen Gene-Disease Validity
-CLINGEN_DOWNLOADS_URL = "https://search.clinicalgenome.org/kb/downloads"
-CLINGEN_BASE_URL = "https://search.clinicalgenome.org/kb/gene-validity/download"
-CLINGEN_FILE_PREFIX = "Clingen-Gene-Disease-Summary"
-CLINGEN_HEADER_SKIP_LINES = 6
-
-CLINGEN_GENE_DISEASE_FIELDS = {
-    "GENE SYMBOL": "gene_symbol",
-    "GENE ID (HGNC)": "hgnc_id",
-    "DISEASE LABEL": "disease_label",
-    "DISEASE ID (MONDO)": "mondo_id",
-    "MOI": "mode_of_inheritance",
-    "SOP": "sop_version",
-    "CLASSIFICATION": "classification",
-    "ONLINE REPORT": "report_url",
-    "CLASSIFICATION DATE": "classification_date",
-    "GCEP": "gene_curation_expert_panel",
-}
-
-CLINGEN_CLASSIFICATION_LEVELS = [
-    "Definitive",
-    "Strong",
-    "Moderate",
-    "Limited",
-    "Disputed",
-    "Refuted",
-    "No Known Disease Relationship",
-]
-
-logger.debug(f"ClinGen base URL: {CLINGEN_BASE_URL}")
-
-# GenCC (Gene Curation Coalition)
-GENCC_BASE_URL = (
-    "https://thegencc.org/download/action/submissions-export-tsv?format=new"
-)
-GENCC_FILE_PREFIX = "gencc-submissions"
-
-GENCC_SUBMISSION_FIELDS = {
-    "sgc_id": "sgc_id",
-    "gene_curie": "hgnc_id",
-    "gene_symbol": "gene_symbol",
-    "disease_curie": "mondo_id",
-    "disease_title": "disease_label",
-    "disease_original_curie": "disease_original_id",
-    "disease_original_title": "disease_original_label",
-    "classification_title": "classification",
-    "moi_title": "mode_of_inheritance",
-    "submitter_title": "submitter",
-    "submitted_as_date": "submission_date",
-    "submitted_as_public_report_url": "report_url",
-    "submitted_as_pmids": "pmids",
-}
-
-GENCC_CLASSIFICATION_LEVELS = [
-    "Definitive",
-    "Strong",
-    "Moderate",
-    "Supportive",
-    "Limited",
-    "Disputed Evidence",
-    "Refuted Evidence",
-    "No Known Disease Relationship",
-]
-
-logger.debug(f"GenCC base URL: {GENCC_BASE_URL}")
-
-# COSMIC Cancer Gene Census (CGC)
-COSMIC_CGC_FILE_PREFIX = "cosmic-cgc"
-
-COSMIC_CGC_FIELDS = {
-    "Gene Symbol": "gene_symbol",
-    "Name": "gene_name",
-    "Entrez GeneId": "entrez_id",
-    "Genome Location": "genome_location",
-    "Tier": "classification",
-    "Hallmark": "hallmark",
-    "Chr Band": "chr_band",
-    "Somatic": "somatic",
-    "Germline": "germline",
-    "Tumour Types(Somatic)": "tumour_types_somatic",
-    "Tumour Types(Germline)": "tumour_types_germline",
-    "Cancer Syndrome": "cancer_syndrome",
-    "Tissue Type": "tissue_type",
-    "Molecular Genetics": "molecular_genetics",
-    "Role in Cancer": "role_in_cancer",
-    "Mutation Types": "mutation_types",
-    "Translocation Partner": "translocation_partner",
-    "Other Germline Mut": "other_germline_mut",
-    "Other Syndrome": "other_syndrome",
-    "Synonyms": "synonyms",
-}
-
-COSMIC_CGC_CLASSIFICATION_LEVELS = [
-    "Tier 1",
-    "Tier 2",
-]
-
-COSMIC_TISSUE_TYPES = {
-    "E": "Epithelial",
-    "L": "Lymphoid",
-    "M": "Mesenchymal",
-    "O": "Other",
-}
-
-COSMIC_MUTATION_CONTEXTS = ["somatic", "germline", "both"]
-
 # HGNC Gene Nomenclature
 HGNC_DOWNLOAD_URL = "https://storage.googleapis.com/public-download-files/hgnc/tsv/tsv/hgnc_complete_set.txt"
 HGNC_INFO_URL = "https://www.genenames.org/download/statistics-and-files/"
@@ -199,25 +93,10 @@ ALPHAGENOME_DEFAULT_REQUEST_TIMEOUT = 120
 # Explicit public API for this module
 __all__ = [
     "BASE_DIR",
-    "CLINGEN_DOWNLOADS_URL",
-    "CLINGEN_BASE_URL",
-    "CLINGEN_FILE_PREFIX",
-    "CLINGEN_HEADER_SKIP_LINES",
-    "CLINGEN_GENE_DISEASE_FIELDS",
-    "CLINGEN_CLASSIFICATION_LEVELS",
     "HGNC_DOWNLOAD_URL",
     "HGNC_INFO_URL",
     "HGNC_GENE_FIELDS",
     "HGNC_PIPE_SEPARATED_FIELDS",
-    "GENCC_BASE_URL",
-    "GENCC_FILE_PREFIX",
-    "GENCC_SUBMISSION_FIELDS",
-    "GENCC_CLASSIFICATION_LEVELS",
-    "COSMIC_CGC_FILE_PREFIX",
-    "COSMIC_CGC_FIELDS",
-    "COSMIC_CGC_CLASSIFICATION_LEVELS",
-    "COSMIC_TISSUE_TYPES",
-    "COSMIC_MUTATION_CONTEXTS",
     "CLINVAR_FTP_BASE",
     "CLINVAR_FTP_BASE_GRCh37",
     "CLINVAR_PATHOGENIC_LABELS",

--- a/hvantk/skills/clingen/SKILL.md
+++ b/hvantk/skills/clingen/SKILL.md
@@ -16,7 +16,7 @@ This skill covers BUILD and UPDATE of the ClinGen Gene-Disease Validity Hail Tab
 
 ## 2. Source identity
 
-Provider metadata (URL, license, citation) lives in the plugin's `catalog/datasets.json` (or query it with `hvantk catalog show <accession>` once a ClinGen catalog entry exists). The URL/version constants live in `hvantk/core/constants.py` (`CLINGEN_BASE_URL`, `CLINGEN_DOWNLOADS_URL`, `CLINGEN_FILE_PREFIX`, `CLINGEN_HEADER_SKIP_LINES`). Read those files; do not restate.
+Provider metadata (URL, license, citation) lives in the plugin's `catalog/datasets.json` (or query it with `hvantk catalog show <accession>` once a ClinGen catalog entry exists). The URL/version constants live in `hvantk/skills/clingen/shared/constants.py` (`CLINGEN_BASE_URL`, `CLINGEN_DOWNLOADS_URL`, `CLINGEN_FILE_PREFIX`, `CLINGEN_HEADER_SKIP_LINES`). Read those files; do not restate.
 
 Stable provider notes the catalog will not capture:
 - ClinGen serves a single rolling Gene-Disease Validity CSV; there are no dated archives. Freshness is determined by the file's HTTP `Last-Modified` header (when present) and by the values in the leading metadata block.
@@ -31,7 +31,7 @@ Stable provider notes the catalog will not capture:
 - File: comma-separated, double-quoted fields, **6-line metadata header** before the column-header line (`CLINGEN_HEADER_SKIP_LINES = 6`). The column header begins with `"GENE SYMBOL"`. Separator rows containing `++++++` are interleaved with the metadata block.
 - Preprocessing: the builder streams the file via `hl.hadoop_open` and writes a cleaned temp CSV containing only the column header + data rows. This is required because `hl.import_table` cannot skip arbitrary leading metadata.
 - Import: `hl.import_table(delimiter=",", quote='"', impute=False, min_partitions=10)`. All fields stay as strings; no type inference.
-- Field renaming is driven by `CLINGEN_GENE_DISEASE_FIELDS` (`hvantk/core/constants.py`). Notable renames: `GENE SYMBOL → gene_symbol`, `GENE ID (HGNC) → hgnc_id`, `DISEASE LABEL → disease_label`, `DISEASE ID (MONDO) → mondo_id`, `MOI → mode_of_inheritance`, `CLASSIFICATION → classification`, `GCEP → gene_curation_expert_panel`.
+- Field renaming is driven by `CLINGEN_GENE_DISEASE_FIELDS` (`hvantk/skills/clingen/shared/constants.py`). Notable renames: `GENE SYMBOL → gene_symbol`, `GENE ID (HGNC) → hgnc_id`, `DISEASE LABEL → disease_label`, `DISEASE ID (MONDO) → mondo_id`, `MOI → mode_of_inheritance`, `CLASSIFICATION → classification`, `GCEP → gene_curation_expert_panel`.
 - ID prefix stripping: the builder strips the `HGNC:` and `MONDO:` prefixes from `hgnc_id` and `mondo_id`. This is asymmetric with the HGNC table (which keeps the prefix); downstream joins (e.g., `clingen_streamer`) account for this.
 - Classification levels (`CLINGEN_CLASSIFICATION_LEVELS`, strongest first): `Definitive`, `Strong`, `Moderate`, `Limited`, `Disputed`, `Refuted`. The builder annotates `classification_level` as the numeric position (lower is stronger). Unknown values get `len(CLINGEN_CLASSIFICATION_LEVELS)` and are clamped to the last valid index in the gene-aggregation branch.
 - Keying: keyed by `(hgnc_id, mondo_id)`.
@@ -50,7 +50,7 @@ Row schema includes: `hgnc_id`, `gene_symbol`, `disease_label`, `mondo_id`, `mod
 - Dataset class: `ClinGenGeneDiseaseDataset` in `hvantk/skills/clingen/shared/datasets.py`.
 - Build CLI: `hvantk reprocess clingen:gene-disease --raw-dir <dir> --output <path>.ht` (skip individual stages with `--skip-download` / `--skip-parse` / `--skip-build`; pass builder kwargs via `--plugin-arg key=value`, e.g. `--plugin-arg key_by=gene_disease --plugin-arg min_classification=Strong`).
 - Streamer (out-of-plugin, intentionally): `hvantk/data/clingen_streamer.py` (`ClinGenStreamer`, subclass of `GeneDiseaseValidityStreamer`); shared with the GenCC/gene-disease streamer family.
-- Constants: `CLINGEN_BASE_URL`, `CLINGEN_DOWNLOADS_URL`, `CLINGEN_FILE_PREFIX`, `CLINGEN_HEADER_SKIP_LINES`, `CLINGEN_GENE_DISEASE_FIELDS`, `CLINGEN_CLASSIFICATION_LEVELS` in `hvantk/core/constants.py`.
+- Constants: `CLINGEN_BASE_URL`, `CLINGEN_DOWNLOADS_URL`, `CLINGEN_FILE_PREFIX`, `CLINGEN_HEADER_SKIP_LINES`, `CLINGEN_GENE_DISEASE_FIELDS`, `CLINGEN_CLASSIFICATION_LEVELS` in `hvantk/skills/clingen/shared/constants.py`.
 - Tests: `hvantk/skills/clingen/tests/test_builder.py`, `test_downloader.py`, `test_drift_probe.py`. Streamer tests stay at `hvantk/tests/test_clingen_streamer.py` (test the unmoved streamer).
 
 ## 7. Workflow steps

--- a/hvantk/skills/clingen/builder.py
+++ b/hvantk/skills/clingen/builder.py
@@ -21,7 +21,7 @@ import logging
 
 import hail as hl
 
-from hvantk.core.constants import (
+from hvantk.skills.clingen.shared.constants import (
     CLINGEN_CLASSIFICATION_LEVELS,
     CLINGEN_GENE_DISEASE_FIELDS,
 )

--- a/hvantk/skills/clingen/drift_probe.py
+++ b/hvantk/skills/clingen/drift_probe.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 
 import requests
 
-from hvantk.core.constants import CLINGEN_BASE_URL, CLINGEN_FILE_PREFIX
+from hvantk.skills.clingen.shared.constants import CLINGEN_BASE_URL, CLINGEN_FILE_PREFIX
 from hvantk.core.plugin.api import DriftProbeError
 
 PROBE_VERSION = 1

--- a/hvantk/skills/clingen/shared/constants.py
+++ b/hvantk/skills/clingen/shared/constants.py
@@ -1,0 +1,35 @@
+"""Plugin-local constants for the clingen skill.
+
+Moved from hvantk/core/constants.py per issue #120 (clean-core principle).
+"""
+
+# URLs
+CLINGEN_DOWNLOADS_URL = "https://search.clinicalgenome.org/kb/downloads"
+CLINGEN_BASE_URL = "https://search.clinicalgenome.org/kb/gene-validity/download"
+CLINGEN_FILE_PREFIX = "Clingen-Gene-Disease-Summary"
+CLINGEN_HEADER_SKIP_LINES = 6
+
+# Field-rename map: source CSV column -> snake_case
+CLINGEN_GENE_DISEASE_FIELDS = {
+    "GENE SYMBOL": "gene_symbol",
+    "GENE ID (HGNC)": "hgnc_id",
+    "DISEASE LABEL": "disease_label",
+    "DISEASE ID (MONDO)": "mondo_id",
+    "MOI": "mode_of_inheritance",
+    "SOP": "sop_version",
+    "CLASSIFICATION": "classification",
+    "ONLINE REPORT": "report_url",
+    "CLASSIFICATION DATE": "classification_date",
+    "GCEP": "gene_curation_expert_panel",
+}
+
+# Classification levels (strongest first)
+CLINGEN_CLASSIFICATION_LEVELS = [
+    "Definitive",
+    "Strong",
+    "Moderate",
+    "Limited",
+    "Disputed",
+    "Refuted",
+    "No Known Disease Relationship",
+]

--- a/hvantk/skills/clingen/shared/datasets.py
+++ b/hvantk/skills/clingen/shared/datasets.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from hvantk.core.constants import (
+from hvantk.skills.clingen.shared.constants import (
     CLINGEN_BASE_URL,
     CLINGEN_FILE_PREFIX,
 )

--- a/hvantk/skills/clingen/streamer.py
+++ b/hvantk/skills/clingen/streamer.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 import hail as hl
 import pandas as pd
 
-from hvantk.core.constants import CLINGEN_CLASSIFICATION_LEVELS
+from hvantk.skills.clingen.shared.constants import CLINGEN_CLASSIFICATION_LEVELS
 from hvantk.core.utils.gene_disease_streamer import GeneDiseaseValidityStreamer
 
 logger = logging.getLogger(__name__)

--- a/hvantk/skills/clingen/tests/test_drift_probe.py
+++ b/hvantk/skills/clingen/tests/test_drift_probe.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import requests_mock
 
-from hvantk.core.constants import CLINGEN_BASE_URL, CLINGEN_FILE_PREFIX
+from hvantk.skills.clingen.shared.constants import CLINGEN_BASE_URL, CLINGEN_FILE_PREFIX
 from hvantk.skills.clingen.drift_probe import fetch_fingerprint
 
 

--- a/hvantk/skills/cosmic_cgc/builder.py
+++ b/hvantk/skills/cosmic_cgc/builder.py
@@ -11,7 +11,7 @@ from typing import Any, List, Optional
 
 import hail as hl
 
-from hvantk.core.constants import (
+from hvantk.skills.cosmic_cgc.shared.constants import (
     COSMIC_CGC_FIELDS,
     COSMIC_CGC_CLASSIFICATION_LEVELS,
     COSMIC_MUTATION_CONTEXTS,

--- a/hvantk/skills/cosmic_cgc/shared/constants.py
+++ b/hvantk/skills/cosmic_cgc/shared/constants.py
@@ -1,0 +1,44 @@
+"""Plugin-local constants for the cosmic_cgc skill.
+
+Moved from hvantk/core/constants.py per issue #120 (clean-core principle).
+"""
+
+COSMIC_CGC_FILE_PREFIX = "cosmic-cgc"
+
+# Field-rename map: source CSV column -> snake_case
+COSMIC_CGC_FIELDS = {
+    "Gene Symbol": "gene_symbol",
+    "Name": "gene_name",
+    "Entrez GeneId": "entrez_id",
+    "Genome Location": "genome_location",
+    "Tier": "classification",
+    "Hallmark": "hallmark",
+    "Chr Band": "chr_band",
+    "Somatic": "somatic",
+    "Germline": "germline",
+    "Tumour Types(Somatic)": "tumour_types_somatic",
+    "Tumour Types(Germline)": "tumour_types_germline",
+    "Cancer Syndrome": "cancer_syndrome",
+    "Tissue Type": "tissue_type",
+    "Molecular Genetics": "molecular_genetics",
+    "Role in Cancer": "role_in_cancer",
+    "Mutation Types": "mutation_types",
+    "Translocation Partner": "translocation_partner",
+    "Other Germline Mut": "other_germline_mut",
+    "Other Syndrome": "other_syndrome",
+    "Synonyms": "synonyms",
+}
+
+COSMIC_CGC_CLASSIFICATION_LEVELS = [
+    "Tier 1",
+    "Tier 2",
+]
+
+COSMIC_TISSUE_TYPES = {
+    "E": "Epithelial",
+    "L": "Lymphoid",
+    "M": "Mesenchymal",
+    "O": "Other",
+}
+
+COSMIC_MUTATION_CONTEXTS = ["somatic", "germline", "both"]

--- a/hvantk/skills/cosmic_cgc/streamer.py
+++ b/hvantk/skills/cosmic_cgc/streamer.py
@@ -15,7 +15,7 @@ from typing import Dict, Optional, Set
 import hail as hl
 import pandas as pd
 
-from hvantk.core.constants import (
+from hvantk.skills.cosmic_cgc.shared.constants import (
     COSMIC_CGC_CLASSIFICATION_LEVELS,
     COSMIC_MUTATION_CONTEXTS,
 )

--- a/hvantk/skills/gencc/SKILL.md
+++ b/hvantk/skills/gencc/SKILL.md
@@ -16,7 +16,7 @@ This skill covers BUILD and UPDATE of the GenCC Submissions Hail Table. It does 
 
 ## 2. Source identity
 
-Provider metadata (URL, license, citation) lives in the plugin's `catalog/datasets.json` (or query it with `hvantk catalog show <accession>` once a GenCC catalog entry exists). The URL/version constants live in `hvantk/core/constants.py` (`GENCC_BASE_URL`, `GENCC_FILE_PREFIX`). Read those files; do not restate.
+Provider metadata (URL, license, citation) lives in the plugin's `catalog/datasets.json` (or query it with `hvantk catalog show <accession>` once a GenCC catalog entry exists). The URL/version constants live in `hvantk/skills/gencc/shared/constants.py` (`GENCC_BASE_URL`, `GENCC_FILE_PREFIX`). Read those files; do not restate.
 
 Stable provider notes the catalog will not capture:
 - GenCC serves a single rolling submissions TSV; there are no dated archives. Freshness is determined by the file's HTTP `Last-Modified` header (when present) and by the `submitted_as_date` values in the body.
@@ -31,7 +31,7 @@ Stable provider notes the catalog will not capture:
 - File: tab-separated, optional double-quoted fields. The column header is the **first** non-blank line and begins with `sgc_id`. There is no metadata preamble (unlike ClinGen).
 - Preprocessing: handled inside the downloader (`sanitize_tsv` strips multiline quoted fields and blank lines). The builder itself calls `hl.import_table` directly on the sanitized TSV.
 - Import: `hl.import_table(delimiter="\t", impute=False, min_partitions=10)`. All fields stay as strings; no type inference.
-- Field renaming is driven by `GENCC_SUBMISSION_FIELDS` (`hvantk/core/constants.py`). Notable renames: `gene_curie → hgnc_id`, `gene_symbol → gene_symbol`, `disease_curie → mondo_id`, `disease_title → disease_label`, `classification_title → classification`, `moi_title → mode_of_inheritance`, `submitter_title → submitter`, `submitted_as_date → submission_date`, `submitted_as_public_report_url → report_url`, `submitted_as_pmids → pmids`.
+- Field renaming is driven by `GENCC_SUBMISSION_FIELDS` (`hvantk/skills/gencc/shared/constants.py`). Notable renames: `gene_curie → hgnc_id`, `gene_symbol → gene_symbol`, `disease_curie → mondo_id`, `disease_title → disease_label`, `classification_title → classification`, `moi_title → mode_of_inheritance`, `submitter_title → submitter`, `submitted_as_date → submission_date`, `submitted_as_public_report_url → report_url`, `submitted_as_pmids → pmids`.
 - ID prefix stripping: the builder strips the `HGNC:` and `MONDO:` prefixes from `hgnc_id` and `mondo_id` (asymmetric with HGNC, symmetric with ClinGen).
 - Classification levels (`GENCC_CLASSIFICATION_LEVELS`, strongest first): `Definitive`, `Strong`, `Moderate`, `Supportive`, `Limited`, `Disputed Evidence`, `Refuted Evidence`, `No Known Disease Relationship`. The builder annotates `classification_level` as the numeric position (lower is stronger); unknown values get `len(GENCC_CLASSIFICATION_LEVELS)` and are clamped to the last valid index in the aggregation branches.
 - Keying: default `key_by="gene_disease_submitter"` keys by `(hgnc_id, mondo_id, submitter)` (one row per submitter assertion). `key_by="gene_disease"` aggregates across submitters and re-derives `classification`/`classification_level` from `max_classification_level`. `key_by="gene"` aggregates all diseases per gene.
@@ -51,7 +51,7 @@ Row schema includes: `sgc_id`, `hgnc_id`, `gene_symbol`, `mondo_id`, `disease_la
 - Dataset class: `GenCCSubmissionsDataset` in `hvantk/skills/gencc/shared/datasets.py`.
 - Build CLI: `hvantk reprocess gencc:submissions --raw-dir <dir> --output <path>.ht` (skip individual stages with `--skip-download` / `--skip-parse` / `--skip-build`; pass builder kwargs via `--plugin-arg key=value`, e.g. `--plugin-arg min_classification=Strong`).
 - Streamer (out-of-plugin, intentionally): `hvantk/data/gencc_streamer.py` (`GenCCStreamer`, subclass of `GeneDiseaseValidityStreamer`); shared with the ClinGen/gene-disease streamer family. Re-exported through `hvantk/data/__init__.py`.
-- Constants: `GENCC_BASE_URL`, `GENCC_FILE_PREFIX`, `GENCC_SUBMISSION_FIELDS`, `GENCC_CLASSIFICATION_LEVELS` in `hvantk/core/constants.py`.
+- Constants: `GENCC_BASE_URL`, `GENCC_FILE_PREFIX`, `GENCC_SUBMISSION_FIELDS`, `GENCC_CLASSIFICATION_LEVELS` in `hvantk/skills/gencc/shared/constants.py`.
 - Tests: `hvantk/skills/gencc/tests/test_gencc.py` (dataset class + builder-driven streamer tests), `test_drift_probe.py`.
 
 ## 7. Workflow steps

--- a/hvantk/skills/gencc/builder.py
+++ b/hvantk/skills/gencc/builder.py
@@ -11,7 +11,7 @@ import logging
 
 import hail as hl
 
-from hvantk.core.constants import (
+from hvantk.skills.gencc.shared.constants import (
     GENCC_CLASSIFICATION_LEVELS,
     GENCC_SUBMISSION_FIELDS,
 )

--- a/hvantk/skills/gencc/drift_probe.py
+++ b/hvantk/skills/gencc/drift_probe.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 
 import requests
 
-from hvantk.core.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
+from hvantk.skills.gencc.shared.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
 from hvantk.core.plugin.api import DriftProbeError
 
 PROBE_VERSION = 1

--- a/hvantk/skills/gencc/shared/constants.py
+++ b/hvantk/skills/gencc/shared/constants.py
@@ -1,0 +1,39 @@
+"""Plugin-local constants for the gencc skill.
+
+Moved from hvantk/core/constants.py per issue #120 (clean-core principle).
+"""
+
+# URLs
+GENCC_BASE_URL = (
+    "https://thegencc.org/download/action/submissions-export-tsv?format=new"
+)
+GENCC_FILE_PREFIX = "gencc-submissions"
+
+# Field-rename map: source TSV column -> snake_case
+GENCC_SUBMISSION_FIELDS = {
+    "sgc_id": "sgc_id",
+    "gene_curie": "hgnc_id",
+    "gene_symbol": "gene_symbol",
+    "disease_curie": "mondo_id",
+    "disease_title": "disease_label",
+    "disease_original_curie": "disease_original_id",
+    "disease_original_title": "disease_original_label",
+    "classification_title": "classification",
+    "moi_title": "mode_of_inheritance",
+    "submitter_title": "submitter",
+    "submitted_as_date": "submission_date",
+    "submitted_as_public_report_url": "report_url",
+    "submitted_as_pmids": "pmids",
+}
+
+# Classification levels (strongest first)
+GENCC_CLASSIFICATION_LEVELS = [
+    "Definitive",
+    "Strong",
+    "Moderate",
+    "Supportive",
+    "Limited",
+    "Disputed Evidence",
+    "Refuted Evidence",
+    "No Known Disease Relationship",
+]

--- a/hvantk/skills/gencc/shared/datasets.py
+++ b/hvantk/skills/gencc/shared/datasets.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from hvantk.core.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
+from hvantk.skills.gencc.shared.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
 from hvantk.core.utils.file_utils import download_file, sanitize_tsv
 
 logger = logging.getLogger(__name__)

--- a/hvantk/skills/gencc/streamer.py
+++ b/hvantk/skills/gencc/streamer.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 import hail as hl
 import pandas as pd
 
-from hvantk.core.constants import GENCC_CLASSIFICATION_LEVELS
+from hvantk.skills.gencc.shared.constants import GENCC_CLASSIFICATION_LEVELS
 from hvantk.core.utils.gene_disease_streamer import GeneDiseaseValidityStreamer
 
 logger = logging.getLogger(__name__)

--- a/hvantk/skills/gencc/tests/test_drift_probe.py
+++ b/hvantk/skills/gencc/tests/test_drift_probe.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import requests_mock
 
-from hvantk.core.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
+from hvantk.skills.gencc.shared.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
 from hvantk.skills.gencc.drift_probe import fetch_fingerprint
 
 


### PR DESCRIPTION
## Summary

Batched move of three plugins' constants from `hvantk/core/constants.py` to per-plugin `shared/constants.py` (user opted for batch over solo PRs):

- **clingen** (6 constants): `CLINGEN_DOWNLOADS_URL`, `CLINGEN_BASE_URL`, `CLINGEN_FILE_PREFIX`, `CLINGEN_HEADER_SKIP_LINES`, `CLINGEN_GENE_DISEASE_FIELDS`, `CLINGEN_CLASSIFICATION_LEVELS` → `hvantk/skills/clingen/shared/constants.py`.
- **gencc** (4 constants): `GENCC_BASE_URL`, `GENCC_FILE_PREFIX`, `GENCC_SUBMISSION_FIELDS`, `GENCC_CLASSIFICATION_LEVELS` → `hvantk/skills/gencc/shared/constants.py`.
- **cosmic_cgc** (5 constants): `COSMIC_CGC_FILE_PREFIX`, `COSMIC_CGC_FIELDS`, `COSMIC_CGC_CLASSIFICATION_LEVELS`, `COSMIC_TISSUE_TYPES`, `COSMIC_MUTATION_CONTEXTS` → `hvantk/skills/cosmic_cgc/shared/constants.py` (new directory created).

`COSMIC_CGC_FILE_PREFIX` currently has zero external consumers; moved (not deleted) because the name is plugin-scoped, matching the move-plugin-named/delete-generic-named rule.

- Dropped 2 module-import `logger.debug` dumps (clingen, gencc).
- Updated 12 Python consumers (drift_probes, tests/test_drift_probes, builders, streamers, shared/datasets.py x 2).
- Updated 6 SKILL.md path references (3 in clingen + 3 in gencc).

Closes #120 (one of several PRs — covers the §3.D/§3.E/§3.F slots).

## Test plan
- flake8 (E9/F63/F7/F82): pass
- pytest -q: pass (14 pre-existing collection errors unchanged; no new failures)
- pytest hvantk/skills/clingen/ hvantk/skills/gencc/ hvantk/skills/cosmic_cgc/: pass (22 passed, 1 skipped)