### PR TITLE
refactor(#143): reclassify AlphaGenomeStreamer as AlphaGenomePipeline; decouple from legacy streaming base

### DIFF
--- a/hvantk/core/utils/streaming.py
+++ b/hvantk/core/utils/streaming.py
@@ -15,7 +15,6 @@ This module is retained because these code paths still depend on it:
     ClinvarTrainingSetProcessor)
   - hvantk.tools.training_sets.enhanced (EnhancedClinvarTrainingSetProcessor
     uses StreamProcessor)
-  - hvantk.skills.alphagenome.streamer (AlphaGenomeStreamer)
 
 For chunked iteration in new code, write a small private helper next to
 the calling class.

--- a/hvantk/skills/alphagenome/SKILL.md
+++ b/hvantk/skills/alphagenome/SKILL.md
@@ -3,7 +3,7 @@
 AlphaGenome is a deep learning model from Google DeepMind that predicts the
 functional effects of genetic variants on gene expression, chromatin accessibility,
 and other molecular phenotypes at nucleotide resolution. The hvantk builder runs
-the AlphaGenome API via the AlphaGenomeStreamer for a given set of input variants
+the AlphaGenome API via the AlphaGenomePipeline for a given set of input variants
 and produces a Hail Table keyed by (locus, alleles).
 
 ## Dataset
@@ -15,7 +15,7 @@ and produces a Hail Table keyed by (locus, alleles).
 This plugin was promoted from the hardcoded `_TABLE_BUILDERS` entry of
 the same name as part of Phase K of the data-model platform refactor.
 The builder uses a delegation-stub to the legacy `create_alphagenome_tb`
-because the AlphaGenome builder wraps the AlphaGenomeStreamer with complex
+because the AlphaGenome builder wraps the AlphaGenomePipeline with complex
 setup/teardown. The drift probe is a stub. The downloader is not implemented;
 a config_path parameter pointing to an AlphaGenome YAML config is required.
 

--- a/hvantk/skills/alphagenome/builder.py
+++ b/hvantk/skills/alphagenome/builder.py
@@ -1,6 +1,6 @@
 """Hail Table builder for AlphaGenome variant effect predictions.
 
-Owns the full pipeline: drives the local AlphaGenomeStreamer to call the
+Owns the full pipeline: drives the local AlphaGenomePipeline to call the
 external API for each variant, persists predictions and checkpoint files
 to a temp directory, then re-emits a Hail Table keyed by (locus, alleles)
 under the Phase B contract.
@@ -20,7 +20,7 @@ from hvantk.core.utils.file_utils import resolve_compression
 logger = logging.getLogger(__name__)
 
 
-def _run_alphagenome_streamer(
+def _run_alphagenome_pipeline(
     input_path: str,
     output_path: str,
     config_path: str,
@@ -29,27 +29,27 @@ def _run_alphagenome_streamer(
 ) -> "hl.Table":
     """Run AlphaGenome predictions and return a checkpointed Hail Table.
 
-    Drives AlphaGenomeStreamer for the API calls, then builds a minimal
+    Drives AlphaGenomePipeline for the API calls, then builds a minimal
     Hail Table keyed by (locus, alleles) from the input variants and
     checkpoints it under output_path/alphagenome_variants.ht.
     """
-    from hvantk.skills.alphagenome.streamer import AlphaGenomeStreamer
+    from hvantk.skills.alphagenome.pipelines import AlphaGenomePipeline
 
     if overwrite and os.path.isdir(output_path):
         shutil.rmtree(output_path)
 
-    streamer = AlphaGenomeStreamer(
+    pipeline = AlphaGenomePipeline(
         input_path=input_path,
         output_dir=output_path,
         config_path=config_path,
         no_resume=no_resume,
     )
-    streamer.setup()
+    pipeline.setup()
     try:
-        for _batch in streamer.stream():
+        for _batch in pipeline.stream():
             pass  # checkpointing handled internally
     finally:
-        streamer.teardown()
+        pipeline.teardown()
 
     logger.info("Creating AlphaGenome variants table from %s", input_path)
 
@@ -110,7 +110,7 @@ def build_alphagenome_predictions(parsed_input, ctx, **params):
     with tempfile.TemporaryDirectory() as td:
         tmp_out = os.path.join(td, "alphagenome_out")
         os.makedirs(tmp_out, exist_ok=True)
-        _run_alphagenome_streamer(
+        _run_alphagenome_pipeline(
             input_path=str(parsed_input),
             output_path=tmp_out,
             overwrite=True,

--- a/hvantk/skills/alphagenome/pipelines.py
+++ b/hvantk/skills/alphagenome/pipelines.py
@@ -1,9 +1,15 @@
-"""AlphaGenome variant prediction streamer.
+"""AlphaGenome variant prediction pipeline.
 
-Streams variant positions through the AlphaGenome API and produces
-multimodal variant effect predictions. Outputs are currently written as
-consolidated JSON (predictions.json); per-modality Hail Table assembly
-will be added once the AlphaGenome SDK response structure is validated.
+Runs variant positions through the AlphaGenome API as a one-shot pipeline
+and produces multimodal variant effect predictions. Outputs are currently
+written as consolidated JSON (predictions.json); per-modality Hail Table
+assembly will be added once the AlphaGenome SDK response structure is
+validated.
+
+This is NOT a per-DataModel streamer (the ``Streamer`` ABCs live in
+:mod:`hvantk.core.streamers`). The AlphaGenome VariantTable artifact is
+produced by :mod:`hvantk.skills.alphagenome.builder`
+(``build_alphagenome_predictions``, ``schema_id="alphagenome-v1"``).
 """
 
 import csv as csv_module
