### PR TITLE
refactor(#121): inject GeneCatalogStreamer; remove 4 transient cross-layer imports

### DIFF
--- a/hvantk/algorithms/psroc/pipeline.py
+++ b/hvantk/algorithms/psroc/pipeline.py
@@ -20,15 +20,20 @@ Example:
     >>> result = pipeline.run()
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
-from typing import Optional, Dict, Any, List, Set
+from typing import TYPE_CHECKING, Optional, Dict, Any, List, Set
 from enum import Enum
 import hashlib
 import json
 import logging
 import re
 from datetime import datetime
+
+if TYPE_CHECKING:
+    from hvantk.core.streamers.gene_catalog import GeneCatalogStreamer
 
 import numpy as np
 import hail as hl
@@ -573,16 +578,23 @@ class PSROCPipeline:
         >>> result = pipeline.run()
     """
 
-    def __init__(self, config: PSROCConfig):
+    def __init__(
+        self,
+        config: PSROCConfig,
+        gene_catalog: GeneCatalogStreamer | None = None,
+    ):
         """Initialize PSROC pipeline.
 
         Args:
             config: Pipeline configuration.
+            gene_catalog: Optional gene catalog for alias expansion. Constructed
+                by the caller (in ``tools/``); the pipeline only calls ABC methods.
 
         Raises:
             ValueError: If configuration validation fails.
         """
         self.config = config
+        self.gene_catalog = gene_catalog
         errors = config.validate()
         if errors:
             raise ValueError(
@@ -816,7 +828,7 @@ class PSROCPipeline:
             )
 
             try:
-                pipeline = PSROCPipeline(group_config)
+                pipeline = PSROCPipeline(group_config, gene_catalog=self.gene_catalog)
                 result = pipeline.run()
                 results[group_name] = result
                 logger.info(
@@ -971,25 +983,25 @@ class PSROCPipeline:
             # Filter by gene set
             gene_set = self.config.get_gene_set()
             if gene_set:
-                # Expand with HGNC aliases if configured
-                if self.config.hgnc_path:
-                    # transient: Task 4 (#121) replaces this with a self.gene_catalog parameter
-                    from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
-
-                    pre_expand_count = len(gene_set)
-                    catalog = HGNCGeneCatalogStreamer.from_path(self.config.hgnc_path)
-                    gene_set, alias_map = catalog.expand_with_aliases(set(gene_set))
+                # Expand with gene catalog aliases if configured
+                pre_expand_count = len(gene_set)
+                if self.gene_catalog is not None:
+                    gene_set, alias_map = self.gene_catalog.expand_with_aliases(
+                        set(gene_set)
+                    )
                     if alias_map:
                         logger.info(
                             f"   Expanded gene set with {len(alias_map)} "
-                            f"aliases from HGNC "
+                            f"aliases from gene catalog "
                             f"({pre_expand_count} → {len(gene_set)} symbols)"
                         )
                         for alias, canonical in sorted(alias_map.items()):
                             logger.info(f"     {alias} → {canonical}")
+                else:
+                    alias_map = {}
 
                 self._n_genes = (
-                    pre_expand_count if self.config.hgnc_path else len(gene_set)
+                    pre_expand_count if self.gene_catalog is not None else len(gene_set)
                 )
                 logger.info(f"   Filtering to {self._n_genes} genes")
                 gene_literal = hl.literal(gene_set)

--- a/hvantk/core/utils/geneset_io.py
+++ b/hvantk/core/utils/geneset_io.py
@@ -3,16 +3,20 @@
 Parses a headerless two-column TSV (gene_set_name<TAB>gene_symbol) into a
 dictionary of {set_name: List[str]}, with format and identifier validation.
 
-Also provides HGNC-based symbol validation and alias resolution using the
-existing ``_load_hgnc_symbol_maps()`` infrastructure from
-``hvantk.core.utils.gene_aliases``.
+Also provides catalog-based symbol validation and alias resolution via the
+:class:`~hvantk.core.streamers.gene_catalog.GeneCatalogStreamer` ABC. Callers
+in ``tools/`` construct the concrete streamer and pass it here.
 """
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 import logging
 import re
+
+if TYPE_CHECKING:
+    from hvantk.core.streamers.gene_catalog import GeneCatalogStreamer
 
 logger = logging.getLogger(__name__)
 
@@ -243,15 +247,15 @@ class ValidationResult:
     gene_sets: Dict[str, List[str]] = field(default_factory=dict)
 
 
-def validate_with_hgnc(
+def validate_with_catalog(
     gene_sets: Dict[str, List[str]],
-    hgnc_path: str,
+    catalog: "GeneCatalogStreamer",
 ) -> ValidationResult:
-    """Validate gene symbols against HGNC and resolve aliases.
+    """Validate gene symbols against a gene catalog and resolve aliases.
 
     For each gene symbol:
 
-    1. If it is a current HGNC-approved symbol, it is recognized.
+    1. If it is a current approved symbol, it is recognized.
     2. If it is a known alias or previous symbol, it is resolved to the
        canonical symbol and the gene set entry is updated.
     3. If it matches nothing, it is marked unrecognized (included as-is
@@ -261,35 +265,17 @@ def validate_with_hgnc(
     ----------
     gene_sets : Dict[str, List[str]]
         Gene sets from :func:`parse_geneset_tsv`.
-    hgnc_path : str
-        Path to HGNC Hail Table (``.ht``) or TSV file.
+    catalog : GeneCatalogStreamer
+        Gene catalog providing symbol classification. Constructed by the
+        caller (in ``tools/``); this function only calls ABC methods.
 
     Returns
     -------
     ValidationResult
     """
-    # transient: Task 4 (#121) replaces this with a GeneCatalogStreamer parameter
-    from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
-
-    catalog = HGNCGeneCatalogStreamer.from_path(hgnc_path)
-    canonical_symbols = catalog._canonical_symbols
-    alias_to_canonical = catalog._alias_to_canonical
-
-    # Classify every unique gene across all sets.
+    # Classify every unique gene across all sets via the ABC contract.
     all_genes = {g for genes in gene_sets.values() for g in genes}
-    recognized: Set[str] = set()
-    aliases_resolved: Dict[str, str] = {}
-    unrecognized: Set[str] = set()
-
-    for gene in all_genes:
-        if gene in canonical_symbols:
-            recognized.add(gene)
-        elif gene in alias_to_canonical:
-            canonical = alias_to_canonical[gene]
-            aliases_resolved[gene] = canonical
-            recognized.add(canonical)
-        else:
-            unrecognized.add(gene)
+    recognized, aliases_resolved, unrecognized = catalog.validate_symbols(all_genes)
 
     # Rebuild gene sets with aliases resolved, deduplicating.
     resolved_sets: Dict[str, List[str]] = {}

--- a/hvantk/skills/cosmic_cgc/builder.py
+++ b/hvantk/skills/cosmic_cgc/builder.py
@@ -7,7 +7,7 @@ source-fingerprint provenance.
 from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 import hail as hl
 
@@ -18,6 +18,9 @@ from hvantk.skills.cosmic_cgc.shared.constants import (
 )
 from hvantk.core.utils.table_utils import get_row_fields, build_rename_map, str_to_bool
 from hvantk.core.utils.file_utils import resolve_compression
+
+if TYPE_CHECKING:
+    from hvantk.core.streamers.gene_catalog import GeneCatalogStreamer
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +43,13 @@ def build_cosmic_cgc_submissions(
         Platform-provided context; supplies provenance.
     **params
         Optional: mutation_context (str, default "both"), min_classification (str),
-                  hgnc_path (str), fields (list of str).
+                  gene_catalog (GeneCatalogStreamer), fields (list of str).
     """
     from hvantk.core.models import AnnotationTable
 
     mutation_context = params.get("mutation_context", "both")
     min_classification = params.get("min_classification", None)
-    hgnc_path = params.get("hgnc_path", None)
+    gene_catalog: Optional[GeneCatalogStreamer] = params.get("gene_catalog", None)
     fields = params.get("fields", None)
 
     if mutation_context not in COSMIC_MUTATION_CONTEXTS:
@@ -148,14 +151,13 @@ def build_cosmic_cgc_submissions(
         )
         ht = ht.filter(ht.classification_level <= min_level)
 
-    # Resolve gene_symbol -> hgnc_id if HGNC table is available
-    if hgnc_path is not None:
-        logger.info("Resolving gene symbols to HGNC IDs using %s", hgnc_path)
-        from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
-
-        mapper = HGNCGeneCatalogStreamer.from_path(hgnc_path)
+    # Resolve gene_symbol -> hgnc_id if a gene catalog is available
+    if gene_catalog is not None:
+        logger.info("Resolving gene symbols to HGNC IDs via gene catalog")
         symbols = set(ht.aggregate(hl.agg.collect_as_set(ht.gene_symbol)))
-        mapping = mapper.map_to_hgnc(list(symbols), source_type="gene_symbol")
+        mapping = gene_catalog.map_ids(
+            list(symbols), source_type="gene_symbol", target_type="hgnc_id"
+        )
         mapping_literal = hl.literal(mapping)
         ht = ht.annotate(hgnc_id=mapping_literal.get(ht.gene_symbol))
         ht = ht.annotate(
@@ -169,8 +171,8 @@ def build_cosmic_cgc_submissions(
         ht = ht.key_by("hgnc_id")
     else:
         logger.warning(
-            "No HGNC path provided; keying by gene_symbol. "
-            "Provide hgnc_path for HGNC ID resolution."
+            "No gene catalog provided; keying by gene_symbol. "
+            "Provide gene_catalog for HGNC ID resolution."
         )
         ht = ht.key_by("gene_symbol")
 

--- a/hvantk/skills/pqtl/builder.py
+++ b/hvantk/skills/pqtl/builder.py
@@ -2,7 +2,7 @@
 
 Owns the Phase B ``build_pqtl_metrics`` builder. The transform (GTEx
 variant-ID parsing, SE derivation via ``|BETA / STAT|``, gene-symbol →
-Ensembl-ID mapping via the HGNC table) is implemented directly here.
+Ensembl-ID mapping via a GeneCatalogStreamer) is implemented directly here.
 
 Shared GTEx variant-ID parsing helpers live in
 ``hvantk.core.utils.qtl_helpers`` (also used by the eQTL builder).
@@ -10,8 +10,12 @@ Shared GTEx variant-ID parsing helpers live in
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import hail as hl
+
+if TYPE_CHECKING:
+    from hvantk.core.streamers.gene_catalog import GeneCatalogStreamer
 
 from hvantk.core.utils.qtl_helpers import (
     parse_gtex_variant_id,
@@ -68,7 +72,7 @@ def build_pqtl_metrics(
     reference_genome: str = "GRCh38",
     source: str = "gtex_fang",
     tissue: str | None = None,
-    hgnc_ht: str | None = None,
+    gene_catalog: GeneCatalogStreamer | None = None,
     no_gene_map: bool = False,
     p_threshold: float | None = None,
     fields: list[str] | None = None,
@@ -102,7 +106,7 @@ def build_pqtl_metrics(
             "Only 'gtex_fang' (Fang et al. 2025) is currently supported."
         )
 
-    if not hgnc_ht and not no_gene_map:
+    if gene_catalog is None and not no_gene_map:
         raise ValueError(
             "Ensembl gene mapping is required for cascade-compatible pQTL "
             "tables. Provide --plugin-arg hgnc_ht=<path> (HGNC Hail Table "
@@ -118,24 +122,20 @@ def build_pqtl_metrics(
     ht = ht.annotate(se=hl.abs(ht.beta / ht.stat))
     ht = ht.drop("stat", "variant_id")
 
-    if hgnc_ht:
-        from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
-
+    if gene_catalog is not None:
         logger.info(
-            "Mapping gene symbols → Ensembl IDs via HGNCGeneCatalogStreamer (%s)",
-            hgnc_ht,
+            "Mapping gene symbols → Ensembl IDs via gene catalog"
         )
-        mapper = HGNCGeneCatalogStreamer.from_path(hgnc_ht)
-        ht = mapper.annotate_table(
-            ht,
-            source_field="gene_symbol",
-            source_type="gene_symbol",
-            fields_to_add=["ensembl_gene_id"],
+        symbols = set(ht.aggregate(hl.agg.collect_as_set(ht.gene_symbol)))
+        ensembl_mapping = gene_catalog.map_ids(
+            list(symbols), source_type="gene_symbol", target_type="ensembl_gene_id"
         )
+        mapping_literal = hl.literal(ensembl_mapping)
         ht = ht.annotate(
-            gene_id=hl.or_else(ht.hgnc_ensembl_gene_id, ht.gene_symbol),
+            gene_id=hl.or_else(
+                mapping_literal.get(ht.gene_symbol), ht.gene_symbol
+            )
         )
-        ht = ht.drop("hgnc_ensembl_gene_id")
     else:
         logger.warning(
             "no_gene_map=True: using gene symbols as gene_id. "

--- a/hvantk/tests/enrichex/test_gene_sets.py
+++ b/hvantk/tests/enrichex/test_gene_sets.py
@@ -2,14 +2,12 @@
 Tests for gene set data structures, I/O, parsing, and validation.
 
 Covers: GeneSet, GeneSetCollection (JSON + GMT round-trips), geneset_io
-(detect_id_type, validate_gene_ids, parse_geneset_tsv, validate_with_hgnc),
+(detect_id_type, validate_gene_ids, parse_geneset_tsv, validate_with_catalog),
 and loading utilities (load_gene_sets, load_marker_genes).
 """
 
 import json
 from pathlib import Path
-from unittest.mock import patch
-
 import pytest
 
 from hvantk.core.utils.gene_sets import (
@@ -23,7 +21,7 @@ from hvantk.core.utils.geneset_io import (
     detect_id_type,
     parse_geneset_tsv,
     validate_gene_ids,
-    validate_with_hgnc,
+    validate_with_catalog,
 )
 
 TESTDATA_GENESET = Path(__file__).parent.parent / "testdata" / "prepare_geneset"
@@ -133,40 +131,48 @@ def test_parse_geneset_tsv_deduplicates(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# geneset_io: validate_with_hgnc
+# geneset_io: validate_with_catalog
 # ---------------------------------------------------------------------------
 
 
 def _make_mock_catalog():
-    """Return a mock HGNCGeneCatalogStreamer with preset symbol maps."""
-    from unittest.mock import MagicMock
+    """Return a minimal GeneCatalogStreamer subclass with preset symbol maps."""
+    from hvantk.core.streamers.gene_catalog import GeneCatalogStreamer
 
     canonical = {"BRCA1", "BRCA2", "TP53", "EGFR", "ERCC1"}
     alias_to_canonical = {"FANCD1": "BRCA2", "ERCC11": "ERCC1", "RNF53": "BRCA1"}
-    mock_catalog = MagicMock()
-    mock_catalog._canonical_symbols = canonical
-    mock_catalog._alias_to_canonical = alias_to_canonical
-    return mock_catalog
+
+    class _FakeCatalog(GeneCatalogStreamer):
+        def __init__(self):
+            # Bypass AnnotationTable requirement; no real artifact needed.
+            self._canonical_symbols = canonical
+            self._alias_to_canonical = alias_to_canonical
+
+        def is_canonical(self, symbol):
+            return symbol in self._canonical_symbols
+
+        def resolve_alias(self, symbol):
+            return self._alias_to_canonical.get(symbol)
+
+        def expand_with_aliases(self, symbols):
+            raise NotImplementedError
+
+        def map_ids(self, ids, source_type, target_type):
+            raise NotImplementedError
+
+    return _FakeCatalog()
 
 
-@patch(
-    "hvantk.skills.hgnc.streamers.HGNCGeneCatalogStreamer.from_path",
-    side_effect=lambda path: _make_mock_catalog(),
-)
-def test_validate_with_hgnc_alias_resolution(mock_from_path):
+def test_validate_with_catalog_alias_resolution():
     gene_sets = {"panel": ["FANCD1", "TP53", "ERCC11"]}
-    vr = validate_with_hgnc(gene_sets, "/fake/hgnc.tsv")
+    vr = validate_with_catalog(gene_sets, _make_mock_catalog())
     assert vr.aliases_resolved == {"FANCD1": "BRCA2", "ERCC11": "ERCC1"}
     assert vr.gene_sets["panel"] == ["BRCA2", "TP53", "ERCC1"]
 
 
-@patch(
-    "hvantk.skills.hgnc.streamers.HGNCGeneCatalogStreamer.from_path",
-    side_effect=lambda path: _make_mock_catalog(),
-)
-def test_validate_with_hgnc_unrecognized(mock_from_path):
+def test_validate_with_catalog_unrecognized():
     gene_sets = {"panel": ["BRCA1", "FAKEGENE"]}
-    vr = validate_with_hgnc(gene_sets, "/fake/hgnc.tsv")
+    vr = validate_with_catalog(gene_sets, _make_mock_catalog())
     assert vr.unrecognized == {"FAKEGENE"}
     assert "FAKEGENE" in vr.gene_sets["panel"]
 

--- a/hvantk/tests/psroc/test_psroc_cli.py
+++ b/hvantk/tests/psroc/test_psroc_cli.py
@@ -259,6 +259,7 @@ class TestPSROCCLIDryRun:
         # Set up mocks
         mock_config = MagicMock()
         mock_config.validate.return_value = []
+        mock_config.hgnc_path = None  # no HGNC; prevents catalog construction in CLI
         mock_config_cls.return_value = mock_config
 
         mock_pipeline = MagicMock()
@@ -314,6 +315,7 @@ class TestPSROCCLIOptions:
 
         mock_config = MagicMock()
         mock_config.validate.return_value = []
+        mock_config.hgnc_path = None  # no HGNC; prevents catalog construction in CLI
         mock_config_cls.return_value = mock_config
 
         mock_pipeline = MagicMock()
@@ -356,6 +358,7 @@ class TestPSROCCLIOptions:
 
         mock_config = MagicMock()
         mock_config.validate.return_value = []
+        mock_config.hgnc_path = None  # no HGNC; prevents catalog construction in CLI
         mock_config_cls.return_value = mock_config
 
         mock_pipeline = MagicMock()
@@ -396,6 +399,7 @@ class TestPSROCCLIOptions:
 
         mock_config = MagicMock()
         mock_config.validate.return_value = []
+        mock_config.hgnc_path = None  # no HGNC; prevents catalog construction in CLI
         mock_config_cls.return_value = mock_config
 
         mock_pipeline = MagicMock()
@@ -440,6 +444,7 @@ class TestPSROCCLIVariantSources:
 
         mock_config = MagicMock()
         mock_config.validate.return_value = []
+        mock_config.hgnc_path = None  # no HGNC; prevents catalog construction in CLI
         mock_config_cls.return_value = mock_config
 
         mock_pipeline = MagicMock()
@@ -481,6 +486,7 @@ class TestPSROCCLIVariantSources:
 
         mock_config = MagicMock()
         mock_config.validate.return_value = []
+        mock_config.hgnc_path = None  # no HGNC; prevents catalog construction in CLI
         mock_config_cls.return_value = mock_config
 
         mock_pipeline = MagicMock()
@@ -524,6 +530,7 @@ class TestPSROCCLIVariantSources:
 
         mock_config = MagicMock()
         mock_config.validate.return_value = []
+        mock_config.hgnc_path = None  # no HGNC; prevents catalog construction in CLI
         mock_config_cls.return_value = mock_config
 
         mock_pipeline = MagicMock()

--- a/hvantk/tests/test_prepare_geneset_cli.py
+++ b/hvantk/tests/test_prepare_geneset_cli.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -13,7 +13,14 @@ TESTDATA = Path(__file__).parent / "testdata" / "prepare_geneset"
 
 
 def _make_mock_catalog_cli():
-    """Return a mock HGNCGeneCatalogStreamer with preset symbol maps for CLI tests."""
+    """Return a minimal GeneCatalogStreamer subclass for CLI tests.
+
+    Implements is_canonical / resolve_alias so that the inherited
+    validate_symbols() template method returns correct 3-tuples.
+    FANCD1 → BRCA2 alias resolution is included to satisfy the alias test.
+    """
+    from hvantk.core.streamers.gene_catalog import GeneCatalogStreamer
+
     canonical = {
         "BRCA1",
         "BRCA2",
@@ -36,10 +43,27 @@ def _make_mock_catalog_cli():
         "HRAS",
         "MAP2K1",
     }
-    mock_catalog = MagicMock()
-    mock_catalog._canonical_symbols = canonical
-    mock_catalog._alias_to_canonical = {"FANCD1": "BRCA2", "ERCC11": "ERCC1"}
-    return mock_catalog
+    alias_to_canonical = {"FANCD1": "BRCA2", "ERCC11": "ERCC1"}
+
+    class _FakeCatalog(GeneCatalogStreamer):
+        def __init__(self):
+            # Bypass AnnotationTable requirement; no real artifact needed.
+            self._canonical_symbols = canonical
+            self._alias_to_canonical = alias_to_canonical
+
+        def is_canonical(self, symbol):
+            return symbol in self._canonical_symbols
+
+        def resolve_alias(self, symbol):
+            return self._alias_to_canonical.get(symbol)
+
+        def expand_with_aliases(self, symbols):
+            raise NotImplementedError
+
+        def map_ids(self, ids, source_type, target_type):
+            raise NotImplementedError
+
+    return _FakeCatalog()
 
 
 @pytest.fixture

--- a/hvantk/tools/genesets/genesets_cli.py
+++ b/hvantk/tools/genesets/genesets_cli.py
@@ -612,7 +612,7 @@ def genesets_prepare(
       hvantk genesets prepare -i panels.tsv -o panels.json --hgnc /data/hgnc.ht
     """
     from hvantk.core.utils.gene_sets import load_gene_set, load_gene_sets_from_dict
-    from hvantk.core.utils.geneset_io import parse_geneset_tsv, validate_with_hgnc
+    from hvantk.core.utils.geneset_io import parse_geneset_tsv, validate_with_catalog
 
     output_path = Path(output)
     if output_path.exists() and not overwrite:
@@ -648,7 +648,9 @@ def genesets_prepare(
 
     if hgnc:
         click.echo(f"\nValidating against HGNC ({hgnc}) ...", err=True)
-        vr = validate_with_hgnc(gene_sets, hgnc)
+        from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
+        catalog = HGNCGeneCatalogStreamer.from_path(hgnc)
+        vr = validate_with_catalog(gene_sets, catalog)
         gene_sets = vr.gene_sets
         hgnc_validated = True
         aliases_resolved = vr.aliases_resolved

--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -184,6 +184,16 @@ def reprocess_cmd(
         else:
             # Phase B contract: orchestrator handles BuildContext, validation,
             # and save. Returns the stamped Provenance.
+            #
+            # Interface separation (#121): builders receive a GeneCatalogStreamer
+            # ABC, never construct the concrete HGNC streamer themselves (skills
+            # must not import sibling skills). tools/ is the only layer allowed
+            # to build it.
+            if "hgnc_path" in extras or "hgnc_ht" in extras:
+                from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
+                hgnc_loc = extras.pop("hgnc_path", None) or extras.pop("hgnc_ht", None)
+                extras["gene_catalog"] = HGNCGeneCatalogStreamer.from_path(hgnc_loc)
+
             from hvantk.core.plugin.run_builder import run_builder_for_spec
             from pathlib import Path
             run_builder_for_spec(

--- a/hvantk/tools/ptm/psroc_cli.py
+++ b/hvantk/tools/ptm/psroc_cli.py
@@ -390,8 +390,16 @@ def psroc_cmd(
                 click.echo(f"  - {error}", err=True)
             ctx.exit(1)
 
+        # Construct the gene catalog in tools/ (the only layer allowed to import skills/).
+        from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
+        gene_catalog = (
+            HGNCGeneCatalogStreamer.from_path(config.hgnc_path)
+            if config.hgnc_path
+            else None
+        )
+
         # Create pipeline
-        pipeline = PSROCPipeline(config)
+        pipeline = PSROCPipeline(config, gene_catalog=gene_catalog)
 
         # Show plan if dry-run
         if dry_run:


### PR DESCRIPTION
## Summary
- Removes the 4 transient `skills.hgnc` imports PR #137 deliberately left in dev.
- `core/utils/geneset_io.py`: `validate_with_hgnc(hgnc_path)` → `validate_with_catalog(catalog: GeneCatalogStreamer)`; uses `catalog.validate_symbols()` (ABC template method).
- `algorithms/psroc/pipeline.py`: `PSROCPipeline` gains a `gene_catalog` parameter; alias expansion gated on `self.gene_catalog is not None`. Sub-pipeline constructions propagate `gene_catalog=self.gene_catalog`.
- `skills/cosmic_cgc/builder.py`: accepts `gene_catalog: GeneCatalogStreamer` parameter; uses `map_ids()` ABC method instead of concrete `map_to_hgnc()`.
- `skills/pqtl/builder.py`: accepts `gene_catalog: GeneCatalogStreamer` parameter; uses `map_ids()` ABC method instead of concrete `annotate_table()`.
- `tools/plugins/reprocess_cli.py`: constructs `HGNCGeneCatalogStreamer` from the `hgnc_path`/`hgnc_ht` plugin-arg and injects `gene_catalog` — **`tools/` is the only layer that imports `skills/`**.
- `tools/genesets/genesets_cli.py` and `tools/ptm/psroc_cli.py`: construct + inject the catalog.
- Test mocks updated to the catalog form: fake `GeneCatalogStreamer` subclasses replace `MagicMock` so `validate_symbols()` template method works correctly. `psroc` CLI mocks set `hgnc_path=None` to prevent catalog construction in mock-heavy tests.

Closes #121 (one of several PRs).

## Test plan
- VERIFY-LINT: `flake8` — 0 errors
- Dependency-direction guards: **4 passed** (all transient violations cleared)
- `pytest hvantk/tests/test_prepare_geneset_cli.py hvantk/tests/enrichex/test_gene_sets.py hvantk/tests/psroc/`: **175 passed**
- VERIFY-FAST: 977 passed, 2 pre-existing `test_cli_qtlcascade.py` failures, 12 pre-existing collection errors — baseline-consistent