### PR TITLE
refactor(#142): rename annotation Streamer classes to Annotator; decouple from legacy streaming base

### DIFF
--- a/hvantk/algorithms/annotation/annotation_pipeline.py
+++ b/hvantk/algorithms/annotation/annotation_pipeline.py
@@ -3,7 +3,8 @@
 
 import hail as hl
 from typing import Iterator, Optional, List, Dict, Any, Callable
-from hvantk.core.utils.streaming import DEFAULT_CHUNK_SIZE, HailDataStreamer, StreamProcessor
+from hvantk.core.utils.streaming import HailDataStreamer, StreamProcessor
+from hvantk.algorithms.annotation.annotator import Annotator, DEFAULT_CHUNK_SIZE
 from hvantk.algorithms.hgc.constants import VCF_EXTENSION
 import logging
 import os
@@ -47,14 +48,16 @@ class AnnotationConfig:
         return defaults.get(self.annotation_type, "key")
 
 
-class FlexibleAnnotationStreamer(HailDataStreamer):
+class FlexibleAnnotator(Annotator):
     """
-    Highly flexible annotation streamer that can handle any data source
+    Highly flexible annotator that can handle any data source
     through configuration rather than hard-coded implementations.
     """
 
     def __init__(self, config: AnnotationConfig, chunk_size: int = DEFAULT_CHUNK_SIZE):
-        super().__init__(f"FlexibleAnnotation_{config.name}", chunk_size)
+        super().__init__(
+            f"FlexibleAnnotation_{config.name}", config.source_path, chunk_size
+        )
         self.config = config
         self.annotation_data = None
 
@@ -337,9 +340,9 @@ class FlexibleAnnotationStreamer(HailDataStreamer):
         return annotated.annotate(**renames) if renames else annotated
 
     def stream(self) -> Iterator[hl.Table]:
-        """Not implemented for annotation streamers"""
+        """Not implemented for annotators"""
         raise NotImplementedError(
-            "FlexibleAnnotationStreamer is for processing existing chunks"
+            "FlexibleAnnotator is for processing existing chunks"
         )
 
     def process_chunk(self, chunk: hl.Table) -> hl.Table:
@@ -374,12 +377,12 @@ class AnnotationRegistry:
         """List all registered annotations"""
         return list(self._annotations.keys())
 
-    def create_streamer(self, name: str, **kwargs) -> FlexibleAnnotationStreamer:
-        """Create a streamer for a registered annotation"""
+    def create_annotator(self, name: str, **kwargs) -> FlexibleAnnotator:
+        """Create an annotator for a registered annotation"""
         config = self.get(name)
         if not config:
             raise ValueError(f"Annotation '{name}' not registered")
-        return FlexibleAnnotationStreamer(config, **kwargs)
+        return FlexibleAnnotator(config, **kwargs)
 
 
 class ConfigurableAnnotationPipeline(StreamProcessor):
@@ -407,9 +410,9 @@ class ConfigurableAnnotationPipeline(StreamProcessor):
     ) -> "ConfigurableAnnotationPipeline":
         """Add annotation by name (from registry) or direct config"""
         if config:
-            streamer = FlexibleAnnotationStreamer(config, **streamer_kwargs)
+            streamer = FlexibleAnnotator(config, **streamer_kwargs)
         elif annotation_name and self.registry:
-            streamer = self.registry.create_streamer(annotation_name, **streamer_kwargs)
+            streamer = self.registry.create_annotator(annotation_name, **streamer_kwargs)
         else:
             raise ValueError("Either annotation_name or config must be provided")
 

--- a/hvantk/algorithms/annotation/annotator.py
+++ b/hvantk/algorithms/annotation/annotator.py
@@ -1,23 +1,41 @@
-# Multi-Source Annotation Streamer
-# Extends the basic streamer to include variant and gene-level annotations
+# Multi-Source Annotators
+# Annotation pipeline steps that add variant and gene-level annotations to
+# existing data chunks. These are NOT DataModel streamers (the "Streamer"
+# concept is reserved for the Artifact-wrapping ABCs in
+# hvantk.core.streamers); they are pipeline-step "Annotators" with a small,
+# self-contained base that intentionally does not depend on the legacy
+# chunked-IO base in hvantk.core.utils.streaming.
 
 import hail as hl
-from typing import Iterator, Optional, Set
-from hvantk.core.utils.streaming import DEFAULT_CHUNK_SIZE, HailDataStreamer, StreamProcessor
+from abc import ABC, abstractmethod
+from typing import Iterator, Optional
+from hvantk.core.utils.hail_context import init_hail, hail_initialized
 import logging
 
 logger = logging.getLogger(__name__)
 
