### PR TITLE
refactor: rename ptm/test.py to ptm/lmm.py (PR-3)

### DIFF
--- a/hvantk/algorithms/ptm/__init__.py
+++ b/hvantk/algorithms/ptm/__init__.py
@@ -87,11 +87,11 @@ _LAZY_MODULES = {
         "annotate_variants_by_symbol",
     ),
     # Phase-2 constraint tests (statsmodels)
-    "LMMResult": ("hvantk.algorithms.ptm.test", "LMMResult"),
-    "BinnedLMMResult": ("hvantk.algorithms.ptm.test", "BinnedLMMResult"),
-    "run_lmm": ("hvantk.algorithms.ptm.test", "run_lmm"),
+    "LMMResult": ("hvantk.algorithms.ptm.lmm", "LMMResult"),
+    "BinnedLMMResult": ("hvantk.algorithms.ptm.lmm", "BinnedLMMResult"),
+    "run_lmm": ("hvantk.algorithms.ptm.lmm", "run_lmm"),
     "run_binned_interaction_lmm": (
-        "hvantk.algorithms.ptm.test",
+        "hvantk.algorithms.ptm.lmm",
         "run_binned_interaction_lmm",
     ),
     # Phase-2 report writer

--- a/hvantk/algorithms/ptm/constants.py
+++ b/hvantk/algorithms/ptm/constants.py
@@ -58,7 +58,7 @@ RESOLUTION_METHODS = ["xref_mane", "xref_any", "gene_mane"]
 
 # ---------------------------------------------------------------------------
 # Variant-annotation and LMM defaults
-# (consumed by hvantk.ptm.annotate and hvantk.ptm.test).
+# (consumed by hvantk.algorithms.ptm.annotate and hvantk.algorithms.ptm.lmm).
 # ---------------------------------------------------------------------------
 
 # Proximal flanking window for gene-symbol variant annotation:
@@ -84,13 +84,13 @@ EXPRESSION_BIN_LABELS = ["b0_none", "b1_Q1", "b2_Q2", "b3_Q3", "b4_Q4"]
 LOG_AF_EPSILON = 1e-8
 
 # Minimum per-stratum sample counts for the constraint LMM
-# (hvantk.ptm.test.fit_constraint_lmm). Below these the per-gene estimate
+# (hvantk.algorithms.ptm.lmm.fit_constraint_lmm). Below these the per-gene estimate
 # is unstable.
 LMM_MIN_N_PTM = 30
 LMM_MIN_N_NONPTM = 30
 LMM_MIN_MIXED_GENES = 10
 
 # Sparsity gates for the binned-interaction LMM
-# (hvantk.ptm.test.fit_binned_interaction_lmm).
+# (hvantk.algorithms.ptm.lmm.fit_binned_interaction_lmm).
 LMM_BINNED_MIN_POS_EXPR = 100
 LMM_BINNED_MIN_CELL_N = 5

--- a/hvantk/algorithms/ptm/lmm.py
+++ b/hvantk/algorithms/ptm/lmm.py
@@ -12,7 +12,7 @@ and keeps the API surface small.
 
 Example
 -------
-    >>> from hvantk.algorithms.ptm.test import run_lmm, run_binned_interaction_lmm
+    >>> from hvantk.algorithms.ptm.lmm import run_lmm, run_binned_interaction_lmm
     >>> result = run_lmm(df_heart, stratum="Heart")
     >>> print(result.beta_ptm, result.p_ptm)
 """

--- a/hvantk/algorithms/ptm/report.py
+++ b/hvantk/algorithms/ptm/report.py
@@ -26,7 +26,7 @@ from hvantk.algorithms.ptm.plot import (
 
 if TYPE_CHECKING:  # avoid import-time Hail/statsmodels load for type hints
     from hvantk.algorithms.ptm.atlas import PTMAtlasResult
-    from hvantk.algorithms.ptm.test import BinnedLMMResult, LMMResult
+    from hvantk.algorithms.ptm.lmm import BinnedLMMResult, LMMResult
 
 logger = logging.getLogger(__name__)
 

--- a/hvantk/tools/ptm/ptm_cli.py
+++ b/hvantk/tools/ptm/ptm_cli.py
@@ -964,7 +964,7 @@ def ptm_test(
         click.echo(f"Running {mode} for {len(strata)} strata...")
 
         if mode == "lmm":
-            from hvantk.algorithms.ptm.test import run_lmm
+            from hvantk.algorithms.ptm.lmm import run_lmm
 
             rows = []
             for s in strata:
@@ -998,7 +998,7 @@ def ptm_test(
                     err=True,
                 )
                 ctx.exit(1)
-            from hvantk.algorithms.ptm.test import run_binned_interaction_lmm
+            from hvantk.algorithms.ptm.lmm import run_binned_interaction_lmm
 
             wide = _read_expression_wide(expression_pkl, expression_tsv)
             rows = []


### PR DESCRIPTION
Part of the pre-release code-hardening audit. **PR-3 = naming clarity.** No behavior change.

Renames `algorithms/ptm/test.py` -> `algorithms/ptm/lmm.py`. The module holds the LMM constraint-test functions (`run_lmm`, `run_binned_interaction_lmm`, `LMMResult`, `BinnedLMMResult`); a module literally named `test.py` is confusing structure for a stats module. All references updated:
- `ptm/__init__.py` lazy-import map (4 entries)
- `tools/ptm/ptm_cli.py` (2 imports), `algorithms/ptm/report.py` (1 import)
- stale module references in `ptm/constants.py` comments

## Descoped
The audit also flagged a `GeneSet` name collision (`core/utils/gene_sets.py` dataclass vs the `core/models/gene_set.py` typed artifact). On review this is purely cosmetic — no file imports both; they live in separate subsystems — so it was deliberately left out rather than churn ~19 files.

## Verification
flake8 (E9,F63,F7,F82,F401) clean; the lazy symbols (`run_lmm` etc.) resolve via `hvantk.algorithms.ptm` on the project venv (3.10).
