### PR TITLE
feat(#92): progress reporting for long-running reprocess builds

### DIFF
--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -8,10 +8,29 @@ with the `--skip-*` flags.
 from __future__ import annotations
 
 import json
+import logging
 import re
+import sys
+import time
 from typing import Any
 
 import click
+
+
+def _configure_logging(verbose: bool) -> None:
+    """On ``--verbose``, surface builders' INFO logs (e.g. the UCSC streaming
+    loop's per-chunk lines) on the terminal.
+
+    Called before any lifecycle stage runs — and therefore before Hail
+    initializes — so the root logger is configured first. ``basicConfig`` is a
+    no-op once handlers exist, so the level is also set explicitly to guarantee
+    INFO records are emitted even if something (e.g. Hail) already attached a
+    handler.
+    """
+    if not verbose:
+        return
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+    logging.getLogger().setLevel(logging.INFO)
 
 
 _INT_RE = re.compile(r"^-?\d+$")
@@ -106,6 +125,18 @@ def _coerce_plugin_arg_value(value: str) -> Any:
     is_flag=True,
     help="Disable the post-build drift probe",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Surface builders' INFO logs (per-chunk progress, etc.) on stderr",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    help="Suppress the per-stage progress lines (errors still print)",
+)
 def reprocess_cmd(
     dataset,
     raw_dir,
@@ -117,8 +148,24 @@ def reprocess_cmd(
     plugin_args,
     check_drift,
     no_check_drift,
+    verbose,
+    quiet,
 ):
     """Run download -> parse -> build for a plugin dataset."""
+    _configure_logging(verbose)
+
+    # Per-stage progress to stderr (keeps stdout clean for piping). Each line
+    # carries the cumulative elapsed time so an operator can tell a long build
+    # is still alive. Suppressed by --quiet; --verbose adds the builders' own
+    # INFO logs on top.
+    _start = time.monotonic()
+
+    def _progress(message: str) -> None:
+        if quiet:
+            return
+        elapsed = time.monotonic() - _start
+        click.echo(f"[reprocess {dataset}] {message} ({elapsed:.0f}s)", err=True)
+
     from hvantk.core.plugin import drift_runner, loader as plugin_loader
 
     reg = plugin_loader.get_registry()
@@ -152,7 +199,7 @@ def reprocess_cmd(
                 f"{dataset} has no lifecycle.download declared; "
                 "use --skip-download or add it to plugin.yaml"
             )
-        click.echo(f"download: {dataset} -> {raw_dir}")
+        _progress(f"download -> {raw_dir}")
         spec.download_fn(raw_dir=raw_dir, **extras)
 
     # 2. Parse stage
@@ -161,7 +208,7 @@ def reprocess_cmd(
             raise click.UsageError(
                 "--intermediate is required when the plugin declares lifecycle.parse"
             )
-        click.echo(f"parse: {raw_dir} -> {intermediate}")
+        _progress(f"parse: {raw_dir} -> {intermediate}")
         spec.parse_fn(raw_dir=raw_dir, output_path=intermediate, **extras)
         parsed_path = intermediate
     elif not skip_parse:
@@ -175,7 +222,7 @@ def reprocess_cmd(
 
     # 3. Build stage
     if not skip_build:
-        click.echo(f"build: {parsed_path} -> {output}")
+        _progress(f"build: {parsed_path} -> {output}")
         if spec.artifact_type is None:
             # Legacy (Phase A) plugin not yet migrated to Phase B contract.
             # Fall back to the old shape: spec.builder(input, output) writes
@@ -207,6 +254,10 @@ def reprocess_cmd(
     # 4. Optional drift check
     if check_drift and not no_check_drift:
         result = drift_runner.run_drift_check(dataset)
-        click.echo(f"drift: {result.status}")
+        # Drift status is a result, not routine chatter — show it on stderr even
+        # under --quiet so a "drifted" outcome is never silently swallowed.
+        click.echo(f"drift: {result.status}", err=True)
         if result.status == "drifted" and result.diff:
             click.echo(json.dumps(result.diff, indent=2, default=str))
+
+    _progress(f"done -> {output}")


### PR DESCRIPTION
## Summary

Adds progress reporting to long-running plugin builds (#92). The original target (`hvantk mkmatrix ucsc`) was retired in the plugin-system refactor; the work is re-scoped onto `hvantk reprocess`, which now drives every plugin build — including the UCSC cell-browser atlases (520k cells, ~8.7 GB, 30–45 min) that motivated the issue.

Previously `reprocess` printed only stage-start lines to stdout and never configured the root logger, so the builders' `logger.info(...)` progress lines (e.g. the UCSC streaming loop's per-chunk logs) never reached the terminal — a long build looked indistinguishable from a hang.

## Changes (`hvantk/tools/plugins/reprocess_cli.py`)

- **Per-stage progress → stderr with elapsed time.** `download` / `parse` / `build` / `done` lines now go to stderr via a small `_progress()` helper, each stamped with cumulative seconds, so an operator can see a build is still alive. stdout stays clean for piping.
- **`--verbose` / `-v`.** Wires `logging.basicConfig(level=INFO, stream=stderr)` **before any stage runs** (and therefore before Hail initializes), then forces the root level, so the builders' own INFO logs surface — including the UCSC per-chunk lines the issue called out.
- **`--quiet` / `-q`.** Suppresses the routine per-stage lines. Drift status still prints (it's a result, not chatter) so a `drifted` outcome is never silently swallowed.

## Verification (end-to-end against `onek-genomes:samples`, existing TSV fixture)

- `flake8 reprocess_cli.py --select=E9,F63,F7,F82` → clean.
- `reprocess --help` lists `-v/--verbose` and `-q/--quiet`.
- **Default run:** progress lines (`build: …`, `done -> … (12s)`) appear on **stderr**; stdout carries no progress chatter.
- **`--quiet`:** 0 progress lines emitted.
- **`--verbose`:** the builder's `INFO Importing IGSR samples …` line surfaces on stderr.

Closes #92.
