### PR TITLE
chore(#59): make scikit-learn optional behind extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ eval "$(poetry env activate)"
 
 **Prerequisites**: Python >=3.10, Hail
 
+### Optional extras
+
+The base install is intentionally lean — heavy plotting and ML dependencies are
+opt-in via Poetry extras. Install only what a given workflow needs:
+
+| Extra | Enables | Pulls in |
+| --- | --- | --- |
+| `viz` | Static and interactive plotting | matplotlib, seaborn, plotly |
+| `interactive` | Interactive plots / dashboards | plotly |
+| `duckdb` | DuckDB-backed queries | duckdb |
+| `hgc` | Joint genotyping (incl. genotype adjustment + plots) | gnomad, matplotlib, seaborn, plotly |
+| `psroc` | Pathogenicity Score ROC analysis | matplotlib, plotly, scikit-learn |
+| `ptm` | CPTAC proteomics builders | cptac |
+| `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn |
+| `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn |
+| `ml` | scikit-learn-backed features only | scikit-learn |
+
+```bash
+# One or more extras at once
+poetry install --extras "ancestry psroc"
+
+# Or a single extra
+poetry install --extras ml
+```
+
 Verify it works:
 
 ```bash

--- a/hvantk/algorithms/ancestry/classify.py
+++ b/hvantk/algorithms/ancestry/classify.py
@@ -11,9 +11,21 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.metrics import classification_report, confusion_matrix
-from sklearn.model_selection import StratifiedKFold, cross_val_predict
+# Make scikit-learn import optional - only required for classifier training.
+try:
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.metrics import classification_report, confusion_matrix
+    from sklearn.model_selection import StratifiedKFold, cross_val_predict
+
+    SKLEARN_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    SKLEARN_AVAILABLE = False
+    # Defined to satisfy linters; guarded by SKLEARN_AVAILABLE.
+    RandomForestClassifier = None
+    classification_report = None
+    confusion_matrix = None
+    StratifiedKFold = None
+    cross_val_predict = None
 
 from hvantk.algorithms.ancestry.constants import (
     ANCESTRY_PROB_COL,
@@ -195,6 +207,12 @@ def train_classifier(
     ... )
     >>> print(f"Accuracy: {result.get_accuracy():.2%}")
     """
+    if not SKLEARN_AVAILABLE:
+        raise RuntimeError(
+            "Ancestry classification requires scikit-learn. Install it with "
+            "'poetry install --extras ml' (or --extras ancestry / --extras psroc)."
+        )
+
     # Get PC columns
     pc_cols = _get_pc_columns(n_pcs)
 

--- a/hvantk/algorithms/ancestry/plot.py
+++ b/hvantk/algorithms/ancestry/plot.py
@@ -642,7 +642,13 @@ def plot_confusion_matrix(
         The figure.
     """
     plt, _, _ = _get_matplotlib()
-    from sklearn.metrics import confusion_matrix as sk_confusion_matrix
+    try:
+        from sklearn.metrics import confusion_matrix as sk_confusion_matrix
+    except ImportError:  # pragma: no cover
+        raise RuntimeError(
+            "Confusion matrix plotting requires scikit-learn. Install it with "
+            "'poetry install --extras ancestry' (or --extras ml / --extras psroc)."
+        )
 
     if labels is None:
         labels = sorted(set(y_true) | set(y_pred))

--- a/hvantk/algorithms/psroc/roc.py
+++ b/hvantk/algorithms/psroc/roc.py
@@ -9,7 +9,16 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 import numpy as np
 
-from sklearn.metrics import roc_curve, roc_auc_score
+# Make scikit-learn import optional - only required for ROC computation.
+try:
+    from sklearn.metrics import roc_curve, roc_auc_score
+
+    SKLEARN_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    SKLEARN_AVAILABLE = False
+    # Defined to satisfy linters; guarded by SKLEARN_AVAILABLE.
+    roc_curve = None
+    roc_auc_score = None
 
 
 @dataclass
@@ -266,6 +275,12 @@ def bootstrap_auc_ci(
         ValueError: If inputs are invalid (mismatched lengths, single class,
             bad n_resamples or confidence_level).
     """
+    if not SKLEARN_AVAILABLE:
+        raise RuntimeError(
+            "ROC analysis requires scikit-learn. Install it with "
+            "'poetry install --extras psroc' (or --extras ml / --extras ancestry)."
+        )
+
     labels = np.asarray(labels).ravel()
     scores = np.asarray(scores).ravel()
 
@@ -337,6 +352,12 @@ def compute_roc_metrics(
         ValueError: If labels and score arrays have different lengths,
                    if no valid labels exist, or if all scores are excluded.
     """
+    if not SKLEARN_AVAILABLE:
+        raise RuntimeError(
+            "ROC analysis requires scikit-learn. Install it with "
+            "'poetry install --extras psroc' (or --extras ml / --extras ancestry)."
+        )
+
     if len(labels) == 0:
         raise ValueError("Labels array is empty")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pysam = ">=0.22"
 anndata = ">=0.10.0"
 scanpy = ">=1.10.0"
 gnomad = { version = "*", optional = true }
-scikit-learn = "^1.3.0"
+scikit-learn = { version = "^1.3.0", optional = true }
 matplotlib = { version = "*", optional = true }
 seaborn = { version = "*", optional = true }
 plotly = { version = "*", optional = true }
@@ -58,9 +58,11 @@ viz = ["matplotlib", "seaborn", "plotly"]
 duckdb = ["duckdb"]
 interactive = ["plotly"]
 hgc = ["matplotlib", "seaborn", "plotly", "gnomad"]
-psroc = ["matplotlib", "plotly"]
+psroc = ["matplotlib", "plotly", "scikit-learn"]
 ptm = ["cptac"]
 constraint = ["tspex", "matplotlib", "seaborn"]
+ancestry = ["scikit-learn", "matplotlib", "seaborn"]
+ml = ["scikit-learn"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
@@ -72,6 +74,7 @@ matplotlib = "*"
 seaborn = "*"
 plotly = "*"
 tspex = "*"
+scikit-learn = "*"
 mkdocs = "*"
 mkdocs-material = "*"
 ipykernel = "^7.2.0"


### PR DESCRIPTION
## Summary

Finishes the extras-hygiene checklist from #59 by making `scikit-learn` — the last heavy dependency still required at base install — optional. The base `poetry install` is now ML-free; sklearn-backed features (ancestry classification, PS-ROC) live behind extras and fail with a clear install hint if invoked without it.

## Changes

- **`pyproject.toml`**
  - `scikit-learn` → `optional = true`.
  - Added extras: `ml = ["scikit-learn"]` and `ancestry = ["scikit-learn", "matplotlib", "seaborn"]`; added `scikit-learn` to the existing `psroc` extra.
  - Added `scikit-learn = "*"` to dev dependencies so CI's ancestry/psroc tests keep the dependency (mirrors how matplotlib/seaborn/plotly/tspex are already dev deps).
- **Import guards** (established `try/except ImportError` + deferred-`RuntimeError` pattern from `hgc/converters.py`):
  - `algorithms/ancestry/classify.py` — guarded module imports; guard on `train_classifier`.
  - `algorithms/psroc/roc.py` — guarded module imports; guards on `compute_roc_metrics` and `bootstrap_auc_ci`.
  - `algorithms/ancestry/plot.py` — guarded the deferred import in `plot_confusion_matrix`.
  - Modules import cleanly without sklearn (`SKLEARN_AVAILABLE = False`); only the sklearn-backed entry points raise.
- **README** — added an "Optional extras" subsection documenting all extras + usage.

## Verification

- `flake8 . --select=E9,F63,F7,F82` → clean (no undefined names from the guard refactor).
- sklearn-**present** import smoke of all three modules → ok.
- sklearn-**absent** simulation (import blocked): modules still import, `SKLEARN_AVAILABLE` is `False`, and each guarded entry point raises the friendly `RuntimeError` with the `--extras` hint.
- `pytest hvantk/tests/psroc` → 143 passed; fast ancestry tests → 105 passed (sklearn present).

Full clean-env `poetry install` (no extras, fresh venv) is left as a release-validation step — the `pyproject` change is mechanical and the guards are simulation-verified.

Closes #59.
