### PR TITLE
refactor(#145): inject ClinVar pathogenicity vocabulary into annotation & ptm (1/2)

### DIFF
--- a/hvantk/algorithms/annotation/annotate.py
+++ b/hvantk/algorithms/annotation/annotate.py
@@ -12,34 +12,14 @@ from hvantk.core.io.legacy_artifacts import (
 )
 
 
-def annotate_clinvar_clnsig(t: hl.Table) -> hl.Table:
+def annotate_clinvar_clnsig(
+    t: hl.Table, *, pathogenic_labels, benign_labels
+) -> hl.Table:
     """
     Annotates variants with simplified ClinVar clinical significance labels.
 
-    Variants are annotated with a clinical significance label based on ClinVar data: "P" for pathogenic, "B" for benign, or missing if neither applies. The annotation is determined by matching ClinVar CLNSIG values against predefined sets of pathogenic and benign labels.
+    Variants are annotated with a clinical significance label based on ClinVar data: "P" for pathogenic, "B" for benign, or missing if neither applies. The annotation is determined by matching ClinVar CLNSIG values against the injected pathogenic and benign label vocabularies.
     """
-    # TEMP duplication — tracked by https://github.com/bigbio/hvantk/issues/133
-    #
-    # These label sets are also defined in
-    # hvantk/skills/clinvar/shared/constants.py. Importing them from
-    # there would violate the algorithms-must-not-import-from-skills
-    # dependency guard.
-    #
-    # The proper fix — parameterizing the schema and vocabulary so this
-    # function accepts any conformant pathogenicity-labeled table, not
-    # just ClinVar — is tracked by issue #133. Remove this duplication
-    # when that parameterization lands.
-    CLINVAR_PATHOGENIC_LABELS = [
-        "Pathogenic/Likely_pathogenic",
-        "Likely_pathogenic",
-        "Pathogenic",
-    ]
-    CLINVAR_BENIGN_LABELS = [
-        "Benign/Likely_benign",
-        "Likely_benign",
-        "Benign",
-    ]
-
     logger.info("Annotating ClinVar CLNSIG")
     clinvar_ht = load_legacy_table("clinvar")
 
@@ -48,10 +28,10 @@ def annotate_clinvar_clnsig(t: hl.Table) -> hl.Table:
 
     # Now compute conditions using the annotated field
     is_pathogenic = t.clinvar_clnsig.any(
-        lambda x: hl.set(CLINVAR_PATHOGENIC_LABELS).contains(x)
+        lambda x: hl.set(pathogenic_labels).contains(x)
     )
     is_benign = t.clinvar_clnsig.any(
-        lambda x: hl.set(CLINVAR_BENIGN_LABELS).contains(x)
+        lambda x: hl.set(benign_labels).contains(x)
     )
 
     t = t.annotate(

--- a/hvantk/algorithms/ptm/analysis.py
+++ b/hvantk/algorithms/ptm/analysis.py
@@ -17,29 +17,6 @@ from typing import Dict, List, Optional
 
 import hail as hl
 
-# TEMP duplication — tracked by https://github.com/bigbio/hvantk/issues/133
-#
-# These label sets are also defined in
-# hvantk/skills/clinvar/shared/constants.py. Importing them from there
-# would violate the algorithms-must-not-import-from-skills dependency
-# guard (see hvantk/tests/test_dependency_directions.py and
-# hvantk/tests/test_tools_ptm_pipeline.py).
-#
-# The proper fix — parameterizing the schema and vocabulary so this
-# module accepts any conformant pathogenicity-labeled table, not just
-# ClinVar — is tracked by issue #133. Remove this duplication when
-# that parameterization lands.
-CLINVAR_PATHOGENIC_LABELS = [
-    "Pathogenic/Likely_pathogenic",
-    "Likely_pathogenic",
-    "Pathogenic",
-]
-CLINVAR_BENIGN_LABELS = [
-    "Benign/Likely_benign",
-    "Likely_benign",
-    "Benign",
-]
-
 logger = logging.getLogger(__name__)
 
 
@@ -136,11 +113,11 @@ def _extract_clnsig(ht: hl.Table) -> hl.Expression:
     return ht.info.CLNSIG
 
 
-def _label_clinvar(ht: hl.Table) -> hl.Table:
+def _label_clinvar(ht: hl.Table, *, pathogenic_labels, benign_labels) -> hl.Table:
     """Add _label field ('P', 'B', or 'other') based on ClinVar CLNSIG."""
     clnsig = _extract_clnsig(ht)
-    p_labels = hl.literal(CLINVAR_PATHOGENIC_LABELS)
-    b_labels = hl.literal(CLINVAR_BENIGN_LABELS)
+    p_labels = hl.literal(pathogenic_labels)
+    b_labels = hl.literal(benign_labels)
     return ht.annotate(
         _label=hl.case()
         .when(hl.is_defined(clnsig) & p_labels.contains(clnsig), "P")
@@ -274,6 +251,9 @@ def ptm_landscape(
     clinvar_ht: hl.Table,
     ptm_ht: hl.Table,
     output_dir: str,
+    *,
+    pathogenic_labels,
+    benign_labels,
     flanking_codons: int = 5,
 ) -> PTMLandscapeResult:
     """PTM-variant overlap and enrichment analysis (Q1).
@@ -290,6 +270,10 @@ def ptm_landscape(
         PTM sites Hail Table built via ``hvantk reprocess uniprot_ptm:sites``.
     output_dir : str
         Directory for output files (landscape_summary.json).
+    pathogenic_labels : Iterable[str]
+        ClinVar CLNSIG values treated as pathogenic.
+    benign_labels : Iterable[str]
+        ClinVar CLNSIG values treated as benign.
     flanking_codons : int
         Flanking codons for proximal window (default: 5).
 
@@ -304,7 +288,11 @@ def ptm_landscape(
 
     # Annotate ClinVar with PTM info and assign P/B labels
     annotated = annotate_variants_with_ptm(clinvar_ht, ptm_ht, flanking_codons)
-    annotated = _label_clinvar(annotated)
+    annotated = _label_clinvar(
+        annotated,
+        pathogenic_labels=pathogenic_labels,
+        benign_labels=benign_labels,
+    )
 
     # Aggregate counts in a single pass
     stats = annotated.aggregate(

--- a/hvantk/skills/clinvar/streamers.py
+++ b/hvantk/skills/clinvar/streamers.py
@@ -6,10 +6,17 @@ from typing import Iterable
 import hail as hl
 
 from hvantk.core.streamers.variant_table import VariantTableStreamer
+from hvantk.skills.clinvar.shared.constants import (
+    CLINVAR_PATHOGENIC_LABELS,
+    CLINVAR_BENIGN_LABELS,
+)
 
 
 class ClinVarVariantTableStreamer(VariantTableStreamer):
     """ClinVar variant table streamer (info.CLNSIG, info.GENEINFO, info.CLNDN)."""
+
+    PATHOGENIC_LABELS = CLINVAR_PATHOGENIC_LABELS
+    BENIGN_LABELS = CLINVAR_BENIGN_LABELS
 
     def to_hail(self) -> hl.Table:
         return self._artifact.to_hail()

--- a/hvantk/tools/annotation/annotate_features.py
+++ b/hvantk/tools/annotation/annotate_features.py
@@ -26,6 +26,7 @@ from hvantk.algorithms.annotation.annotate import (
     annotate_clinvar_clnsig,
     annotate_hca,
 )
+from hvantk.skills.clinvar.streamers import ClinVarVariantTableStreamer
 
 """
 Annotate variant table with features from multiple sources.
@@ -69,7 +70,11 @@ def main(args):
     # annotate clinvar significance
     # annotate clinvar significance
     logger.info("Annotating ClinVar significance")
-    ht = annotate_clinvar_clnsig(ht)
+    ht = annotate_clinvar_clnsig(
+        ht,
+        pathogenic_labels=ClinVarVariantTableStreamer.PATHOGENIC_LABELS,
+        benign_labels=ClinVarVariantTableStreamer.BENIGN_LABELS,
+    )
 
     # annotate variant ID from locus and alleles
     logger.info("Annotating variant ID")

--- a/hvantk/tools/ptm/ptm_cli.py
+++ b/hvantk/tools/ptm/ptm_cli.py
@@ -258,11 +258,19 @@ def ptm_landscape_cmd(ctx, clinvar_ht, ptm_ht, output, flanking_codons, save_plo
         import os
         import hail as hl
         from hvantk.algorithms.ptm.analysis import ptm_landscape
+        from hvantk.skills.clinvar.streamers import ClinVarVariantTableStreamer
 
         clinvar = hl.read_table(clinvar_ht)
         ptm = hl.read_table(ptm_ht)
 
-        result = ptm_landscape(clinvar, ptm, output, flanking_codons=flanking_codons)
+        result = ptm_landscape(
+            clinvar,
+            ptm,
+            output,
+            pathogenic_labels=ClinVarVariantTableStreamer.PATHOGENIC_LABELS,
+            benign_labels=ClinVarVariantTableStreamer.BENIGN_LABELS,
+            flanking_codons=flanking_codons,
+        )
         click.echo(result.summary())
 
         if save_plots:


### PR DESCRIPTION
PR 1 of 2 for issue #145 (closes #133). Replaces TEMP-duplicated ClinVar pathogenicity label lists with an **injected vocabulary** at two of the three sites — the `annotation` and `ptm` algorithms. (`psroc` follows in PR 2.)

Algorithms cannot import the canonical labels from `skills/clinvar/shared/constants.py` (the dependency guard forbids `algorithms/` → `skills/`), which is why the lists were duplicated. The fix passes the vocabulary in as parameters; only the `tools/` layer (which may import `skills/`) supplies it.

## What changed

- **`skills/clinvar/streamers.py`** — `ClinVarVariantTableStreamer` now exposes `PATHOGENIC_LABELS` / `BENIGN_LABELS` as class attributes, sourced **by reference** from `skills/clinvar/shared/constants.py` (one source of truth). This realizes the issue's "via the `VariantTableStreamer` contract" intent and mirrors the existing `ClinvarDataStreamer.PATHOGENIC_LABELS`/`BENIGN_LABELS` precedent.
- **`algorithms/annotation/annotate.py`** — `annotate_clinvar_clnsig(t, *, pathogenic_labels, benign_labels)`; TEMP-duplicated lists removed; classification logic unchanged.
- **`algorithms/ptm/analysis.py`** — `_label_clinvar` and `ptm_landscape` take injected `pathogenic_labels`/`benign_labels` (keyword-only); module-level TEMP lists removed; `ptm_population` untouched.
- **`tools/annotation/annotate_features.py`**, **`tools/ptm/ptm_cli.py`** — supply the vocabulary from `ClinVarVariantTableStreamer`.

No `hvantk.skills`/`hvantk.tools` import was added under `algorithms/` — the dependency guards stay green.

## Verification

- `flake8 --select=E9,F63,F7,F82` → 0
- Guards (`test_dependency_directions.py`, `test_intra_core_dependencies.py`, `test_tools_ptm_pipeline.py` incl. `test_algorithms_ptm_has_no_skill_imports`) → all pass
- Focused (`test_ptm.py`, `test_annotate_features_cli.py`) → pass
- Full fast suite → only the pre-existing baseline failures (2 `test_cli_qtlcascade.py`, 12 `test_drift_probe.py` collection errors)
- Spec-compliance reviewed independently.

Refs #145, #133.
