### PR TITLE
refactor(#122): split core/ptm_constants.py into per-plugin and per-algorithm homes

### DIFF
--- a/hvantk/algorithms/ptm/__init__.py
+++ b/hvantk/algorithms/ptm/__init__.py
@@ -19,10 +19,7 @@ Example (pure mapping core):
 
 import importlib as _importlib
 
-from hvantk.core.ptm_constants import (
-    UNIPROT_API_URL,
-    UNIPROT_API_FIELDS,
-    UNIPROT_HUMAN_PTM_QUERY,
+from hvantk.algorithms.ptm.constants import (
     ENSEMBL_GTF_URL,
     PTM_TYPE_CATEGORIES,
     DEFAULT_FLANKING_CODONS,
@@ -40,7 +37,7 @@ from hvantk.core.ptm_constants import (
 
 # Lazy imports for Hail-dependent and heavy modules (PEP 562).
 # Accessing any name listed here triggers on-demand loading so that
-# ``from hvantk.core.ptm_constants import ...`` never pulls in Hail.
+# importing constants never pulls in Hail.
 
 _LAZY_MODULES = {
     # mapper
@@ -148,9 +145,6 @@ __all__ = [
     # Report
     "generate_report",
     # Constants
-    "UNIPROT_API_URL",
-    "UNIPROT_API_FIELDS",
-    "UNIPROT_HUMAN_PTM_QUERY",
     "ENSEMBL_GTF_URL",
     "PTM_TYPE_CATEGORIES",
     "DEFAULT_FLANKING_CODONS",

--- a/hvantk/algorithms/ptm/annotate.py
+++ b/hvantk/algorithms/ptm/annotate.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from hvantk.core.ptm_constants import PROXIMAL_BP
+from hvantk.algorithms.ptm.constants import PROXIMAL_BP
 
 if TYPE_CHECKING:
     import hail as hl

--- a/hvantk/algorithms/ptm/constants.py
+++ b/hvantk/algorithms/ptm/constants.py
@@ -1,10 +1,7 @@
-"""Constants and default values for PTM module."""
+"""Algorithm-local constants for the PTM analysis algorithm.
 
-# UniProt REST API
-UNIPROT_API_URL = "https://rest.uniprot.org/uniprotkb/search"
-UNIPROT_API_FIELDS = "accession,gene_names,ft_mod_res,xref_ensembl,sequence"
-UNIPROT_HUMAN_PTM_QUERY = "organism_id:9606 AND reviewed:true AND ft_mod_res:*"
-UNIPROT_BATCH_SIZE = 500
+Moved from hvantk/core/ptm_constants.py per issue #122 (clean-core principle).
+"""
 
 # Ensembl GTF
 ENSEMBL_RELEASE = "113"
@@ -13,29 +10,6 @@ ENSEMBL_GTF_URL = (
     f"/gtf/homo_sapiens/Homo_sapiens.GRCh38.{ENSEMBL_RELEASE}.gtf.gz"
 )
 ENSEMBL_GTF_FILENAME = f"Homo_sapiens.GRCh38.{ENSEMBL_RELEASE}.gtf.gz"
-
-# PeptideAtlas Phospho Build
-PEPTIDEATLAS_PHOSPHO_BASE_URL = "https://peptideatlas.org/builds/human/phospho"
-PEPTIDEATLAS_LATEST_BUILD_DATE = "202512"
-PEPTIDEATLAS_LATEST_BUILD_ID = "606"
-
-# CPTAC Phospho (via cptac Python package)
-CPTAC_CANCER_TYPES = [
-    "brca", "ccrcc", "coad", "gbm",
-    "hnscc", "lscc", "luad", "ov", "pdac", "ucec",
-]
-CPTAC_CANCER_CLASS_MAP = {
-    "brca": "Brca",
-    "ccrcc": "Ccrcc",
-    "coad": "Coad",
-    "gbm": "Gbm",
-    "hnscc": "Hnscc",
-    "lscc": "Lscc",
-    "luad": "Luad",
-    "ov": "Ov",
-    "pdac": "Pdac",
-    "ucec": "Ucec",
-}
 
 # PTM type categories (UniProt MOD_RES description prefixes)
 PTM_TYPE_CATEGORIES = {

--- a/hvantk/algorithms/ptm/pipeline.py
+++ b/hvantk/algorithms/ptm/pipeline.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from hvantk.core.utils.bgzf import BgzfWriter
-from hvantk.core.ptm_constants import (
+from hvantk.algorithms.ptm.constants import (
     ENSEMBL_GTF_URL,
     ENSEMBL_GTF_FILENAME,
     PTM_TYPE_CATEGORIES,

--- a/hvantk/algorithms/ptm/test.py
+++ b/hvantk/algorithms/ptm/test.py
@@ -28,7 +28,7 @@ import numpy as np
 import pandas as pd
 import statsmodels.formula.api as smf
 
-from hvantk.core.ptm_constants import (
+from hvantk.algorithms.ptm.constants import (
     LMM_BINNED_MIN_CELL_N,
     LMM_BINNED_MIN_POS_EXPR,
     LMM_MIN_MIXED_GENES,

--- a/hvantk/skills/cptac/phospho/cli.py
+++ b/hvantk/skills/cptac/phospho/cli.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 import click
 
-from hvantk.core.ptm_constants import CPTAC_CANCER_TYPES
+from hvantk.skills.cptac.shared.constants import CPTAC_CANCER_TYPES
 
 logger = logging.getLogger(__name__)
 

--- a/hvantk/skills/cptac/shared/constants.py
+++ b/hvantk/skills/cptac/shared/constants.py
@@ -1,0 +1,22 @@
+"""Plugin-local constants for the cptac skill.
+
+Moved from hvantk/core/ptm_constants.py per issue #122 (clean-core principle).
+"""
+
+# CPTAC Phospho (via cptac Python package)
+CPTAC_CANCER_TYPES = [
+    "brca", "ccrcc", "coad", "gbm",
+    "hnscc", "lscc", "luad", "ov", "pdac", "ucec",
+]
+CPTAC_CANCER_CLASS_MAP = {
+    "brca": "Brca",
+    "ccrcc": "Ccrcc",
+    "coad": "Coad",
+    "gbm": "Gbm",
+    "hnscc": "Hnscc",
+    "lscc": "Lscc",
+    "luad": "Luad",
+    "ov": "Ov",
+    "pdac": "Pdac",
+    "ucec": "Ucec",
+}

--- a/hvantk/skills/cptac/shared/datasets.py
+++ b/hvantk/skills/cptac/shared/datasets.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
-from hvantk.core.ptm_constants import CPTAC_CANCER_TYPES, CPTAC_CANCER_CLASS_MAP
+from hvantk.skills.cptac.shared.constants import CPTAC_CANCER_TYPES, CPTAC_CANCER_CLASS_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +246,7 @@ class CPTACPhosphoDataset:
     Parameters
     ----------
     cancer_type : str
-        One of :data:`~hvantk.core.ptm_constants.CPTAC_CANCER_TYPES`.
+        One of :data:`~hvantk.skills.cptac.shared.constants.CPTAC_CANCER_TYPES`.
     """
 
     cancer_type: str

--- a/hvantk/skills/peptideatlas/phospho/drift_probe.py
+++ b/hvantk/skills/peptideatlas/phospho/drift_probe.py
@@ -6,8 +6,8 @@ shape::
     {PEPTIDEATLAS_PHOSPHO_BASE_URL}/{build_date}/atlas_build_{build_id}.tsv.zip
 
 A new build is released once or twice per year. The pinned ``(build_date,
-build_id)`` lives in :mod:`hvantk.core.ptm_constants` and is exported by the
-dataset class as ``PeptideAtlasPhosphoDataset.from_latest()``. A HEAD request
+build_id)`` lives in :mod:`hvantk.skills.peptideatlas.phospho.shared.constants`
+and is exported by the dataset class as ``PeptideAtlasPhosphoDataset.from_latest()``. A HEAD request
 against that URL returns ``Last-Modified`` and ``Content-Length``, which
 together form a lightweight fingerprint that flips when a new build is cut
 or the existing archive is regenerated.

--- a/hvantk/skills/peptideatlas/phospho/shared/constants.py
+++ b/hvantk/skills/peptideatlas/phospho/shared/constants.py
@@ -1,0 +1,9 @@
+"""Plugin-local constants for the peptideatlas skill.
+
+Moved from hvantk/core/ptm_constants.py per issue #122 (clean-core principle).
+"""
+
+# PeptideAtlas Phospho Build
+PEPTIDEATLAS_PHOSPHO_BASE_URL = "https://peptideatlas.org/builds/human/phospho"
+PEPTIDEATLAS_LATEST_BUILD_DATE = "202512"
+PEPTIDEATLAS_LATEST_BUILD_ID = "606"

--- a/hvantk/skills/peptideatlas/phospho/shared/datasets.py
+++ b/hvantk/skills/peptideatlas/phospho/shared/datasets.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from hvantk.core.ptm_constants import (
+from hvantk.skills.peptideatlas.phospho.shared.constants import (
     PEPTIDEATLAS_PHOSPHO_BASE_URL,
     PEPTIDEATLAS_LATEST_BUILD_DATE,
     PEPTIDEATLAS_LATEST_BUILD_ID,

--- a/hvantk/skills/uniprot_ptm/drift_probe.py
+++ b/hvantk/skills/uniprot_ptm/drift_probe.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 import requests
 
 from hvantk.core.plugin.api import DriftProbeError
-from hvantk.core.ptm_constants import (
+from hvantk.skills.uniprot_ptm.shared.constants import (
     UNIPROT_API_FIELDS,
     UNIPROT_API_URL,
     UNIPROT_HUMAN_PTM_QUERY,

--- a/hvantk/skills/uniprot_ptm/shared/constants.py
+++ b/hvantk/skills/uniprot_ptm/shared/constants.py
@@ -1,0 +1,10 @@
+"""Plugin-local constants for the uniprot_ptm skill.
+
+Moved from hvantk/core/ptm_constants.py per issue #122 (clean-core principle).
+"""
+
+# UniProt REST API
+UNIPROT_API_URL = "https://rest.uniprot.org/uniprotkb/search"
+UNIPROT_API_FIELDS = "accession,gene_names,ft_mod_res,xref_ensembl,sequence"
+UNIPROT_HUMAN_PTM_QUERY = "organism_id:9606 AND reviewed:true AND ft_mod_res:*"
+UNIPROT_BATCH_SIZE = 500

--- a/hvantk/skills/uniprot_ptm/shared/datasets.py
+++ b/hvantk/skills/uniprot_ptm/shared/datasets.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from hvantk.core.ptm_constants import (
+from hvantk.skills.uniprot_ptm.shared.constants import (
     UNIPROT_API_URL,
     UNIPROT_API_FIELDS,
     UNIPROT_HUMAN_PTM_QUERY,

--- a/hvantk/skills/uniprot_ptm/tests/test_drift_probe.py
+++ b/hvantk/skills/uniprot_ptm/tests/test_drift_probe.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import requests_mock
 
-from hvantk.core.ptm_constants import (
+from hvantk.skills.uniprot_ptm.shared.constants import (
     UNIPROT_API_FIELDS,
     UNIPROT_API_URL,
     UNIPROT_HUMAN_PTM_QUERY,

--- a/hvantk/tests/test_ptm.py
+++ b/hvantk/tests/test_ptm.py
@@ -21,7 +21,7 @@ from hvantk.algorithms.ptm.mapper import (
     resolve_transcript,
 )
 from hvantk.algorithms.ptm.pipeline import PTMBuildConfig, map_ptm_sites
-from hvantk.core.ptm_constants import PTM_OUTPUT_COLUMNS
+from hvantk.algorithms.ptm.constants import PTM_OUTPUT_COLUMNS
 
 
 # ---------- Fixtures ----------


### PR DESCRIPTION
## Summary
- `UNIPROT_*` → `skills/uniprot_ptm/shared/constants.py`
- `PEPTIDEATLAS_*` → `skills/peptideatlas/phospho/shared/constants.py`
- `CPTAC_*` → `skills/cptac/shared/constants.py`
- `ENSEMBL_GTF_*`/`ENSEMBL_RELEASE` + the PTM-algorithm params (`PTM_TYPE_CATEGORIES`, `PTM_OUTPUT_COLUMNS`, `RESOLUTION_METHODS`, `EXPRESSION_BIN_LABELS`, `LMM_*`, `PROXIMAL_BP`, `DEFAULT_FLANKING_*`, `DEFAULT_MAF_THRESHOLDS`, `LOG_AF_EPSILON`) → `algorithms/ptm/constants.py` (NEW).
  - **Correction to the issue table:** `ENSEMBL_GTF_*` are consumed only by `algorithms/ptm/pipeline.py`, not by peptideatlas — so they go with the PTM algorithm, keeping `download_ensembl_gtf` an intra-`algorithms/` import.
- Dropped the dead `UNIPROT_*` re-exports from `algorithms/ptm/__init__.py`.
- Deleted the now-empty `core/ptm_constants.py`.

Closes #122 (one of several PRs).

## Test plan
- VERIFY-LINT: pass
- dependency-direction + intra-core guards: pass (11/11)
- `pytest tests/test_ptm.py`: pass (12/12)
- VERIFY-FAST: baseline-consistent (only pre-existing `test_cli_qtlcascade.py` failures)