### PR TITLE
docs: fix stale Python import paths in tool and example docs

### DIFF
--- a/docs_site/examples/ancestry.md
+++ b/docs_site/examples/ancestry.md
@@ -26,9 +26,9 @@ hvantk ancestry-inference \
 ## Python API
 
 ```python
-from hvantk.ancestry.pipeline import run_ancestry_pipeline
+from hvantk.algorithms.ancestry.pipeline import run_ancestry_inference
 
-run_ancestry_pipeline(
+run_ancestry_inference(
     query_mt_path="cohort.mt",
     reference_mt_path="1kg_reference.mt",
     output_dir="results/",

--- a/docs_site/examples/clingen.md
+++ b/docs_site/examples/clingen.md
@@ -14,14 +14,14 @@ hvantk reprocess clingen:gene-disease \
 
 If you already downloaded `Clingen-Gene-Disease-Summary-<YYYY-MM-DD>.csv` into `data/`, add `--skip-download` to reuse it.
 
-## ClinGenStreamer API
+## ClinGenGeneDiseaseTableStreamer API
 
-`ClinGenStreamer` inherits from `GeneDiseaseValidityStreamer`, which provides generic query, aggregation, and integration methods. The same API is available via `GenCCStreamer` for GenCC data.
+`ClinGenGeneDiseaseTableStreamer` inherits from `GeneDiseaseTableStreamer`, which provides generic query, aggregation, and integration methods. The same API is available via `GenCCGeneDiseaseTableStreamer` for GenCC data.
 
 ```python
-from hvantk.data.clingen_streamer import ClinGenStreamer
+from hvantk.skills.clingen.streamers import ClinGenGeneDiseaseTableStreamer
 
-streamer = ClinGenStreamer("clingen.ht", init_hail=False)
+streamer = ClinGenGeneDiseaseTableStreamer("clingen.ht", init_hail=False)
 streamer.setup()
 
 # Get genes by classification level
@@ -60,7 +60,7 @@ summary_df = streamer.categorize_by_ontology_summary(
 )
 ```
 
-Default MONDO categories include organ/system-based (cardiovascular, nervous system, metabolic), cancer, genetic (hereditary, autosomal dominant/recessive), and developmental. See `hvantk/utils/mondo_parser.py` for the full list.
+Default MONDO categories include organ/system-based (cardiovascular, nervous system, metabolic), cancer, genetic (hereditary, autosomal dominant/recessive), and developmental. See `hvantk/core/utils/mondo_parser.py` for the full list.
 
 ## Classification Levels
 

--- a/docs_site/examples/clingen.md
+++ b/docs_site/examples/clingen.md
@@ -60,7 +60,7 @@ summary_df = streamer.categorize_by_ontology_summary(
 )
 ```
 
-Default MONDO categories include organ/system-based (cardiovascular, nervous system, metabolic), cancer, genetic (hereditary, autosomal dominant/recessive), and developmental. See `hvantk/core/utils/mondo_parser.py` for the full list.
+Default MONDO categories include organ/system-based (cardiovascular, nervous system, metabolic), cancer, genetic (hereditary, autosomal dominant/recessive), and developmental. See `hvantk/core/ontology/mondo.py` (`MONDO_DISEASE_CATEGORIES`) for the full list.
 
 ## Classification Levels
 

--- a/docs_site/examples/clinvar.md
+++ b/docs_site/examples/clinvar.md
@@ -1,6 +1,6 @@
-# ClinVar Streaming Examples
+# ClinVar Query Examples
 
-Stream and filter ClinVar variant annotations using hvantk's `ClinvarDataStreamer`.
+Query and filter ClinVar variant annotations using hvantk's `ClinVarVariantTableStreamer`.
 
 ## Prerequisites
 
@@ -15,86 +15,75 @@ hvantk reprocess clinvar:variants \
 
 If you already have `clinvar.vcf.bgz` (or `.vcf.gz`), place it under `data/clinvar/` and add `--skip-download`.
 
