### PR TITLE
test(#121): add reverse-rule guards; remove dead Streamer Protocol

### DIFF
--- a/hvantk/core/protocols.py
+++ b/hvantk/core/protocols.py
@@ -88,83 +88,6 @@ class Builder(Protocol):
         ...
 
 
-class Streamer(Protocol):
-    """
-    Protocol for data transformers (streamers) that process Hail Tables/MatrixTables.
-
-    Streamers take Hail data structures and transform them (filter, join, aggregate, etc.)
-    into new Hail data structures. They are composable building blocks for pipelines.
-
-    Example:
-        class VariantFilterStreamer:
-            def transform(self, input_data: hl.Table, **params: Any) -> hl.Table:
-                min_qual = params.get('min_quality', 30)
-                return input_data.filter(input_data.qual >= min_qual)
-
-            def validate_input(self, input_data: hl.Table) -> bool:
-                return 'qual' in input_data.row
-
-            def get_metadata(self) -> Dict[str, Any]:
-                return {'type': 'filter', 'input_type': 'variant_table'}
-    """
-
-    def transform(
-        self, input_data: Union[hl.Table, hl.MatrixTable], **params: Any
-    ) -> Union[hl.Table, hl.MatrixTable]:
-        """
-        Transform input data and return output.
-
-        Parameters
-        ----------
-        input_data : Union[hl.Table, hl.MatrixTable]
-            Input Hail data structure
-        **params : Any
-            Transformation parameters (e.g., filter thresholds, join tables, etc.)
-
-        Returns
-        -------
-        Union[hl.Table, hl.MatrixTable]
-            Transformed Hail data structure
-
-        Raises
-        ------
-        ValueError
-            If input schema is invalid or params are incorrect
-        """
-        ...
-
-    def validate_input(self, input_data: Union[hl.Table, hl.MatrixTable]) -> bool:
-        """
-        Validate that input schema matches expectations.
-
-        Parameters
-        ----------
-        input_data : Union[hl.Table, hl.MatrixTable]
-            The Hail data structure to validate
-
-        Returns
-        -------
-        bool
-            True if input schema is valid, False otherwise
-        """
-        ...
-
-    def get_metadata(self) -> Dict[str, Any]:
-        """
-        Return metadata about this streamer.
-
-        Returns
-        -------
-        Dict[str, Any]
-            Metadata dictionary containing:
-            - type: str - 'filter', 'join', 'aggregate', 'annotate', etc.
-            - input_type: str - Expected input type
-            - output_type: str - Output type (optional)
-            - description: str - Human-readable description (optional)
-        """
-        ...
-
-
 class Downloader(Protocol):
     """
     Protocol for data downloaders that fetch external datasets.
@@ -268,6 +191,3 @@ class Downloader(Protocol):
 # Type aliases for convenience
 TableOrMatrix = Union[hl.Table, hl.MatrixTable]
 BuilderFunction = Callable[..., Union[hl.Table, hl.MatrixTable]]
-StreamerFunction = Callable[
-    [Union[hl.Table, hl.MatrixTable]], Union[hl.Table, hl.MatrixTable]
-]

--- a/hvantk/core/utils/streaming.py
+++ b/hvantk/core/utils/streaming.py
@@ -1,21 +1,24 @@
-"""Low-level chunked-IO streaming primitives.
+"""Legacy chunked-IO streaming primitives.
 
-This module pre-dates the Phase A artifact contract and is intentionally
-NOT part of the artifact pipeline. Streamers handle the byte-level
-download → on-disk landing of raw upstream files (e.g. ClinVar VCF chunks,
-HGNC TSV chunks) before any parse/build step runs. The artifact pipeline
-(``hvantk/core/io`` + ``AnnotationTable``/``ExpressionMatrix``/``GeneSet``)
-starts where streamers end: at well-formed on-disk files.
+NOT for new code. The Streamer concept now lives in
+:mod:`hvantk.core.streamers` as Artifact-wrapping ABCs
+(VariantTableStreamer, GeneDiseaseTableStreamer, GeneCatalogStreamer);
+new plugins implement those ABCs in skills/<plugin>/streamers.py.
 
-For algorithm-side persistence with provenance, use ``hvantk.core.io.save``
-(artifact API) or ``hvantk.core.io.save_native`` (native passthrough), NOT
-the streamer persistence methods.
+This module is retained because these code paths still depend on it:
 
-Streamer subclasses (``HailDataStreamer``, etc.) reason in terms of Hail
-tables, JSON, text, and bytes because that's the shape of raw upstream
-data, not because the streamer layer is platform-architectural. If a
-new upstream source needs a streamer, it adds a subclass here; if the
-source produces ready-to-build files, no streamer is needed.
+  - hvantk.algorithms.annotation.annotation_streamer (AnnotationStreamer
+    base + the four annotator subclasses) and annotation_pipeline
+  - hvantk.skills.clinvar.pipelines.training_set (ClinvarDataStreamer,
+    ClinvarTrainingSetProcessor)
+  - hvantk.tools.training_sets.enhanced (EnhancedClinvarTrainingSetProcessor)
+  - hvantk.skills.alphagenome.streamer (AlphaGenomeStreamer)
+
+The "Annotator" rename + reframing of the annotation_streamer family is
+tracked in a follow-up issue; when it lands, this module can be removed.
+
+For chunked iteration in new code, write a small private helper next to
+the calling class.
 """
 
 import logging

--- a/hvantk/tests/test_intra_core_dependencies.py
+++ b/hvantk/tests/test_intra_core_dependencies.py
@@ -127,3 +127,75 @@ def test_core_constants_has_no_plugin_specific_blocks():
         f"Found prefixes: {offenders}. Move each block to "
         "hvantk/skills/<plugin>/shared/constants.py per issue #120."
     )