@@ -25,7 +31,7 @@ from hvantk.skills.alphagenome.shared.constants import (
     ALPHAGENOME_DEFAULT_REQUEST_TIMEOUT,
     ALPHAGENOME_DEFAULT_RETRY_BACKOFF,
 )
-from hvantk.core.utils.streaming import HailDataStreamer
+from hvantk.core.utils.hail_context import init_hail, hail_initialized
 
 logger = logging.getLogger(__name__)
 
@@ -528,14 +534,19 @@ def _serialize_prediction(result: Any) -> Dict[str, Any]:
         return {"raw": str(result)}
 
 
-class AlphaGenomeStreamer(HailDataStreamer):
-    """Streams variant predictions from the AlphaGenome API.
+class AlphaGenomePipeline:
+    """One-shot pipeline that runs variant predictions through the AlphaGenome API.
 
     Reads variants from a Hail Table or TSV, groups them into genomic
     intervals, calls the AlphaGenome predict_variant API with rate
     limiting and checkpoint-based resumption, and writes consolidated
     JSON predictions. Per-modality Hail Table assembly is deferred
     until the SDK response structure is validated.
+
+    This is NOT a per-DataModel streamer (those ABCs live in
+    :mod:`hvantk.core.streamers`). The AlphaGenome VariantTable artifact
+    is produced by :mod:`hvantk.skills.alphagenome.builder`
+    (``build_alphagenome_predictions``).
 
     Parameters
     ----------
@@ -559,8 +570,10 @@ class AlphaGenomeStreamer(HailDataStreamer):
         no_resume: bool = False,
         chunk_size: int = 50,
     ):
-        super().__init__(name="AlphaGenomeStreamer", chunk_size=chunk_size,
-                         init_hail=input_path.endswith(".ht"))
+        self.name = "AlphaGenomePipeline"
+        self.chunk_size = chunk_size
+        self.logger = logging.getLogger(f"{__name__}.{self.name}")
+        self._init_hail = input_path.endswith(".ht")
         self.input_path = input_path
         self.output_dir = output_dir
         self.config_path = config_path
@@ -575,7 +588,8 @@ class AlphaGenomeStreamer(HailDataStreamer):
         self._start_time: float = 0.0
 
     def setup(self) -> None:
-        super().setup()
+        if self._init_hail and not hail_initialized():
+            init_hail()
         self._start_time = time.time()
 
         self._config = load_config(self.config_path)
@@ -711,10 +725,6 @@ class AlphaGenomeStreamer(HailDataStreamer):
 
             yield batch_results
 
-    def process_chunk(self, chunk: Any) -> Any:
-        """Identity — processing happens in stream()."""
-        return chunk
-
     def teardown(self) -> None:
         """Log summary and assemble per-modality outputs from checkpoints."""
         elapsed = time.time() - self._start_time
@@ -730,7 +740,6 @@ class AlphaGenomeStreamer(HailDataStreamer):
             f"failed variants: {failed_count}, "
             f"runtime: {elapsed:.0f}s"
         )
