### PR TITLE
refactor(#145): inject ClinVar pathogenicity vocabulary into psroc; remove last TEMP duplication (2/2)

### DIFF
--- a/examples/psroc/run_psroc_example.py
+++ b/examples/psroc/run_psroc_example.py
@@ -120,6 +120,7 @@ def main(output_dir: str = "/tmp/psroc_example") -> int:
     try:
         from hvantk.core.utils.hail_context import init_hail
         from hvantk.algorithms.psroc import PSROCConfig, PSROCPipeline
+        from hvantk.skills.clinvar.streamers import ClinVarVariantTableStreamer
     except ImportError as e:
         print(f"ERROR: Failed to import hvantk modules: {e}")
         print("Make sure hvantk is installed: poetry install")
@@ -161,6 +162,8 @@ def main(output_dir: str = "/tmp/psroc_example") -> int:
         generate_plots=True,
         export_tsv=True,
         overwrite=True,
+        pathogenic_labels=ClinVarVariantTableStreamer.PATHOGENIC_LABELS,
+        benign_labels=ClinVarVariantTableStreamer.BENIGN_LABELS,
     )
 
     print(f"Genes: {config.genes}")

--- a/hvantk/algorithms/psroc/__init__.py
+++ b/hvantk/algorithms/psroc/__init__.py
@@ -41,8 +41,6 @@ from hvantk.algorithms.psroc.pipeline import (
     PSROCResult,
     PSROCPipeline,
     PSROCStage,
-    PATHOGENIC_LABELS,
-    BENIGN_LABELS,
 )
 
 __all__ = [
@@ -67,7 +65,4 @@ __all__ = [
     "PSROCResult",
     "PSROCPipeline",
     "PSROCStage",
-    # Constants
-    "PATHOGENIC_LABELS",
-    "BENIGN_LABELS",
 ]

--- a/hvantk/algorithms/psroc/pipeline.py
+++ b/hvantk/algorithms/psroc/pipeline.py
@@ -57,29 +57,6 @@ from hvantk.core.utils.gene_sets import load_gene_set
 logger = logging.getLogger(__name__)
 
 
-# TEMP duplication — tracked by https://github.com/bigbio/hvantk/issues/133
-#
-# These label sets are also defined in
-# hvantk/skills/clinvar/shared/constants.py (under names
-# CLINVAR_PATHOGENIC_LABELS / CLINVAR_BENIGN_LABELS). Importing them
-# from there would violate the algorithms-must-not-import-from-skills
-# dependency guard.
-#
-# The proper fix — parameterizing the schema and vocabulary so this
-# module accepts any conformant pathogenicity-labeled table, not just
-# ClinVar — is tracked by issue #133. Remove this duplication when
-# that parameterization lands.
-PATHOGENIC_LABELS = [
-    "Pathogenic/Likely_pathogenic",
-    "Likely_pathogenic",
-    "Pathogenic",
-]
-BENIGN_LABELS = [
-    "Benign/Likely_benign",
-    "Likely_benign",
-    "Benign",
-]
-
 # Score directionality: True means higher values indicate pathogenicity.
 # Scores not in this map default to higher_is_pathogenic=True.
 SCORE_DIRECTIONALITY: Dict[str, bool] = {
@@ -218,6 +195,12 @@ class PSROCConfig:
 
     # Bootstrap confidence interval for AUC
     n_bootstrap: int = 2000
+
+    # ClinVar pathogenicity vocabulary (injected by the CLI/caller; see #145).
+    # algorithms/ may not import skills/, so the vocabulary is supplied as
+    # config rather than imported from skills/clinvar/shared/constants.py.
+    pathogenic_labels: Optional[List[str]] = None
+    benign_labels: Optional[List[str]] = None
 
     def validate(self) -> List[str]:
         """Validate configuration and return list of errors.
@@ -825,6 +808,8 @@ class PSROCPipeline:
                 group_name=group_name,
                 min_variants=self.config.min_variants,
                 n_bootstrap=self.config.n_bootstrap,
+                pathogenic_labels=self.config.pathogenic_labels,
+                benign_labels=self.config.benign_labels,
             )
 
             try:
@@ -1096,6 +1081,14 @@ class PSROCPipeline:
         """Stage 3: Assign binary labels to ClinVar variants."""
         logger.info("🔄 [3/7] Assigning binary labels (Pathogenic/Benign)...")
 
+        pathogenic_labels = self.config.pathogenic_labels
+        benign_labels = self.config.benign_labels
+        if not pathogenic_labels or not benign_labels:
+            raise ValueError(
+                "PSROCConfig.pathogenic_labels and benign_labels must be set "
+                "(the CLI supplies ClinVar's vocabulary); see issue #145."
+            )
+
         if self._labeled_ht is None:
             raise RuntimeError(
                 "ClinVar variants not filtered. Run _filter_clinvar first."
@@ -1119,13 +1112,13 @@ class PSROCPipeline:
             .when(
                 hl.is_defined(clnsig)
                 & (clnsig != "")
-                & hl.literal(PATHOGENIC_LABELS).contains(clnsig),
+                & hl.literal(pathogenic_labels).contains(clnsig),
                 "Pathogenic",
             )
             .when(
                 hl.is_defined(clnsig)
                 & (clnsig != "")
-                & hl.literal(BENIGN_LABELS).contains(clnsig),
+                & hl.literal(benign_labels).contains(clnsig),
                 "Benign",
             )
             .default("Uncertain/Conflicting"),

--- a/hvantk/tests/psroc/test_pipeline.py
+++ b/hvantk/tests/psroc/test_pipeline.py
@@ -18,8 +18,6 @@ from hvantk.algorithms.psroc.pipeline import (
     PSROCResult,
     PSROCPipeline,
     PSROCStage,
-    PATHOGENIC_LABELS,
-    BENIGN_LABELS,
     CLNREVSTAT_STAR_MAP,
     SCORE_DIRECTIONALITY,
     parse_variant_list,
@@ -407,20 +405,6 @@ class TestPSROCStage:
 
 class TestConstants:
     """Test pipeline constants (labels, star map)."""
-
-    def test_pathogenic_labels(self):
-        """Test pathogenic label list."""
-        assert "Pathogenic" in PATHOGENIC_LABELS
-        assert "Likely_pathogenic" in PATHOGENIC_LABELS
-        assert "Pathogenic/Likely_pathogenic" in PATHOGENIC_LABELS
-        assert len(PATHOGENIC_LABELS) == 3
-
-    def test_benign_labels(self):
-        """Test benign label list."""
-        assert "Benign" in BENIGN_LABELS
-        assert "Likely_benign" in BENIGN_LABELS
-        assert "Benign/Likely_benign" in BENIGN_LABELS
-        assert len(BENIGN_LABELS) == 3
 
     def test_clnrevstat_star_map_known_values(self):
         """Test CLNREVSTAT star map assigns correct star counts."""

--- a/hvantk/tools/ptm/psroc_cli.py
+++ b/hvantk/tools/ptm/psroc_cli.py
@@ -360,6 +360,10 @@ def psroc_cmd(
             click.echo(f"Loaded {len(gene_set_collection)} gene sets from {gene_sets}")
 
         # Create configuration
+        # tools/ is the only layer allowed to import skills/; it supplies the
+        # ClinVar pathogenicity vocabulary to the psroc algorithm (see #145).
+        from hvantk.skills.clinvar.streamers import ClinVarVariantTableStreamer
+
         config = PSROCConfig(
             genes=genes_list,
             genes_file=genes_file,
@@ -380,6 +384,8 @@ def psroc_cmd(
             generate_plots=not no_plots,
             min_variants=min_variants,
             n_bootstrap=n_bootstrap,
+            pathogenic_labels=ClinVarVariantTableStreamer.PATHOGENIC_LABELS,
+            benign_labels=ClinVarVariantTableStreamer.BENIGN_LABELS,
         )
 
         # Validate configuration


### PR DESCRIPTION
PR 2 of 2 for issue #145 — **closes #133**. Removes the final TEMP-duplicated ClinVar pathogenicity label list, in the `psroc` algorithm, replacing it with an injected vocabulary. After this PR, no `algorithms/` module holds a copy of the ClinVar P/B labels.

## What changed

- **`algorithms/psroc/pipeline.py`** — removed the module-level `PATHOGENIC_LABELS`/`BENIGN_LABELS` lists + TEMP comment. `PSROCConfig` gains `pathogenic_labels`/`benign_labels` (`Optional[List[str]] = None`). `PSROCPipeline._assign_labels` reads them and raises a clear `ValueError` if unset; the `hl.case()` Pathogenic/Benign/default classification logic is unchanged. `run_collection` forwards the vocabulary to per-group configs.
- **`algorithms/psroc/__init__.py`** — dropped the `PATHOGENIC_LABELS`/`BENIGN_LABELS` re-exports (no external consumers; verified by grep).
- **`tools/ptm/psroc_cli.py`**, **`examples/psroc/run_psroc_example.py`** — supply the vocabulary from `ClinVarVariantTableStreamer` (exposed in PR #151).
- **`tests/psroc/test_pipeline.py`** — removed the two obsolete label-content assertions (the symbols they tested no longer exist; the vocabulary's correctness is now anchored at its single source in `skills/clinvar`).

`algorithms/` gains no `skills/`/`tools/` import — dependency guards stay green.

## #133 closure proof

- `grep -rn "PATHOGENIC_LABELS|BENIGN_LABELS" hvantk/algorithms/` → empty (no copies anywhere in the algorithms tree).
- `grep -rn "TEMP duplication" hvantk/algorithms/psroc/` → empty.

## Verification

- `flake8 --select=E9,F63,F7,F82` → 0
- Guards (`test_dependency_directions.py`, `test_intra_core_dependencies.py`) → pass
- `pytest hvantk/tests/psroc/` → 143 passed (16 `@pytest.mark.hail` deselected)
- Full fast suite → only the pre-existing baseline failures (2 `test_cli_qtlcascade.py`, 12 `test_drift_probe.py`)
- Spec-compliance reviewed independently.

Closes #133. Refs #145.
