### PR TITLE
docs: align CLI/build-path + module layout with current code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ See the full contributing guide at [docs_site/contributing.md](docs_site/contrib
 Each external data source ships as a self-contained plugin under `hvantk/skills/<provider>/`. The HGNC plugin (`hvantk/skills/hgnc/`) is the canonical reference. Step by step:
 
 1. Create the folder layout. Single-dataset providers: `hvantk/skills/<provider>/{plugin.yaml,builder.py,cli.py,drift_probe.py,SKILL.md,tests/}`. Multi-dataset providers: add one subfolder per dataset and a `shared/` folder for code reused across them.
-2. Write `plugin.yaml` with `api_version: 2`, a `source.catalog_ref` pointing into `hvantk/resources/catalog.yaml`, and one `datasets:` entry per dataset declaring `builder`, `drift_probe`, optional `lifecycle.{download,parse}`, and the `tests:` block (fixture, schema/row snapshots, drift fingerprint, command).
-3. Implement the builder (`create_<source>_tb` or `build_<source>_ad`) using `_create_table_base()` from `hvantk/tables/table_builders.py` for Hail Table builders.
+2. Write `plugin.yaml` with `api_version: 2`, a `source.catalog_ref` (a bare provider identifier, e.g. `catalog_ref: hgnc`), and one `datasets:` entry per dataset declaring `builder`, `drift_probe`, optional `lifecycle.{download,parse}`, and the `tests:` block (fixture, schema/row snapshots, drift fingerprint, command).
+3. Implement the Phase B builder `build_<source>(parsed_input, ctx, **params)` in `builder.py`, returning a typed artifact (`AnnotationTable` / `ExpressionMatrix` / `VariantMatrix` / `GeneSet`) stamped via `ctx.provenance(schema_id=…)`. Generic Hail helpers (`create_table_base`, `cleanup_temp_file`) live in `hvantk/core/utils/hail_helpers.py`.
 4. Implement the downloader in `cli.py` (Click command + a `download_dataset` function the loader can wire to `lifecycle.download`).
 5. Implement the drift probe — a zero-arg function returning the fingerprint dict described in `hvantk/skills/_conventions/SKILL.md` § 12. Commit the expected fingerprint at `tests/drift_fingerprint.json`.
 6. Add the round-trip test under `tests/`, mark it `@pytest.mark.hail` if applicable, snapshot the schema and a small set of rows.

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ sequenceDiagram
     IO-->>IO: write data + sidecar .provenance.json
 ```
 
-Twenty plugins ship today: `clinvar`, `clingen`, `gencc`, `gwas-catalog`,
+Twenty-one plugins ship today: `clinvar`, `clingen`, `gencc`, `gwas-catalog`,
 `hgnc`, `gtex-eqtl`, `insider`, `msigdb`, `uniprot-ptm`, `peptideatlas`,
 `expression-atlas`, `cptac`, `ucsc-cellbrowser`, `gevir`, `gnomad-metrics`,
-`ensembl-gene`, `dbnsfp`, `cosmic-cgc`, `pqtl`, `alphagenome`.
+`ensembl-gene`, `dbnsfp`, `cosmic-cgc`, `pqtl`, `alphagenome`, `onek-genomes`.
 
 ### Project structure
 
@@ -178,7 +178,7 @@ hvantk/
 │   ├── qtlcascade/             # eQTL → pQTL cascade + colocalization
 │   └── annotation/             # multi-source annotation pipelines
 │
-├── skills/                     # data-source plugins (20 total)
+├── skills/                     # data-source plugins (21 total)
 │   ├── <plugin>/
 │   │   ├── plugin.yaml         # declarative manifest (drives discovery + CLI)
 │   │   ├── builder.py          # Phase B: (parsed, ctx) → Artifact

--- a/docs_site/architecture.md
+++ b/docs_site/architecture.md
@@ -60,20 +60,22 @@ hvantk/
 │   │   ├── loader.py      # Plugin discovery (filesystem + entry points)
 │   │   ├── run_builder.py # run_builder_for_spec() — Phase B orchestrator
 │   │   └── drift_runner.py# Drift probe execution
-│   └── utils/             # Cross-cutting utilities
-│       ├── hail_context.py          # Idempotent Hail init
-│       ├── hail_helpers.py          # create_table_base, cleanup_temp_file
-│       ├── qtl_helpers.py           # GTEx variant-ID parsing (shared by eqtl/pqtl)
-│       ├── bgzf.py                  # BGZF utilities
-│       ├── streaming.py             # Generic DataStreamer / HailDataStreamer primitives
-│       ├── gene_disease_streamer.py # Abstract base shared by clingen/cosmic-cgc/gencc
-│       ├── clinvar_streamer.py      # ClinVar streamer (consumed by algorithms/)
-│       ├── file_utils.py            # File I/O helpers
-│       ├── gene_sets.py             # Gene set utilities
-│       ├── genome.py                # Genome/contig utilities
-│       ├── table_utils.py           # Hail Table manipulation helpers
-│       ├── writers.py               # HailTableWriter
-│       └── ...                      # Other shared utilities
+│   ├── utils/             # Cross-cutting utilities
+│   │   ├── hail_context.py   # Idempotent Hail init
+│   │   ├── hail_helpers.py   # create_table_base, cleanup_temp_file
+│   │   ├── qtl_helpers.py    # GTEx variant-ID parsing (shared by eqtl/pqtl)
+│   │   ├── bgzf.py           # BGZF utilities
+│   │   ├── catalog.py        # Catalog helpers
+│   │   ├── file_utils.py     # File I/O helpers
+│   │   ├── gene_sets.py      # Gene set utilities
+│   │   ├── geneset_io.py     # Gene set parsing / validation
+│   │   ├── genome.py         # Genome/contig utilities (contig_recoding)
+│   │   ├── table_utils.py    # Hail Table manipulation helpers
+│   │   └── writers.py        # HailTableWriter
+│   └── streamers/         # Base streamer classes (consumed by algorithms/ + skills/)
+│       ├── gene_disease_table.py # GeneDiseaseTableStreamer (clingen/gencc/cosmic-cgc base)
+│       ├── variant_table.py      # VariantTableStreamer (clinvar base)
+│       └── gene_catalog.py       # GeneCatalogStreamer (hgnc base)
 │
 ├── algorithms/            # L4-L5: Analysis pipelines
 │   ├── annotation/        # Variant annotation pipeline
@@ -166,7 +168,7 @@ The codebase is organized by function and biological domain:
 - **Variants** - Keyed by `(locus, alleles)`
 - **Genes** - Keyed by `gene_id`
 - **Proteins** - Keyed by `protein_id` or `interval`
-- **Expression** - MatrixTables with rows=genes, columns=samples/cells
+- **Expression** - AnnData matrices (`.h5ad`) with rows=genes, columns=samples/cells
 
 ### 2. Artifact Contract
 
@@ -299,22 +301,17 @@ block — no manual edits in `hvantk/tools/plugins/download_cli.py` needed.
 
 ### Streamer placement rule
 
-Streamers (classes that yield batches over a built table) are split by
-**who consumes them**, not by which provider produced the underlying table.
-This decouples streamer release cadence from provider release cadence and
-keeps the one-way `skills → algorithms → tools` dependency direction
-clean.
+Streamers (classes that yield batches over a built table) are split between a
+**base class** that lives above the skills layer and **per-provider subclasses**
+that ship with their plugin. This keeps the one-way
+`skills → algorithms → tools` dependency direction clean: the sibling-skill
+rule (`skills/X` cannot import from `skills/Y`) forces any base class shared by
+multiple skills to live in `core/streamers/`.
 
 | Streamer kind | Lives in | Example |
 |---|---|---|
-| Generic, no domain knowledge | `core/utils/streaming.py` | `DataStreamer`, `HailDataStreamer`, `StreamProcessor` |
-| Shared abstract base across sibling skills | `core/utils/` | `gene_disease_streamer.py` (used by `clingen`, `cosmic-cgc`, `gencc`) |
-| Consumed by `algorithms/` | `core/utils/` | `clinvar_streamer.py` (consumed by `algorithms/annotation`, `algorithms/training_sets`) |
-| Truly source-specific (only the skill itself and `tools/` consume it) | `skills/<provider>/streamer.py` | `clingen/streamer.py`, `cosmic_cgc/streamer.py`, `gencc/streamer.py`, `alphagenome/streamer.py` |
-
-The shared-base case is the one most likely to surprise: the sibling-skill
-rule (`skills/X` cannot import from `skills/Y`) forces any base class used
-by multiple skills to live above the skills layer — in `core/utils/`.
+| Shared base class | `core/streamers/` | `GeneDiseaseTableStreamer` (`gene_disease_table.py`), `VariantTableStreamer` (`variant_table.py`), `GeneCatalogStreamer` (`gene_catalog.py`) |
+| Per-provider subclass | `skills/<provider>/streamers.py` | `ClinGenGeneDiseaseTableStreamer` (`clingen/streamers.py`), `GenCCGeneDiseaseTableStreamer` (`gencc/streamers.py`), `ClinVarVariantTableStreamer` (`clinvar/streamers.py`) |
 
 ### 3. CLI-First Design
 
@@ -341,33 +338,16 @@ Raw File (VCF/TSV/BED) → Builder → Hail Table → Disk (.ht)
 ```
 
 Example:
-```python
-# Via the plugin system (recommended)
-from hvantk.core.plugin.run_builder import run_builder_for_spec
-
-artifact = run_builder_for_spec("clinvar:variants", input_path="clinvar.vcf.bgz", output_path="clinvar.ht")
+```bash
+# The reprocess CLI runs the full Phase B pipeline: download → parse → build → drift-check
+hvantk reprocess clinvar:variants --raw-dir data/ --output clinvar.ht
 ```
+In-process callers drive the same Phase B builder via
+`run_builder_for_spec(spec, *, parsed_input, output_path, plugin_version, **params)`
+(in `hvantk/core/plugin/run_builder.py`), which takes a resolved `DatasetSpec`
+and returns the stamped `Provenance`.
 
-#### Pattern 2: Batch Building via Recipes
-```
-Recipe JSON → Parser → [Builder 1, Builder 2, ...] → Multiple Tables
-```
-
-Example recipe:
-```json
-{
-  "tables": [
-    {
-      "name": "clinvar",
-      "input": "/data/clinvar.vcf.bgz",
-      "output": "/out/clinvar.ht",
-      "params": {"reference_genome": "GRCh38"}
-    }
-  ]
-}
-```
-
-#### Pattern 3: Multi-Omics Integration
+#### Pattern 2: Multi-Omics Integration
 ```
 Variant Table + Gene Table + Expression Matrix → Integrated Analysis
 ```
@@ -533,7 +513,7 @@ See `hvantk/skills/_conventions/SKILL.md` for the full contract.
 - **gnomAD** - Utilities for gnomAD data
 - **Click** - CLI framework
 - **Pandas** - Data manipulation
-- **PyYAML** - YAML recipe support
+- **PyYAML** - YAML manifest parsing (`plugin.yaml`)
 - **Matplotlib/Seaborn/Plotly** - Visualization (optional)
 
 ## Performance Considerations

--- a/docs_site/getting-started/installation.md
+++ b/docs_site/getting-started/installation.md
@@ -17,6 +17,35 @@ cd hvantk
 pip install -e .
 ```
 
+## Optional features (extras)
+
+The core install is lightweight; visualization, machine-learning, and a few
+provider-specific dependencies ship as optional extras. Install the ones you
+need:
+
+```bash
+# pip
+pip install -e ".[viz,hgc]"
+
+# poetry
+poetry install --extras "viz hgc"      # or: poetry install --all-extras
+```
+
+| Extra | Pulls in | Needed for |
+|---|---|---|
+| `viz` | matplotlib, seaborn, plotly | plots and HTML reports |
+| `interactive` | plotly | interactive QC dashboards |
+| `ml` | scikit-learn | ML-backed analyses |
+| `ancestry` | scikit-learn, matplotlib, seaborn | `hvantk ancestry-inference` |
+| `psroc` | scikit-learn, matplotlib, plotly | `hvantk psroc` |
+| `hgc` | matplotlib, seaborn, plotly, gnomad | `hvantk hgc` QC plots/reports |
+| `ptm` | cptac | CPTAC PTM downloads |
+| `constraint` | tspex, matplotlib, seaborn | `hvantk ptm constraint` |
+| `duckdb` | duckdb | DuckDB-backed catalog queries |
+
+`scikit-learn` is optional — install `ml`, `ancestry`, or `psroc` if you use
+those analyses.
+
 ## Prerequisites
 
 - **Python** ≥ 3.10

--- a/docs_site/getting-started/quickstart.md
+++ b/docs_site/getting-started/quickstart.md
@@ -90,17 +90,17 @@ hvantk reprocess ucsc-cellbrowser:adultPancreas --raw-dir data/ucsc --output ucs
 
 ## Expression Analysis
 
-Inspect, summarize, and extract marker genes from expression MatrixTables.
+Inspect, summarize, and extract marker genes from expression AnnData (`.h5ad`) files.
 
 ```bash
 # Inspect metadata
-hvantk expression describe -m ucsc.mt
+hvantk expression describe -m ucsc.h5ad
 
 # Summarize by cell type
-hvantk expression summarize -m ucsc.mt --group-by cell_type -o summary.ht
+hvantk expression summarize -m ucsc.h5ad --group-by cell_type -o summary.h5ad
 
 # Extract marker genes
-hvantk expression markers -s summary.ht --method fold_change -o markers.json
+hvantk expression markers -m ucsc.h5ad --group-by cell_type --method wilcoxon -o markers.json
 ```
 
 [Expression Guide](../guide/usage.md){ .md-button }

--- a/docs_site/guide/usage.md
+++ b/docs_site/guide/usage.md
@@ -101,7 +101,7 @@ hvantk ancestry-inference \
 
 ```python
 import hail as hl
-from hvantk.ancestry import run_ancestry_inference
+from hvantk.algorithms.ancestry import run_ancestry_inference
 
 # Initialize Hail
 hl.init()
@@ -145,40 +145,42 @@ annotated_mt = result.annotate_matrixtable(query_mt)
 
 ## Expression Analysis
 
-Inspect, summarize, and extract markers from expression MatrixTables.
+Inspect, summarize, and extract markers from expression AnnData (`.h5ad`) files.
 
 ```bash
-# Inspect column metadata fields
-hvantk expression describe -m /data/heart_sc.mt
+# Inspect observation metadata fields
+hvantk expression describe -m /data/heart_sc.h5ad
 
-# Collapse into gene-level summary grouped by cell type
+# Collapse into a per-group × per-gene summary AnnData grouped by cell type
 hvantk expression summarize \
-  -m /data/heart_sc.mt \
+  -m /data/heart_sc.h5ad \
   --group-by cell_type \
-  -o /out/heart_celltype_summary.ht
+  -o /out/heart_celltype_summary.h5ad
 
 # Multi-field grouping with pre-filtering
 hvantk expression summarize \
-  -m /data/heart_sc.mt \
+  -m /data/heart_sc.h5ad \
   --group-by cell_type --group-by region \
   --filter-by time_point=9wpc \
   --min-cells 50 \
-  -o /out/heart_summary.ht
+  -o /out/heart_summary.h5ad
 
-# Extract marker genes (fold-change method)
+# Extract marker genes (Wilcoxon rank-sum test)
 hvantk expression markers \
-  -s /out/heart_celltype_summary.ht \
-  --method fold_change \
-  --top-n 200 \
-  -o /out/heart_markers.json
-
-# Extract markers using Wilcoxon rank-sum test
-hvantk expression markers \
-  -m /data/heart_sc.mt \
+  -m /data/heart_sc.h5ad \
   --method wilcoxon \
   --group-by cell_type \
   --top-n 200 \
-  -o /out/heart_wilcoxon_markers.json
+  -o /out/heart_markers.json
+
+# Extract markers using a t-test, pre-filtered to one region
+hvantk expression markers \
+  -m /data/heart_sc.h5ad \
+  --method t-test \
+  --group-by cell_type \
+  --filter-by region=LV \
+  --top-n 200 \
+  -o /out/heart_LV_markers.json
 ```
 
 ## Prepare Custom Gene Sets
@@ -209,14 +211,16 @@ hvantk genesets cosmic --ht /data/cosmic_cgc.ht -o cosmic_gene_sets.json
 ### Python API
 
 ```python
-from hvantk.utils.geneset_io import parse_geneset_tsv, validate_with_hgnc
-from hvantk.utils.gene_sets import load_gene_sets_from_dict
+from hvantk.core.utils.geneset_io import parse_geneset_tsv, validate_with_catalog
+from hvantk.core.utils.gene_sets import load_gene_sets_from_dict
+from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
 
 # Parse TSV
 result = parse_geneset_tsv("panels.tsv")
 
-# Optional: validate against HGNC
-vr = validate_with_hgnc(result.gene_sets, "/data/hgnc.ht")
+# Optional: validate against the HGNC gene catalog (resolves aliases)
+catalog = HGNCGeneCatalogStreamer.from_path("/data/hgnc.ht")
+vr = validate_with_catalog(result.gene_sets, catalog)
 
 # Build and save collection
 collection = load_gene_sets_from_dict(vr.gene_sets, source="prepare-geneset")
@@ -226,9 +230,9 @@ collection.save("panels.json")
 ## ClinGen Gene-Disease streamer
 
 ```python
-from hvantk.data.clingen_streamer import ClinGenStreamer
+from hvantk.skills.clingen.streamers import ClinGenGeneDiseaseTableStreamer
 
-streamer = ClinGenStreamer("/data/clingen/clingen_gene_disease.ht")
+streamer = ClinGenGeneDiseaseTableStreamer("/data/clingen/clingen_gene_disease.ht")
 
 # High-confidence genes
 definitive = streamer.get_genes_by_classification("Definitive")
@@ -250,23 +254,21 @@ streamer.export_for_enrichex(
     min_classification="Moderate",
 )
 
-# Translate output to Ensembl IDs using GeneMapper
-import hail as hl
-from hvantk.data.gene_mapper import GeneMapper
+# Translate output to Ensembl IDs using the HGNC gene catalog
+from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
 
-hgnc_ht = hl.read_table("/data/hgnc/hgnc.ht")
-mapper = GeneMapper(hgnc_ht)
+catalog = HGNCGeneCatalogStreamer.from_path("/data/hgnc/hgnc.ht")
 
 ensembl_ids = streamer.get_genes_by_classification(
-    "Definitive",
-    gene_mapper=mapper,
+    min_classification="Definitive",
+    gene_catalog=catalog,
     output_id_type="ensembl_gene_id",
 )
 
 # Or translate to HGNC IDs
 hgnc_ids = streamer.to_gene_set(
     min_classification="Moderate",
-    gene_mapper=mapper,
+    gene_catalog=catalog,
     output_id_type="hgnc_id",
 )
 ```
@@ -288,13 +290,12 @@ The command auto-detects whether the file is already BGZF and skips conversion i
 ## Tips & troubleshooting
 
 - Use `--overwrite` to replace an existing output. Without it, builders abort if the output exists.
-- For JSON vs YAML: JSON works out of the box; YAML recipes require `PyYAML` installed.
 - For UCSC, gene labels may be pipe-delimited (e.g., A|B); `--split-gene-field` defaults to true.
-- MatrixTables typically store sample/cell metadata under `mt.col_key` and cols metadata; inspect with `mt.describe()` in Python or logs from CLI.
+- Expression AnnData stores per-cell/sample metadata in `adata.obs`; inspect it with `hvantk expression describe -m <file.h5ad>` or `adata.obs` in Python.
 - **gzip vs BGZF**: Hail reads standard gzip files single-threaded, which is significantly slower for large files. Pre-convert with `hvantk utils convert-bgz <file.gz>` for parallel import before running `hvantk reprocess`.
 
 ## See also
 
 - [Architecture](../architecture.md) – system design and extension points
 - [Contributing](../contributing.md) – development workflow and contribution guidelines
-- [Recipe Examples](https://github.com/bigbio/hvantk/tree/main/examples/recipes/) – ready-to-edit recipe templates
+- [Data Sources](data-sources.md) – available datasets and how to acquire them

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,9 @@ nav:
     - EnrichEx - Enrichment Analysis: tools/enrichex.md
     - PS-ROC - Score Evaluation: tools/psroc.md
     - Ancestry Inference: tools/ancestry.md
+    - PTM - Variant Classification: tools/ptm.md
+    - PTM Constraint: tools/ptm-constraint.md
+    - QTL Cascade: tools/qtlcascade.md
   - Examples:
     - Overview: examples/index.md
     - HGC: examples/hgc.md
@@ -74,6 +77,5 @@ nav:
     - ClinGen: examples/clingen.md
     - QTL Cascade: examples/qtlcascade.md
     - PTM: examples/ptm.md
-    - Recipes: examples/recipes.md
   - Architecture: architecture.md
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary

The plugin-system refactor (#109/#110) moved code into `core/`, `algorithms/`, `tools/`, `skills/` and replaced the `mktable`/`mkmatrix` recipe CLI with `hvantk reprocess <provider>:<dataset>`. Several docs still described the old layout and commands. This PR is the first of a series correcting that drift (CLI/build-path + module layout cluster).

## Changes
- **architecture.md** — fix the `core/utils/` tree (drop deleted `streaming.py` / `gene_disease_streamer.py` / `clinvar_streamer.py`), add the real `core/streamers/`; rewrite the streamer-placement rule to `core/streamers/` base classes + `skills/<p>/streamers.py` subclasses; correct the `run_builder_for_spec` signature; **delete the retired recipe/batch-build pattern**; note `ExpressionMatrix` is AnnData (not MatrixTable); `PyYAML` parses `plugin.yaml`.
- **usage.md** — `hvantk.ancestry` → `hvantk.algorithms.ancestry`; `hvantk.utils.*` → `hvantk.core.utils.*`; `validate_with_hgnc` → `validate_with_catalog` (takes a catalog object); ClinGen streamer → `skills.clingen.streamers.ClinGenGeneDiseaseTableStreamer`; `GeneMapper` → `HGNCGeneCatalogStreamer.from_path(...)` + `gene_catalog=`; `expression` commands operate on AnnData `.h5ad` (not `.mt`); drop dead recipe links.
- **quickstart.md** — expression examples use `.h5ad` and real `markers` flags.
- **installation.md** — document optional extras (scikit-learn is now optional behind `ml`/`ancestry`/`psroc`).
- **CONTRIBUTING.md** — `catalog_ref` is a bare identifier (`catalog.yaml` was removed); builder is `build_<source>(parsed_input, ctx, **params)`; helpers live in `core/utils/hail_helpers.py`.
- **README.md** — 21 plugins (`onek-genomes` was missing from the list/count).
- **mkdocs.yml** — remove the broken `examples/recipes.md` nav entry; add the `ptm` / `ptm-constraint` / `qtlcascade` tool pages that were orphaned from nav.

## Verification
`mkdocs build --strict` passes (no broken links / nav references). CLI examples checked against `hvantk <cmd> --help`.