+# Default chunk size for annotators. Kept local (value 10000) so this module
+# does not depend on the legacy streaming module; matches the historical
+# default that the annotators inherited from HailDataStreamer.
+DEFAULT_CHUNK_SIZE = 10000
 
-class AnnotationStreamer(HailDataStreamer):
+
+class Annotator(ABC):
     """
-    Base class for annotation streamers that add features to variant data.
+    Base class for annotators that add features to existing data chunks.
+
+    Self-contained: provides the small surface the annotator family relies on
+    (name, chunk_size, logger, idempotent Hail-initializing setup, no-op
+    teardown, and the annotation hooks) without inheriting the legacy
+    chunked-IO streaming base.
     """
 
     def __init__(self, name: str, annotation_source: str, chunk_size: int = DEFAULT_CHUNK_SIZE):
-        super().__init__(name, chunk_size)
+        self.name = name
         self.annotation_source = annotation_source
+        self.chunk_size = chunk_size
         self.annotation_data = None
+        self.logger = logging.getLogger(f"{__name__}.{name}")
 
     def load_annotation_data(self) -> hl.Table:
         """
@@ -26,11 +44,17 @@ class AnnotationStreamer(HailDataStreamer):
         raise NotImplementedError("Subclasses must implement load_annotation_data")
 
     def setup(self) -> None:
-        """Load annotation data"""
-        super().setup()
+        """Initialize Hail (idempotently) and load annotation data."""
+        if not hail_initialized():
+            init_hail()
         self.logger.info(f"Loading annotation data from {self.annotation_source}")
         self.annotation_data = self.load_annotation_data()
 
+    def teardown(self) -> None:
+        """No-op for global Hail lifecycle (do not stop shared Hail context)."""
+        pass
+
+    @abstractmethod
     def annotate_chunk(self, chunk: hl.Table) -> hl.Table:
         """
         Add annotations to a chunk. Must be implemented by subclasses.
@@ -40,10 +64,10 @@ class AnnotationStreamer(HailDataStreamer):
     def stream(self) -> Iterator[hl.Table]:
         """
         This is used when the annotator is the first in pipeline.
-        Usually annotation streamers are used to process existing chunks.
+        Usually annotators are used to process existing chunks.
         """
         raise NotImplementedError(
-            "Annotation streamers typically process existing data chunks"
+            "Annotators typically process existing data chunks"
         )
 
     def process_chunk(self, chunk: hl.Table) -> hl.Table:
@@ -94,7 +118,7 @@ class AnnotationStreamer(HailDataStreamer):
             return chunk
 
 
-class VariantPredictionScoreStreamer(AnnotationStreamer):
+class VariantPredictionScoreAnnotator(Annotator):
     """
     Adds variant prediction scores (CADD, SIFT, PolyPhen, etc.) from dbNSFP.
     """
@@ -159,7 +183,7 @@ class VariantPredictionScoreStreamer(AnnotationStreamer):
         return annotated
 
 
-class GeneExpressionStreamer(AnnotationStreamer):
+class GeneExpressionAnnotator(Annotator):
     """
     Adds gene expression data from various tissue/cell types.
     """
@@ -226,7 +250,7 @@ class GeneExpressionStreamer(AnnotationStreamer):
         return annotated
 
 
-class GeneConstraintStreamer(AnnotationStreamer):
+class GeneConstraintAnnotator(Annotator):
     """
     Adds gene constraint metrics (pLI, LOEUF, etc.) and evolutionary metrics.
     """
@@ -287,7 +311,7 @@ class GeneConstraintStreamer(AnnotationStreamer):
         return annotated
 
 
-class PopulationFrequencyStreamer(AnnotationStreamer):
+class PopulationFrequencyAnnotator(Annotator):
     """
     Adds population frequency data from gnomAD.
     """

--- a/hvantk/core/utils/streaming.py
+++ b/hvantk/core/utils/streaming.py
@@ -7,15 +7,15 @@ new plugins implement those ABCs in skills/<plugin>/streamers.py.
 
 This module is retained because these code paths still depend on it:
 
-  - hvantk.algorithms.annotation.annotation_streamer (AnnotationStreamer
-    base + the four annotator subclasses) and annotation_pipeline
+  - hvantk.core.streamers.gene_disease_table (GeneDiseaseTableStreamer
+    inherits HailDataStreamer)
+  - hvantk.algorithms.annotation.annotation_pipeline (StreamProcessor
+    orchestration + a HailDataStreamer type hint)
   - hvantk.skills.clinvar.pipelines.training_set (ClinvarDataStreamer,
     ClinvarTrainingSetProcessor)