+
+
+# Reverse-rule guard for issue #121: core/streamers/ must not import from skills/.
+def test_core_streamers_imports_no_skills():
+    """core/streamers/*.py must not contain ``from hvantk.skills``."""
+    streamers_dir = PACKAGE_ROOT / "core" / "streamers"
+    if not streamers_dir.is_dir():
+        return
+    offenders: list[str] = []
+    for py in streamers_dir.rglob("*.py"):
+        if "__pycache__" in py.parts:
+            continue
+        for i, line in enumerate(py.read_text().splitlines(), 1):
+            s = line.lstrip()
+            if s.startswith("from hvantk.skills") or s.startswith("import hvantk.skills"):
+                offenders.append(f"{py.relative_to(PACKAGE_ROOT)}:{i}: {s}")
+    assert not offenders, (
+        "core/streamers/ must not import from hvantk.skills. "
+        f"Offenders: {offenders}. See issue #121."
+    )
+
+
+# Reverse-rule guard for issue #121: no plugin-specific classes in core/streamers/.
+def test_core_streamers_has_no_plugin_specific_classes():
+    """No class declared in core/streamers/ may carry a plugin-name prefix."""
+    forbidden_prefixes = (
+        "ClinGen", "ClinVar", "GenCC", "COSMIC", "CosmicCGC", "HGNC",
+        "Ensembl", "MSigDB", "DbNSFP", "UCSC", "AlphaGenome",
+        "ExpressionAtlas", "GTEx", "PQTL", "GWAS",
+        "GnomAD", "GeVIR", "UniProt", "PeptideAtlas", "CPTAC", "Insider",
+    )
+    streamers_dir = PACKAGE_ROOT / "core" / "streamers"
+    if not streamers_dir.is_dir():
+        return
+    offenders: list[str] = []
+    for py in streamers_dir.rglob("*.py"):
+        if "__pycache__" in py.parts:
+            continue
+        for i, line in enumerate(py.read_text().splitlines(), 1):
+            s = line.lstrip()
+            if s.startswith("class "):
+                name = s[len("class "):]
+                if any(name.startswith(p) for p in forbidden_prefixes):
+                    offenders.append(f"{py.relative_to(PACKAGE_ROOT)}:{i}: {s}")
+    assert not offenders, (
+        "core/streamers/ must not declare plugin-specific classes. "
+        f"Concrete plugin streamers belong in skills/<plugin>/streamers.py. "
+        f"Offenders: {offenders}. See issue #121."
+    )
+
+
+# Reverse-rule guard for issue #121: core/utils/ must hold only platform-generic files.
+def test_core_utils_has_no_provider_specific_files():
+    """core/utils/ must not hold provider-specific files."""
+    forbidden_prefixes = (
+        "clinvar_", "mondo_", "hgnc_", "cosmic_", "gencc_", "clingen_",
+        "gtex_", "expression_atlas_", "ucsc_", "alphagenome_",
+        "peptideatlas_", "uniprot_", "cptac_", "gene_disease_",
+    )
+    utils_dir = PACKAGE_ROOT / "core" / "utils"
+    if not utils_dir.is_dir():
+        return
+    offenders: list[str] = []
+    for py in utils_dir.rglob("*.py"):
+        if "__pycache__" in py.parts:
+            continue
+        if any(py.name.startswith(p) for p in forbidden_prefixes):
+            offenders.append(str(py.relative_to(PACKAGE_ROOT)))
+    assert not offenders, (
+        "core/utils/ must not hold provider-specific files. "
+        f"Offenders: {offenders}. Move each to skills/<plugin>/ per issue #121."
+    )


### PR DESCRIPTION
## Summary
- Deleted the dead `Streamer` Protocol + `StreamerFunction` alias from `core/protocols.py`.
- Marked `core/utils/streaming.py` legacy in its docstring (classes retained — still used; full removal tracked in the Annotator follow-up).
- Added three reverse-rule guards to `tests/test_intra_core_dependencies.py`:
  - `test_core_streamers_imports_no_skills`
  - `test_core_streamers_has_no_plugin_specific_classes`
  - `test_core_utils_has_no_provider_specific_files`

Closes #121.

## Test plan
- VERIFY-LINT: pass
- `pytest tests/test_intra_core_dependencies.py tests/test_dependency_directions.py`: pass (incl. 3 new guards)
- VERIFY-FAST: baseline-consistent