-## Basic Streaming
+## Basic Usage
+
+The streamer wraps a built ClinVar `AnnotationTable` and exposes typed query
+methods. Construct it from a saved table with `from_path`, then drop to the
+underlying Hail Table with `to_hail()`:
 
 ```python
-from hvantk.data.clinvar_streamer import ClinvarDataStreamer
+from hvantk.skills.clinvar.streamers import ClinVarVariantTableStreamer
 
-streamer = ClinvarDataStreamer(
-    clinvar_path="clinvar.ht",
-    chunk_size=5000,
-)
+streamer = ClinVarVariantTableStreamer.from_path("clinvar.ht")
 
-streamer.setup()
-try:
-    for chunk in streamer.stream():
-        print(f"Chunk rows: {chunk.count()}")
-finally:
-    streamer.teardown()
+ht = streamer.to_hail()
+print(f"Total variants: {ht.count()}")
 ```
 
 ## Filtering by Gene Set
 
+`filter_to_genes` keeps variants whose `info.GENEINFO` gene matches the set and
+returns a Hail Table:
+
 ```python
-streamer = ClinvarDataStreamer(
-    clinvar_path="clinvar.ht",
-    gene_set={"BRCA1", "BRCA2", "TP53"},
-)
-streamer.setup()
-for chunk in streamer.stream():
-    # Process chunk
-    pass
-streamer.teardown()
+brca_ht = streamer.filter_to_genes({"BRCA1", "BRCA2", "TP53"})
+print(f"Variants in panel: {brca_ht.count()}")
 ```
 
-## Filtering by Disease Terms
+## Filtering by Pathogenicity
+
+`filter_by_pathogenicity` filters on the ClinVar `info.CLNSIG` clinical
+significance labels:
 
 ```python
-streamer = ClinvarDataStreamer(
-    clinvar_path="clinvar.ht",
-    disease_terms={"breast_cancer", "ovarian_cancer"},
+pathogenic_ht = streamer.filter_by_pathogenicity(
+    ["Pathogenic", "Likely_pathogenic"]
 )
-streamer.setup()
-for chunk in streamer.stream():
-    pass
-streamer.teardown()
+print(f"Pathogenic variants: {pathogenic_ht.count()}")
 ```
 
 ## Aggregating Results
 
-```python
-from collections import Counter
+The methods return ordinary Hail Tables, so aggregate them natively:
 
-gene_counts = Counter()
-streamer.setup()
-for chunk in streamer.stream():
-    rows = chunk.select("gene").collect()
-    for row in rows:
-        gene_counts[row.gene] += 1
-streamer.teardown()
-print(gene_counts)
+```python
+import hail as hl
+
+brca_ht = streamer.filter_to_genes({"BRCA1", "BRCA2", "TP53"})
+by_sig = brca_ht.aggregate(hl.agg.counter(brca_ht.info.CLNSIG))
+print(by_sig)
 ```
 
-## Training Set Generation
+## Deriving a Training-Label Column
+
+`label_training_set` derives a TP/TN label column (default `rf_label`) from the
+ClinVar pathogenic/benign labels, optionally restricted to a gene set or disease
+terms:
 
 ```python