-  - hvantk.tools.training_sets.enhanced (EnhancedClinvarTrainingSetProcessor)
+  - hvantk.tools.training_sets.enhanced (EnhancedClinvarTrainingSetProcessor
+    uses StreamProcessor)
   - hvantk.skills.alphagenome.streamer (AlphaGenomeStreamer)
-
-The "Annotator" rename + reframing of the annotation_streamer family is
-tracked in a follow-up issue; when it lands, this module can be removed.
 
 For chunked iteration in new code, write a small private helper next to
 the calling class.

--- a/hvantk/tests/test_flexible_annotation.py
+++ b/hvantk/tests/test_flexible_annotation.py
@@ -6,7 +6,7 @@ import logging
 from unittest.mock import Mock, patch
 from hvantk.algorithms.annotation.annotation_pipeline import (
     AnnotationConfig,
-    FlexibleAnnotationStreamer,
+    FlexibleAnnotator,
     AnnotationRegistry,
     ConfigurableAnnotationPipeline,
     create_flexible_pipeline,
@@ -212,7 +212,7 @@ class TestRealWorldScenarios:
         # All should be creatable without code changes
         streamers = []
         for config in configs:
-            streamer = FlexibleAnnotationStreamer(config)
+            streamer = FlexibleAnnotator(config)
             streamers.append(streamer)
             assert streamer.config.name == config.name
 
@@ -222,7 +222,7 @@ class TestRealWorldScenarios:
         """Test that new framework doesn't break existing functionality"""
 
         # Original hard-coded approach should still work
-        from hvantk.algorithms.annotation.annotation_streamer import VariantPredictionScoreStreamer
+        from hvantk.algorithms.annotation.annotator import VariantPredictionScoreAnnotator
 
         # New flexible approach
         flexible_config = AnnotationConfig(
@@ -231,7 +231,7 @@ class TestRealWorldScenarios:
             annotation_type="variant",
             loader_func=lambda _: Mock(spec=hl.Table),
         )
-        flexible_streamer = FlexibleAnnotationStreamer(flexible_config)
+        flexible_streamer = FlexibleAnnotator(flexible_config)
 
         # Both should have similar interfaces
         assert hasattr(flexible_streamer, "process_chunk")
@@ -245,7 +245,7 @@ class TestRealWorldScenarios:
             name="bad_source", source_path="/nonexistent/path.tsv"
         )
 
-        streamer = FlexibleAnnotationStreamer(bad_config)
+        streamer = FlexibleAnnotator(bad_config)
 
         # Should handle missing data gracefully
         mock_chunk = Mock(spec=hl.Table)

--- a/hvantk/tools/training_sets/enhanced.py
+++ b/hvantk/tools/training_sets/enhanced.py
@@ -1,9 +1,9 @@
 # Enhanced Training Set Generation Pipeline
 # Composes a ClinVar skill data source with algorithm-level annotators.
 #
-# Moved from hvantk/algorithms/annotation/annotation_streamer.py (issue #121).
+# Moved from hvantk/algorithms/annotation/annotator.py (issue #121).
 # Only tools/ may import both skills/ (ClinvarDataStreamer) and algorithms/
-# (VariantPredictionScoreStreamer, etc.) -- that is the correct layer for
+# (VariantPredictionScoreAnnotator, etc.) -- that is the correct layer for
 # code that crosses the boundary between data sources and annotators.
 
 import hail as hl
@@ -11,11 +11,11 @@ from typing import Optional, Set
 
 from hvantk.core.utils.streaming import StreamProcessor
 from hvantk.skills.clinvar.pipelines.training_set import ClinvarDataStreamer