-        super().teardown()
 
     def _assemble_outputs(self) -> None:
         """Assemble predictions from batch checkpoint files.

--- a/hvantk/skills/alphagenome/tests/test_pipelines.py
+++ b/hvantk/skills/alphagenome/tests/test_pipelines.py
@@ -12,7 +12,7 @@ CONFIG_PATH = os.path.join(TESTDATA_DIR, "alphagenome_config.yaml")
 
 class TestLoadConfig:
     def test_load_valid_config(self):
-        from hvantk.skills.alphagenome.streamer import load_config
+        from hvantk.skills.alphagenome.pipelines import load_config
 
         config = load_config(CONFIG_PATH)
         assert config["api"]["key"] == "test-api-key-123"
@@ -22,13 +22,13 @@ class TestLoadConfig:
         assert config["intervals"]["adaptive"] is True
 
     def test_load_config_file_not_found(self):
-        from hvantk.skills.alphagenome.streamer import load_config
+        from hvantk.skills.alphagenome.pipelines import load_config
 
         with pytest.raises(FileNotFoundError):
             load_config("/nonexistent/path.yaml")
 
     def test_load_config_missing_api_section(self, tmp_path):
-        from hvantk.skills.alphagenome.streamer import load_config
+        from hvantk.skills.alphagenome.pipelines import load_config
 
         bad_config = tmp_path / "bad.yaml"
         bad_config.write_text(yaml.dump({"ontology": {"terms": []}}))
@@ -36,7 +36,7 @@ class TestLoadConfig:
             load_config(str(bad_config))
 
     def test_load_config_missing_ontology_section(self, tmp_path):
-        from hvantk.skills.alphagenome.streamer import load_config
+        from hvantk.skills.alphagenome.pipelines import load_config
 
         bad_config = tmp_path / "bad.yaml"
         bad_config.write_text(yaml.dump({"api": {"key": "x"}, "intervals": {}}))
@@ -44,7 +44,7 @@ class TestLoadConfig:
             load_config(str(bad_config))
 
     def test_resolve_api_key_from_env(self, tmp_path, monkeypatch):
-        from hvantk.skills.alphagenome.streamer import load_config
+        from hvantk.skills.alphagenome.pipelines import load_config
 
         cfg = {
             "api": {"key": None, "max_retries": 3, "retry_backoff": 2.0, "request_timeout": 120},
@@ -59,7 +59,7 @@ class TestLoadConfig:
         assert config["api"]["key"] == "env-key-456"
 
     def test_resolve_api_key_missing_everywhere(self, tmp_path, monkeypatch):
-        from hvantk.skills.alphagenome.streamer import load_config
+        from hvantk.skills.alphagenome.pipelines import load_config
 
         cfg = {
             "api": {"key": None, "max_retries": 3, "retry_backoff": 2.0, "request_timeout": 120},
@@ -97,7 +97,7 @@ class TestComputeIntervals:
         }
 
     def test_single_variant_fixed_mode(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         variants = [SimpleVariant("chr1", 500_000, "A", "T")]
         config = self._make_config(adaptive=False, default_size=100_000)
@@ -111,7 +111,7 @@ class TestComputeIntervals:
         assert len(grouped_variants) == 1
 
     def test_two_close_variants_adaptive_grouped(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         variants = [
             SimpleVariant("chr1", 100_000, "A", "T"),
@@ -123,7 +123,7 @@ class TestComputeIntervals:
         assert len(result[0][1]) == 2
 
     def test_two_distant_variants_adaptive_separate(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         variants = [
             SimpleVariant("chr1", 100_000, "A", "T"),
@@ -136,7 +136,7 @@ class TestComputeIntervals:
         assert len(result[1][1]) == 1
 
     def test_different_chromosomes_always_separate(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         variants = [
             SimpleVariant("chr1", 100_000, "A", "T"),
@@ -147,7 +147,7 @@ class TestComputeIntervals:
         assert len(result) == 2
 
     def test_large_cluster_split_at_max_size(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         variants = [SimpleVariant("chr1", i * 10_000, "A", "T") for i in range(200)]
         config = self._make_config(
@@ -159,7 +159,7 @@ class TestComputeIntervals:
             assert interval.end - interval.start <= 500_000
 
     def test_interval_centered_on_variant(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         variants = [SimpleVariant("chr5", 1_000_000, "A", "T")]
         config = self._make_config(adaptive=False, default_size=200_000)
@@ -169,13 +169,13 @@ class TestComputeIntervals:
         assert abs(midpoint - 1_000_000) <= 1
 
     def test_empty_variant_list(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         result = compute_intervals([], self._make_config())
         assert result == []
 
     def test_chromosome_numeric_sort_order_keeps_chr2_before_chr10(self):
-        from hvantk.skills.alphagenome.streamer import compute_intervals
+        from hvantk.skills.alphagenome.pipelines import compute_intervals
 
         variants = [
             SimpleVariant("chr10", 100_000, "A", "T"),
@@ -190,14 +190,14 @@ class TestComputeIntervals:
 
 class TestCheckpointManager:
     def test_fresh_start_no_checkpoints(self, tmp_path):
-        from hvantk.skills.alphagenome.streamer import CheckpointManager
+        from hvantk.skills.alphagenome.pipelines import CheckpointManager
 
         mgr = CheckpointManager(str(tmp_path / "out"))
         assert mgr.completed_intervals == set()
         assert mgr.failed_variants == []
 
     def test_save_and_reload_state(self, tmp_path):
-        from hvantk.skills.alphagenome.streamer import CheckpointManager
+        from hvantk.skills.alphagenome.pipelines import CheckpointManager
 
         out_dir = str(tmp_path / "out")
         mgr = CheckpointManager(out_dir)
@@ -211,7 +211,7 @@ class TestCheckpointManager:
         assert mgr2.failed_variants[0]["chrom"] == "chr1"
 
     def test_save_batch_data(self, tmp_path):
-        from hvantk.skills.alphagenome.streamer import CheckpointManager
+        from hvantk.skills.alphagenome.pipelines import CheckpointManager
 
         out_dir = str(tmp_path / "out")
         mgr = CheckpointManager(out_dir)
@@ -225,7 +225,7 @@ class TestCheckpointManager:
         assert loaded == batch_data
 
     def test_is_interval_complete(self, tmp_path):
-        from hvantk.skills.alphagenome.streamer import CheckpointManager
+        from hvantk.skills.alphagenome.pipelines import CheckpointManager
 
         mgr = CheckpointManager(str(tmp_path / "out"))
         mgr.mark_interval_complete("chr1:100-200")
@@ -233,7 +233,7 @@ class TestCheckpointManager:
         assert mgr.is_interval_complete("chr2:100-200") is False
 
     def test_clear_checkpoints(self, tmp_path):
-        from hvantk.skills.alphagenome.streamer import CheckpointManager
+        from hvantk.skills.alphagenome.pipelines import CheckpointManager
 
         out_dir = str(tmp_path / "out")
         mgr = CheckpointManager(out_dir)
@@ -259,7 +259,7 @@ class TestRateLimitedCaller:
         }
 
     def test_successful_call(self):
-        from hvantk.skills.alphagenome.streamer import RateLimitedCaller
+        from hvantk.skills.alphagenome.pipelines import RateLimitedCaller
 
         mock_model = MagicMock()
         mock_model.predict_variant.return_value = {"rna_seq": [1.0]}
@@ -273,7 +273,7 @@ class TestRateLimitedCaller:
         mock_model.predict_variant.assert_called_once()
 
     def test_retry_on_transient_error(self):
-        from hvantk.skills.alphagenome.streamer import RateLimitedCaller
+        from hvantk.skills.alphagenome.pipelines import RateLimitedCaller
 
         mock_model = MagicMock()
         mock_model.predict_variant.side_effect = [
@@ -290,7 +290,7 @@ class TestRateLimitedCaller:
         assert mock_model.predict_variant.call_count == 3
 
     def test_max_retries_exceeded_returns_none(self):
-        from hvantk.skills.alphagenome.streamer import RateLimitedCaller
+        from hvantk.skills.alphagenome.pipelines import RateLimitedCaller
 
         mock_model = MagicMock()
         mock_model.predict_variant.side_effect = Exception("503 Server Error")
@@ -305,7 +305,7 @@ class TestRateLimitedCaller:
         assert mock_model.predict_variant.call_count == 2
 
     def test_cooldown_after_consecutive_rate_limits(self):
-        from hvantk.skills.alphagenome.streamer import RateLimitedCaller
+        from hvantk.skills.alphagenome.pipelines import RateLimitedCaller
 
         mock_model = MagicMock()
         caller = RateLimitedCaller(mock_model, self._make_api_config())
@@ -315,7 +315,7 @@ class TestRateLimitedCaller:
         assert caller._should_cooldown() is False
 
 
-class TestAlphaGenomeStreamer:
+class TestAlphaGenomePipeline:
     def _make_variant_tsv(self, tmp_path, variants):
         """Write a TSV with chrom/pos/ref/alt columns."""
         tsv_path = tmp_path / "variants.tsv"
@@ -341,16 +341,16 @@ class TestAlphaGenomeStreamer:
         cfg_path.write_text(yaml.dump(cfg))
         return str(cfg_path)
 
-    @patch("hvantk.skills.alphagenome.streamer._create_dna_client")
+    @patch("hvantk.skills.alphagenome.pipelines._create_dna_client")
     def test_setup_loads_tsv_input(self, mock_create_client, tmp_path):
-        from hvantk.skills.alphagenome.streamer import AlphaGenomeStreamer
+        from hvantk.skills.alphagenome.pipelines import AlphaGenomePipeline
 
         mock_create_client.return_value = MagicMock()
         tsv = self._make_variant_tsv(tmp_path, [("chr1", 500000, "A", "T")])
         cfg = self._make_config_file(tmp_path)
         out = str(tmp_path / "output")
 
-        streamer = AlphaGenomeStreamer(
+        streamer = AlphaGenomePipeline(
             input_path=tsv, output_dir=out, config_path=cfg,
         )
         streamer.setup()
@@ -358,10 +358,10 @@ class TestAlphaGenomeStreamer:
         assert streamer._variants[0].chrom == "chr1"
         streamer.teardown()
 
-    @patch("hvantk.skills.alphagenome.streamer._import_alphagenome")
-    @patch("hvantk.skills.alphagenome.streamer._create_dna_client")
+    @patch("hvantk.skills.alphagenome.pipelines._import_alphagenome")
+    @patch("hvantk.skills.alphagenome.pipelines._create_dna_client")
     def test_stream_calls_api_per_variant(self, mock_create_client, mock_import, tmp_path):
-        from hvantk.skills.alphagenome.streamer import AlphaGenomeStreamer
+        from hvantk.skills.alphagenome.pipelines import AlphaGenomePipeline
 
         mock_model = MagicMock()
         mock_result = MagicMock()
@@ -381,7 +381,7 @@ class TestAlphaGenomeStreamer:
         cfg = self._make_config_file(tmp_path)
         out = str(tmp_path / "output")
 
-        streamer = AlphaGenomeStreamer(
+        streamer = AlphaGenomePipeline(
             input_path=tsv, output_dir=out, config_path=cfg,
         )
         streamer.setup()
@@ -389,9 +389,9 @@ class TestAlphaGenomeStreamer:
         assert mock_model.predict_variant.call_count == 2
         streamer.teardown()
 
-    @patch("hvantk.skills.alphagenome.streamer._create_dna_client")
+    @patch("hvantk.skills.alphagenome.pipelines._create_dna_client")
     def test_no_resume_clears_checkpoints(self, mock_create_client, tmp_path):
-        from hvantk.skills.alphagenome.streamer import AlphaGenomeStreamer
+        from hvantk.skills.alphagenome.pipelines import AlphaGenomePipeline
 
         mock_create_client.return_value = MagicMock()
         tsv = self._make_variant_tsv(tmp_path, [("chr1", 500000, "A", "T")])
@@ -405,7 +405,7 @@ class TestAlphaGenomeStreamer:
         with open(state_path, "w") as f:
             json.dump({"completed_intervals": ["chr1:450000-550000"], "failed_variants": []}, f)
 
-        streamer = AlphaGenomeStreamer(
+        streamer = AlphaGenomePipeline(
             input_path=tsv, output_dir=out, config_path=cfg, no_resume=True,
         )
         streamer.setup()
@@ -416,10 +416,10 @@ class TestAlphaGenomeStreamer:
 class TestEndToEnd:
     """End-to-end test with mocked AlphaGenome API."""
 
-    @patch("hvantk.skills.alphagenome.streamer._import_alphagenome")
-    @patch("hvantk.skills.alphagenome.streamer._create_dna_client")
+    @patch("hvantk.skills.alphagenome.pipelines._import_alphagenome")
+    @patch("hvantk.skills.alphagenome.pipelines._create_dna_client")
     def test_full_pipeline_tsv_input(self, mock_create_client, mock_import_ag, tmp_path):
-        from hvantk.skills.alphagenome.streamer import AlphaGenomeStreamer
+        from hvantk.skills.alphagenome.pipelines import AlphaGenomePipeline
 
         # Setup mock model
         mock_model = MagicMock()
@@ -460,7 +460,7 @@ class TestEndToEnd:
         out_dir = str(tmp_path / "output")
 
         # Run streamer
-        streamer = AlphaGenomeStreamer(
+        streamer = AlphaGenomePipeline(
             input_path=str(tsv_path),
             output_dir=out_dir,
             config_path=str(cfg_path),
@@ -479,10 +479,10 @@ class TestEndToEnd:
             state = json.load(f)
         assert len(state["completed_intervals"]) > 0
 
-    @patch("hvantk.skills.alphagenome.streamer._import_alphagenome")
-    @patch("hvantk.skills.alphagenome.streamer._create_dna_client")
+    @patch("hvantk.skills.alphagenome.pipelines._import_alphagenome")
+    @patch("hvantk.skills.alphagenome.pipelines._create_dna_client")
     def test_resume_skips_completed(self, mock_create_client, mock_import_ag, tmp_path):
-        from hvantk.skills.alphagenome.streamer import AlphaGenomeStreamer
+        from hvantk.skills.alphagenome.pipelines import AlphaGenomePipeline
 
         mock_model = MagicMock()
         mock_result = MagicMock()
@@ -516,7 +516,7 @@ class TestEndToEnd:
         out_dir = str(tmp_path / "output")
 
         # Run first time
-        streamer = AlphaGenomeStreamer(
+        streamer = AlphaGenomePipeline(
             input_path=str(tsv_path), output_dir=out_dir,
             config_path=str(cfg_path),
         )
@@ -527,7 +527,7 @@ class TestEndToEnd:
 
         # Run again — should skip all intervals
         mock_model.predict_variant.reset_mock()
-        streamer2 = AlphaGenomeStreamer(
+        streamer2 = AlphaGenomePipeline(
             input_path=str(tsv_path), output_dir=out_dir,
             config_path=str(cfg_path),
         )


### PR DESCRIPTION
Follow-up from the #121 streamer-architecture refactor. **Closes #143.**

`skills/alphagenome/streamer.py` defined `AlphaGenomeStreamer(HailDataStreamer)`, but the word "Streamer" is now reserved for the per-DataModel ABCs in `core/streamers/`. Structurally this class is a **one-shot pipeline** (load YAML config → create API client → compute genomic intervals → call the AlphaGenome `predict_variant` API in rate-limited, checkpoint-resumable batches → write `predictions.json`), not a DataModel operation surface.

## Decision (the issue's "decision needed")

**Reclassify as a pipeline; do NOT add an `AlphaGenomeVariantTableStreamer`.**

Evidence:
- The only consumer, `builder.py::_run_alphagenome_pipeline`, drives it **directly** (`setup()` → `for _ in stream()` → `teardown()`), never via `StreamProcessor`; `process_chunk` was an unused abstract-base artifact.
- The AlphaGenome **VariantTable artifact is already produced by `builder.py`** (`AnnotationTable`, `schema_id="alphagenome-v1"`). Per-modality Hail-table prediction assembly is explicitly deferred in the code, so a `VariantTableStreamer` would wrap a stub today — adding it now would be speculative (YAGNI). It can be added when that assembly lands.

## What changed

- `git mv streamer.py → pipelines.py`; `AlphaGenomeStreamer` → `AlphaGenomePipeline`.
- Decoupled from `HailDataStreamer`: self-contained class; `setup()` initialises Hail only for `.ht` input (`if self._init_hail and not hail_initialized(): init_hail()`); removed the unused `process_chunk()`. **All** API/interval/checkpoint/serialization logic is byte-for-byte unchanged (verified by diffing the pre/post-rename file).
- Updated `builder.py` consumer; `git mv test_streamer.py → test_pipelines.py` (imports + all `@patch` targets retargeted to the new module).
- Removed alphagenome from `core/utils/streaming.py`'s retention docstring (it no longer depends on the legacy module).

## Verification

- `flake8 --select=E9,F63,F7,F82` → 0
- Guards (`test_dependency_directions.py`, `test_intra_core_dependencies.py`) → pass
- `pytest hvantk/skills/alphagenome/tests/` → 29 passed, 1 skipped
- Full fast suite → only the pre-existing baseline failures (2 `test_cli_qtlcascade.py`, 12 `test_drift_probe.py`)
- Spec-compliance reviewed independently (confirmed zero logic drift).

Closes #143.