-from hvantk.data.clinvar_streamer import create_clinvar_training_set_streamer
-
-processor = create_clinvar_training_set_streamer(
-    clinvar_path="clinvar.ht",
-    output_dir="./data/training_set",
+labeled_ht = streamer.label_training_set(
     gene_set={"BRCA1", "BRCA2"},
+    disease_terms={"breast", "ovarian"},
+    label_column="rf_label",
 )
-result = processor.process()
-if result:
-    print(f"Generated training set with {result.count()} variants")
+labeled_ht = labeled_ht.filter(hl.is_defined(labeled_ht.rf_label))
+print(f"Labeled training variants: {labeled_ht.count()}")
 ```
 
 ## Tips
 
-- **Chunk size**: Adjust for memory/performance tradeoffs (default: 10000)
-- **Data freshness**: Update ClinVar tables regularly (monthly recommended)
-- **Gene names**: ClinVar uses HGNC symbols; verify your gene names match
+- **Data freshness**: Update ClinVar tables regularly (monthly recommended).
+- **Gene names**: ClinVar uses HGNC symbols; verify your gene names match.
 
 ## Runnable Scripts
 

--- a/docs_site/examples/hgc.md
+++ b/docs_site/examples/hgc.md
@@ -22,7 +22,7 @@ hvantk hgc qc-report -i cohort_qc.mt -o report.html
 ### Python API
 
 ```python
-from hvantk.hgc.pipeline import PipelineConfig, PipelineRunner
+from hvantk.algorithms.hgc.pipeline import PipelineConfig, PipelineRunner
 
 config = PipelineConfig(
     input_dir="/data/gvcfs",

--- a/docs_site/examples/psroc.md
+++ b/docs_site/examples/psroc.md
@@ -20,7 +20,7 @@ hvantk psroc \
 ## Python API
 
 ```python
-from hvantk.psroc import PSROCConfig, PSROCPipeline
+from hvantk.algorithms.psroc import PSROCConfig, PSROCPipeline
 
 config = PSROCConfig(
     genes=["BRCA1", "BRCA2", "TP53"],

--- a/docs_site/examples/ptm.md
+++ b/docs_site/examples/ptm.md
@@ -176,19 +176,19 @@ All steps can also be run programmatically:
 
 ```python
 import hail as hl
-from hvantk.ptm import (
+from hvantk.algorithms.ptm import (
     PTMBuildConfig,
-    ptm_build_pipeline,
+    ptm_build_pipeline_core,
     annotate_variants_with_ptm,
     ptm_landscape,
     ptm_population,
     export_ptm_strata,
 )
-from hvantk.ptm.report import generate_report
+from hvantk.algorithms.ptm.report import generate_report
 
 # Build
 config = PTMBuildConfig(output_dir="data/ptm/", output_ht="data/ptm/ptm_sites.ht")
-build_result = ptm_build_pipeline(config)
+build_result = ptm_build_pipeline_core(config)
 
 # Annotate
 clinvar = hl.read_table("data/clinvar.ht")

--- a/docs_site/examples/qtlcascade.md
+++ b/docs_site/examples/qtlcascade.md
@@ -45,7 +45,7 @@ hvantk qtlcascade run \
 ## Quick Start (Python API)
 
 ```python
-from hvantk.qtlcascade import (
+from hvantk.algorithms.qtlcascade import (
     build_cascade,
     build_cascade_gene_summary,
     CascadeConfig,

--- a/docs_site/tools/ancestry.md
+++ b/docs_site/tools/ancestry.md
@@ -61,7 +61,7 @@ hvantk ancestry-inference \
 
 ```python
 import hail as hl
-from hvantk.ancestry import run_ancestry_inference
+from hvantk.algorithms.ancestry import run_ancestry_inference
 
 # Initialize Hail
 hl.init()
@@ -279,7 +279,7 @@ The HTML report includes:
 ### Main Function
 
 ```python
-from hvantk.ancestry import run_ancestry_inference, PipelineConfig
+from hvantk.algorithms.ancestry import run_ancestry_inference, PipelineConfig
 
 result = run_ancestry_inference(
     query_mt: hl.MatrixTable,
@@ -319,7 +319,7 @@ result.annotate_matrixtable(mt) -> hl.MatrixTable
 ### PipelineConfig
 
 ```python
-from hvantk.ancestry import PipelineConfig
+from hvantk.algorithms.ancestry import PipelineConfig
 
 config = PipelineConfig(
     # Variant filtering
@@ -359,7 +359,7 @@ config = PipelineConfig(
 
 ```python
 import hail as hl
-from hvantk.ancestry import run_ancestry_inference
+from hvantk.algorithms.ancestry import run_ancestry_inference
 
 hl.init()
 

--- a/docs_site/tools/hgc.md
+++ b/docs_site/tools/hgc.md
@@ -137,7 +137,7 @@ hvantk hgc filter-qc -i analysis_qc.mt -o filtered.mt --min-sample-call-rate 0.9
 Use HGC functions directly in Python:
 
 ```python
-from hvantk.hgc import (
+from hvantk.algorithms.hgc import (
     combine_gvcfs,
     combine_vdses,
     convert_vds_to_mt,
@@ -169,7 +169,7 @@ convert_vds_to_mt(
 Additional QC functionality for combined cohorts:
 
 ```python
-from hvantk.hgc import compute_full_qc, filter_samples_by_qc, filter_variants_by_qc
+from hvantk.algorithms.hgc import compute_full_qc, filter_samples_by_qc, filter_variants_by_qc
 
 # Load combined MatrixTable
 import hail as hl
@@ -202,7 +202,7 @@ mt_filtered = filter_variants_by_qc(
 For end-to-end workflows, use the Pipeline API:
 
 ```python
-from hvantk.hgc.pipeline import PipelineConfig, PipelineRunner
+from hvantk.algorithms.hgc.pipeline import PipelineConfig, PipelineRunner
 
 # Create configuration
 config = PipelineConfig(
@@ -226,7 +226,7 @@ See [Pipeline Orchestration](#pipeline-orchestration) for detailed documentation
 
 ## Core Components
 
-### 1. Pipeline (`hvantk.hgc.pipeline`)
+### 1. Pipeline (`hvantk.algorithms.hgc.pipeline`)
 
 **Recommended** - End-to-end workflow orchestration:
 
@@ -237,25 +237,25 @@ See [Pipeline Orchestration](#pipeline-orchestration) for detailed documentation
 
 See [Pipeline Orchestration](#pipeline-orchestration) for detailed usage.
 
-### 2. Combiners (`hvantk.hgc.combiners`)
+### 2. Combiners (`hvantk.algorithms.hgc.combiners`)
 
 Functions for combining genomic datasets:
 
 - **`combine_gvcfs()`** - Combine GVCF files and/or existing VDS datasets into a new VDS
 - **`combine_vdses()`** - Merge multiple VDS directories into a single VDS
 
-**Advanced functions** (require direct import from `hvantk.hgc.combiners`):
+**Advanced functions** (require direct import from `hvantk.algorithms.hgc.combiners`):
 - **`combine_matrix_table_rows()`** - Combine MatrixTables by rows (variants)
 - **`combine_matrix_table_cols()`** - Combine MatrixTables by columns (samples)
 
-### 3. Converters (`hvantk.hgc.converters`)
+### 3. Converters (`hvantk.algorithms.hgc.converters`)
 
 Functions for format conversion:
 
 - **`convert_vds_to_mt()`** - Convert VDS to dense MatrixTable format
 - **`convert_mt_to_multi_sample_vcf()`** - Export MatrixTable to multi-sample VCF
 
-### 4. File Utilities (`hvantk.hgc.file_utils`)
+### 4. File Utilities (`hvantk.algorithms.hgc.file_utils`)
 
 Helper functions for file handling:
 
@@ -282,7 +282,7 @@ hvantk hgc gvcf-combine \
 
 **Python:**
 ```python
-from hvantk.hgc import combine_gvcfs
+from hvantk.algorithms.hgc import combine_gvcfs
 
 combine_gvcfs(
     gvcf_dir="/data/gvcfs",
@@ -329,7 +329,7 @@ hvantk hgc vds-combine \
 
 **Python:**
 ```python
-from hvantk.hgc import combine_vdses
+from hvantk.algorithms.hgc import combine_vdses
 
 combine_vdses(
     vdses_dir="/data/vds_datasets",
@@ -361,7 +361,7 @@ hvantk hgc vds2mt \
 
 **Python:**
 ```python
-from hvantk.hgc import convert_vds_to_mt
+from hvantk.algorithms.hgc import convert_vds_to_mt
 
 convert_vds_to_mt(
     vds_path="cohort.vds",
@@ -404,7 +404,7 @@ hvantk hgc mt2vcf \
 
 **Python:**
 ```python
-from hvantk.hgc import convert_mt_to_multi_sample_vcf
+from hvantk.algorithms.hgc import convert_mt_to_multi_sample_vcf
 
 convert_mt_to_multi_sample_vcf(
     mt_path="analysis.mt",
@@ -583,7 +583,7 @@ output_directory/
 ### Python API
 
 ```python
-from hvantk.hgc.pipeline import PipelineConfig, PipelineRunner
+from hvantk.algorithms.hgc.pipeline import PipelineConfig, PipelineRunner
 
 # Configure pipeline
 config = PipelineConfig(
@@ -742,7 +742,7 @@ tabix -p vcf input.g.vcf.gz
 ### Example 1: Incremental Cohort Building
 
 ```python
-from hvantk.hgc import combine_gvcfs, combine_vdses
+from hvantk.algorithms.hgc import combine_gvcfs, combine_vdses
 
 # First batch
 combine_gvcfs(
@@ -777,7 +777,7 @@ combine_vdses(
 
 ```python
 import hail as hl
-from hvantk.hgc import convert_vds_to_mt
+from hvantk.algorithms.hgc import convert_vds_to_mt
 
 # Convert VDS to MT
 convert_vds_to_mt(
@@ -828,7 +828,7 @@ mt.write("cohort_filtered.mt")
 
 ### Advanced Functions
 
-These functions require direct import from `hvantk.hgc.combiners`:
+These functions require direct import from `hvantk.algorithms.hgc.combiners`:
 
 | Function | Description | Returns |
 |----------|-------------|---------|
@@ -837,7 +837,7 @@ These functions require direct import from `hvantk.hgc.combiners`:
 
 ## Constants
 
-The module defines commonly used constants in `hvantk.hgc.constants`:
+The module defines commonly used constants in `hvantk.algorithms.hgc.constants`:
 
 **Reference Genomes:**
 - `HG38_GENOME_REFERENCE` - "GRCh38"

--- a/docs_site/tools/psroc.md
+++ b/docs_site/tools/psroc.md
@@ -51,7 +51,7 @@ hvantk psroc \
 ### Python API
 
 ```python
-from hvantk.psroc import PSROCConfig, PSROCPipeline
+from hvantk.algorithms.psroc import PSROCConfig, PSROCPipeline
 
 # Configure analysis
 config = PSROCConfig(
@@ -533,7 +533,7 @@ hvantk psroc \
 Configuration dataclass for the pipeline:
 
 ```python
-from hvantk.psroc import PSROCConfig
+from hvantk.algorithms.psroc import PSROCConfig
 
 config = PSROCConfig(
     # Input sources (exactly one required)
@@ -577,7 +577,7 @@ if errors:
 Main pipeline orchestrator:
 
 ```python
-from hvantk.psroc import PSROCPipeline
+from hvantk.algorithms.psroc import PSROCPipeline
 
 pipeline = PSROCPipeline(config)
 
@@ -588,7 +588,7 @@ pipeline.show_plan()
 result = pipeline.run()
 
 # --- Multi-group analysis ---
-from hvantk.psroc import PSROCConfig, PSROCPipeline
+from hvantk.algorithms.psroc import PSROCConfig, PSROCPipeline
 
 collection_config = PSROCConfig(
     gene_set_collection={
@@ -642,7 +642,7 @@ result_dict = result.to_dict()
 For direct use without the pipeline:
 
 ```python
-from hvantk.psroc import (
+from hvantk.algorithms.psroc import (
     compute_roc_metrics,
     compute_all_missingness,
     filter_scores_by_missingness,
@@ -671,7 +671,7 @@ for name, roc in results.items():
 ### Plotting Functions
 
 ```python
-from hvantk.psroc import (
+from hvantk.algorithms.psroc import (
     plot_roc_curves,
     plot_auc_comparison,
     plot_missingness_summary,
@@ -928,9 +928,9 @@ hvantk genesets clingen \
 ### From ClinGen (Python API)
 
 ```python
-from hvantk.data.clingen_streamer import ClinGenStreamer
+from hvantk.skills.clingen.streamers import ClinGenGeneDiseaseTableStreamer
 
-streamer = ClinGenStreamer(table_path="/data/tables/clingen.ht")
+streamer = ClinGenGeneDiseaseTableStreamer(table_path="/data/tables/clingen.ht")
 streamer.setup()
 
 # GCEP-based (recommended)
@@ -957,7 +957,7 @@ gene_sets = {
 Standard GMT files (e.g., MSigDB pathways) can be loaded directly:
 
 ```python
-from hvantk.utils.gene_sets import load_gene_sets
+from hvantk.core.utils.gene_sets import load_gene_sets
 
 collection = load_gene_sets("/data/pathways.gmt")
 gene_set_dict = {gs.name: gs.genes for gs in collection}
@@ -966,7 +966,7 @@ gene_set_dict = {gs.name: gs.genes for gs in collection}
 ### Saving for CLI Use
 
 ```python
-from hvantk.utils.gene_sets import load_gene_sets_from_dict
+from hvantk.core.utils.gene_sets import load_gene_sets_from_dict
 
 collection = load_gene_sets_from_dict(gene_sets)
 collection.save("/data/gene_sets/my_collection.json")

--- a/docs_site/tools/ptm.md
+++ b/docs_site/tools/ptm.md
@@ -69,32 +69,32 @@ hvantk ptm report -o report.html \
 ### Python API
 
 ```python
-from hvantk.ptm import PTMBuildConfig, ptm_build_pipeline
+from hvantk.algorithms.ptm import PTMBuildConfig, ptm_build_pipeline_core
 
 # Build PTM sites table
 config = PTMBuildConfig(
     output_dir="data/ptm/",
     output_ht="data/ptm/ptm_sites.ht",
 )
-result = ptm_build_pipeline(config)
+result = ptm_build_pipeline_core(config)
 print(f"Mapped {result.n_mapped}/{result.n_total} sites")
 
 # Annotate variants
 import hail as hl
-from hvantk.ptm import annotate_variants_with_ptm
+from hvantk.algorithms.ptm import annotate_variants_with_ptm
 
 variants = hl.read_table("clinvar.ht")
 ptm = hl.read_table("data/ptm/ptm_sites.ht")
 annotated = annotate_variants_with_ptm(variants, ptm)
 
 # Landscape analysis
-from hvantk.ptm import ptm_landscape
+from hvantk.algorithms.ptm import ptm_landscape
 
 result = ptm_landscape(variants, ptm, "results/landscape/")
 print(result.summary())
 
 # Population analysis
-from hvantk.ptm import ptm_population
+from hvantk.algorithms.ptm import ptm_population
 
 gnomad = hl.read_table("gnomad.ht")
 pop_result = ptm_population(gnomad, ptm, "results/population/")
@@ -207,7 +207,7 @@ Gene annotation (exon coordinates, CDS phases) from Ensembl GRCh38. Used for map
 ## Module Structure
 
 ```text
-hvantk/ptm/
+hvantk/algorithms/ptm/
 ├── __init__.py     # Module exports
 ├── constants.py    # PTM-specific constants (URLs, field names, categories)
 ├── mapper.py       # GTF parser and residue-to-genomic coordinate mapper

--- a/docs_site/tools/qtlcascade.md
+++ b/docs_site/tools/qtlcascade.md
@@ -67,7 +67,7 @@ hvantk qtlcascade run \
 ### Python API
 
 ```python
-from hvantk.qtlcascade import CascadeConfig, CascadePipeline
+from hvantk.algorithms.qtlcascade import CascadeConfig, CascadePipeline
 
 # Configure pipeline
 config = CascadeConfig(
@@ -370,7 +370,7 @@ Optional:
 #### `build_cascade`
 
 ```python
-from hvantk.qtlcascade import build_cascade
+from hvantk.algorithms.qtlcascade import build_cascade
 
 ht = build_cascade(
     eqtl_ht_path="/data/eqtl.ht",
@@ -388,7 +388,7 @@ Returns a Hail Table keyed by `(locus, alleles, gene_id)` with cascade classific
 #### `build_cascade_gene_summary`
 
 ```python
-from hvantk.qtlcascade import build_cascade_gene_summary
+from hvantk.algorithms.qtlcascade import build_cascade_gene_summary
 
 gene_ht = build_cascade_gene_summary(
     cascade_ht_path="/results/cascade.ht",
@@ -405,7 +405,7 @@ Returns a Hail Table keyed by `gene_id` with aggregated cascade evidence.
 #### `coloc_abf`
 
 ```python
-from hvantk.qtlcascade import coloc_abf
+from hvantk.algorithms.qtlcascade import coloc_abf
 import numpy as np
 
 result = coloc_abf(
@@ -424,7 +424,7 @@ Returns dict with keys `H0`–`H4`, `n_variants`, `lead_snp_h4_idx`.
 #### `run_coloc_per_gene`
 
 ```python
-from hvantk.qtlcascade import run_coloc_per_gene
+from hvantk.algorithms.qtlcascade import run_coloc_per_gene
 
 coloc_df = run_coloc_per_gene(
     eqtl_allpairs_ht_path="/data/eqtl_allpairs.ht",
@@ -441,7 +441,7 @@ coloc_df = run_coloc_per_gene(
 #### CascadeConfig
 
 ```python
-from hvantk.qtlcascade import CascadeConfig
+from hvantk.algorithms.qtlcascade import CascadeConfig
 
 config = CascadeConfig(
     # Required
@@ -485,7 +485,7 @@ if errors:
 #### CascadePipeline
 
 ```python
-from hvantk.qtlcascade import CascadePipeline
+from hvantk.algorithms.qtlcascade import CascadePipeline
 
 pipeline = CascadePipeline(config)
 
@@ -519,7 +519,7 @@ if result.coloc_df is not None:
 ### Plotting Functions
 
 ```python
-from hvantk.qtlcascade import (
+from hvantk.algorithms.qtlcascade import (
     plot_cascade_classes,
     plot_attenuation,
     plot_coloc_posteriors,
@@ -621,7 +621,7 @@ hvantk reprocess pqtl:metrics \
 ## Module Structure
 
 ```text
-hvantk/qtlcascade/
+hvantk/algorithms/qtlcascade/
 ├── __init__.py      # Public API surface
 ├── constants.py     # Thresholds, priors, tissue mappings, source IDs
 ├── cascade.py       # Outer join + cascade classification


### PR DESCRIPTION
## Summary

The plugin-system refactor moved the analysis packages under `hvantk/algorithms/*` and shared utilities under `hvantk/core/utils/*`. The old top-level imports (`from hvantk.ancestry import …`, `from hvantk.hgc import …`, etc.) are now `ImportError`s. This PR sweeps the tool and example docs so every Python snippet imports from the live module.

## Changes
- `hvantk.{ancestry,hgc,psroc,ptm,qtlcascade}` → `hvantk.algorithms.*` (tools/ + examples/).
- `hvantk.utils.*` → `hvantk.core.utils.*`; `hvantk.core.hail_context` → `hvantk.core.utils.hail_context`.
- `examples/ancestry.md`: `run_ancestry_pipeline` → `run_ancestry_inference`.
- `tools/ptm.md` + `examples/ptm.md`: `ptm_build_pipeline` → `ptm_build_pipeline_core` (the real export).
- `examples/clingen.md` + `tools/psroc.md`: `hvantk.data.clingen_streamer.ClinGenStreamer` → `hvantk.skills.clingen.streamers.ClinGenGeneDiseaseTableStreamer` (and base/sibling class names in prose).
- `examples/clinvar.md`: rewrite the retired `ClinvarDataStreamer` chunk-iterator API to the current `ClinVarVariantTableStreamer` (`from_path` / `to_hail` / `filter_to_genes` / `filter_by_pathogenicity` / `label_training_set`); **remove** the retired `create_clinvar_training_set_streamer` section (superseded by the `tools/training_sets` builder).

## Verification
Every replaced symbol was confirmed against the live source (`hvantk/algorithms/*/__init__.py`, `hvantk/skills/*/streamers.py`, `hvantk/core/streamers/*`). `mkdocs build --strict` shows no *new* warnings from these files (the remaining `mkdocs.yml` nav warnings are pre-existing on dev and fixed by #160).

Pairs with #160 (CLI/build-path + module-layout overhaul).