-from hvantk.algorithms.annotation.annotation_streamer import (
-    VariantPredictionScoreStreamer,
-    GeneExpressionStreamer,
-    GeneConstraintStreamer,
-    PopulationFrequencyStreamer,
+from hvantk.algorithms.annotation.annotator import (
+    VariantPredictionScoreAnnotator,
+    GeneExpressionAnnotator,
+    GeneConstraintAnnotator,
+    PopulationFrequencyAnnotator,
 )
 
 import logging
@@ -55,13 +55,13 @@ class EnhancedClinvarTrainingSetProcessor(StreamProcessor):
         self.add_streamer(clinvar_streamer)
 
         if include_prediction_scores:
-            self.add_streamer(VariantPredictionScoreStreamer(""))
+            self.add_streamer(VariantPredictionScoreAnnotator(""))
         if include_expression:
-            self.add_streamer(GeneExpressionStreamer("", tissue_focus))
+            self.add_streamer(GeneExpressionAnnotator("", tissue_focus))
         if include_constraint:
-            self.add_streamer(GeneConstraintStreamer())
+            self.add_streamer(GeneConstraintAnnotator())
         if include_population_freq:
-            self.add_streamer(PopulationFrequencyStreamer())
+            self.add_streamer(PopulationFrequencyAnnotator())
 
     def process(self, output_path: Optional[str] = None) -> Optional[hl.Table]:
         """
@@ -76,7 +76,7 @@ class EnhancedClinvarTrainingSetProcessor(StreamProcessor):
         try:
             # Start with Clinvar data
             clinvar_streamer = self.streamers[0]
-            annotation_streamers = self.streamers[1:]
+            annotators = self.streamers[1:]
 
             all_chunks = []
 
@@ -84,9 +84,9 @@ class EnhancedClinvarTrainingSetProcessor(StreamProcessor):
                 if base_chunk.count() == 0:
                     continue
 
-                # Apply each annotation streamer sequentially
+                # Apply each annotator sequentially
                 annotated_chunk = base_chunk
-                for annotator in annotation_streamers:
+                for annotator in annotators:
                     annotated_chunk = annotator.process_chunk(annotated_chunk)
 
                 all_chunks.append(annotated_chunk)


### PR DESCRIPTION
Follow-up from the #121 streamer-architecture refactor. Part of issue #142.

The word "Streamer" is reserved for the per-DataModel ABCs in `core/streamers/`. The classes in `algorithms/annotation/` were annotation **pipeline steps**, not DataModel streamers, yet still used the `*Streamer` suffix and inherited the legacy chunked-IO base `core/utils/streaming.HailDataStreamer`.

## What changed

- **Rename** `annotation_streamer.py` → `annotator.py` (git rename, history preserved).
- **Class renames:** `AnnotationStreamer`→`Annotator`, `VariantPredictionScoreStreamer`→`VariantPredictionScoreAnnotator`, `GeneExpressionStreamer`→`GeneExpressionAnnotator`, `GeneConstraintStreamer`→`GeneConstraintAnnotator`, `PopulationFrequencyStreamer`→`PopulationFrequencyAnnotator`, `FlexibleAnnotationStreamer`→`FlexibleAnnotator`.
- **Decouple from legacy base:** new self-contained `Annotator(ABC)` no longer inherits `HailDataStreamer`. Behavior is preserved exactly — `setup()` does idempotent Hail init (`if not hail_initialized(): init_hail()`) then loads annotation data; `teardown()` no-op; `process_chunk()`/`stream()`/`_safe_gene_annotate()` unchanged; `DEFAULT_CHUNK_SIZE = 10000` defined locally.
- **Consumers updated:** `tools/training_sets/enhanced.py`, `tests/test_flexible_annotation.py`. Also renamed `AnnotationRegistry.create_streamer`→`create_annotator` (leftover of the rename).

## Scope note — `core/utils/streaming.py` is intentionally retained (not deleted)

Issue #142 lists deleting `streaming.py` as the end goal "when the family no longer depends on it." An audit shows the module has **other** live dependents beyond the annotation family, so it cannot be deleted yet:

- `core/streamers/gene_disease_table.py` — `GeneDiseaseTableStreamer` inherits `HailDataStreamer` (this dependent was **missing** from the issue's retention list; the module docstring is corrected here to include it).
- `algorithms/annotation/annotation_pipeline.py` — `ConfigurableAnnotationPipeline(StreamProcessor)` orchestration + a `HailDataStreamer` type hint.
- `skills/clinvar/pipelines/training_set.py`, `tools/training_sets/enhanced.py` — `StreamProcessor`.
- `skills/alphagenome/streamer.py` — `HailDataStreamer` (tracked by #143).

This PR removes the annotation-family dependency on `streaming.py` and corrects the retention docstring. Final deletion of `streaming.py` remains gated on #143, #144, and migrating the clinvar pipelines + `gene_disease_table` off the legacy base.

## Verification

- `flake8 --select=E9,F63,F7,F82` → 0
- Architecture guards (`test_dependency_directions.py`, `test_intra_core_dependencies.py`) → all pass
- Full fast suite (`pytest -q --continue-on-collection-errors`) → only the pre-existing baseline failures (2 `test_cli_qtlcascade.py`, 12 `test_drift_probe.py` collection errors); no new failures
- Reviewed for spec compliance and code quality (two independent review passes)

Refs #142.
