### PR TITLE
refactor: extract shared classification/CURIE builder helpers (PR-4c)

### DIFF
--- a/hvantk/core/utils/table_utils.py
+++ b/hvantk/core/utils/table_utils.py
@@ -159,6 +159,98 @@ def str_to_bool(expr: hl.StringExpression) -> hl.BooleanExpression:
 
 
 # ---------------------------------------------------------------------------
+# Gene-disease classification levels & CURIE prefixes
+# ---------------------------------------------------------------------------
+
+
+def strip_curie_prefix(expr: hl.StringExpression, prefix: str) -> hl.StringExpression:
+    """Strip a CURIE *prefix* (e.g. ``"HGNC:"``) from a Hail string expression.
+
+    Values that do not start with *prefix* are returned unchanged.
+
+    Parameters
+    ----------
+    expr : hl.StringExpression
+        The string field to normalise.
+    prefix : str
+        The CURIE prefix to strip (e.g. ``"HGNC:"`` or ``"MONDO:"``).
+
+    Returns
+    -------
+    hl.StringExpression
+    """
+    return hl.if_else(expr.startswith(prefix), expr.replace(prefix, ""), expr)
+
+
+def annotate_classification_level(
+    ht: hl.Table,
+    levels: Sequence[str],
+    *,
+    field: str = "classification",
+    level_field: str = "classification_level",
+) -> hl.Table:
+    """Annotate *level_field* with the ordinal rank of ``ht[field]`` in *levels*.
+
+    The ordinal is the index of the classification within *levels* (most
+    confident first). Values absent from *levels* (including missing) map to
+    ``len(levels)`` so they sort last.
+
+    Parameters
+    ----------
+    ht : hl.Table
+        Table carrying a string *field* of classification labels.
+    levels : sequence of str
+        Ordered classification labels, most-confident first.
+    field : str
+        Source classification field name. Defaults to ``"classification"``.
+    level_field : str
+        Name of the integer rank field to add. Defaults to
+        ``"classification_level"``.
+
+    Returns
+    -------
+    hl.Table
+    """
+    order = {level: i for i, level in enumerate(levels)}
+    return ht.annotate(
+        **{level_field: hl.literal(order).get(ht[field], hl.len(levels))}
+    )
+
+
+def filter_min_classification(
+    ht: hl.Table,
+    levels: Sequence[str],
+    min_classification: str,
+    *,
+    level_field: str = "classification_level",
+) -> hl.Table:
+    """Filter *ht* to rows at or above *min_classification* confidence.
+
+    Keeps rows whose *level_field* ordinal is ``<=`` the ordinal of
+    *min_classification* within *levels* (lower ordinal == higher confidence).
+    Requires *level_field* to already exist — see
+    :func:`annotate_classification_level`.
+
+    Parameters
+    ----------
+    ht : hl.Table
+        Table with *level_field* already annotated.
+    levels : sequence of str
+        Ordered classification labels, most-confident first.
+    min_classification : str
+        Minimum confidence level to keep; must be one of *levels*.
+    level_field : str
+        Integer rank field to filter on. Defaults to ``"classification_level"``.
+
+    Returns
+    -------
+    hl.Table
+    """
+    min_level = {level: i for i, level in enumerate(levels)}[min_classification]
+    return ht.filter(ht[level_field] <= min_level)
+
+
+# ---------------------------------------------------------------------------
 # Field resolution — handles both flat dotted names and nested structs
 # ---------------------------------------------------------------------------
 

--- a/hvantk/skills/clingen/builder.py
+++ b/hvantk/skills/clingen/builder.py
@@ -26,7 +26,12 @@ from hvantk.skills.clingen.shared.constants import (
     CLINGEN_GENE_DISEASE_FIELDS,
 )
 from hvantk.core.utils.hail_helpers import cleanup_temp_file
-from hvantk.core.utils.table_utils import get_row_fields
+from hvantk.core.utils.table_utils import (
+    get_row_fields,
+    strip_curie_prefix,
+    annotate_classification_level,
+    filter_min_classification,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,34 +94,15 @@ def build_clingen_gene_disease(
 
         row_fields = get_row_fields(ht)
         if "hgnc_id" in row_fields:
-            ht = ht.annotate(
-                hgnc_id=hl.if_else(
-                    ht.hgnc_id.startswith("HGNC:"),
-                    ht.hgnc_id.replace("HGNC:", ""),
-                    ht.hgnc_id,
-                )
-            )
+            ht = ht.annotate(hgnc_id=strip_curie_prefix(ht.hgnc_id, "HGNC:"))
         if "mondo_id" in row_fields:
-            ht = ht.annotate(
-                mondo_id=hl.if_else(
-                    ht.mondo_id.startswith("MONDO:"),
-                    ht.mondo_id.replace("MONDO:", ""),
-                    ht.mondo_id,
-                )
-            )
+            ht = ht.annotate(mondo_id=strip_curie_prefix(ht.mondo_id, "MONDO:"))
 
-        classification_order = {
-            level: i for i, level in enumerate(CLINGEN_CLASSIFICATION_LEVELS)
-        }
-        ht = ht.annotate(
-            classification_level=hl.literal(classification_order).get(
-                ht.classification, hl.len(CLINGEN_CLASSIFICATION_LEVELS)
-            )
-        )
-
+        ht = annotate_classification_level(ht, CLINGEN_CLASSIFICATION_LEVELS)
         if min_classification is not None:
-            min_level = classification_order[min_classification]
-            ht = ht.filter(ht.classification_level <= min_level)
+            ht = filter_min_classification(
+                ht, CLINGEN_CLASSIFICATION_LEVELS, min_classification
+            )
 
         ht = ht.key_by("hgnc_id", "mondo_id")
 

--- a/hvantk/skills/cosmic_cgc/builder.py
+++ b/hvantk/skills/cosmic_cgc/builder.py
@@ -16,7 +16,13 @@ from hvantk.skills.cosmic_cgc.shared.constants import (
     COSMIC_CGC_CLASSIFICATION_LEVELS,
     COSMIC_MUTATION_CONTEXTS,
 )
-from hvantk.core.utils.table_utils import get_row_fields, build_rename_map, str_to_bool
+from hvantk.core.utils.table_utils import (
+    get_row_fields,
+    build_rename_map,
+    str_to_bool,
+    annotate_classification_level,
+    filter_min_classification,
+)
 from hvantk.core.utils.file_utils import resolve_compression
 
 if TYPE_CHECKING:
@@ -96,15 +102,7 @@ def build_cosmic_cgc_submissions(
     )
 
     # Add classification_level numeric field
-    classification_order = {
-        level: i for i, level in enumerate(COSMIC_CGC_CLASSIFICATION_LEVELS)
-    }
-    ht = ht.annotate(
-        classification_level=hl.literal(classification_order).get(
-            ht.classification,
-            hl.len(COSMIC_CGC_CLASSIFICATION_LEVELS),
-        )
-    )
+    ht = annotate_classification_level(ht, COSMIC_CGC_CLASSIFICATION_LEVELS)
 
     # Normalize boolean fields
     for bool_field in ("somatic", "germline", "hallmark"):
@@ -143,13 +141,10 @@ def build_cosmic_cgc_submissions(
 
     # Apply min_classification filter
     if min_classification is not None:
-        min_level = classification_order[min_classification]
-        logger.info(
-            "Filtering to classifications >= %s (level %d)",
-            min_classification,
-            min_level,
+        logger.info("Filtering to classifications >= %s", min_classification)
+        ht = filter_min_classification(
+            ht, COSMIC_CGC_CLASSIFICATION_LEVELS, min_classification
         )
-        ht = ht.filter(ht.classification_level <= min_level)
 
     # Resolve gene_symbol -> hgnc_id if a gene catalog is available
     if gene_catalog is not None:

--- a/hvantk/skills/gencc/builder.py
+++ b/hvantk/skills/gencc/builder.py
@@ -15,7 +15,12 @@ from hvantk.skills.gencc.shared.constants import (
     GENCC_CLASSIFICATION_LEVELS,
     GENCC_SUBMISSION_FIELDS,
 )
-from hvantk.core.utils.table_utils import get_row_fields
+from hvantk.core.utils.table_utils import (
+    get_row_fields,
+    strip_curie_prefix,
+    annotate_classification_level,
+    filter_min_classification,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,34 +63,15 @@ def build_gencc_submissions(
 
     row_fields = get_row_fields(ht)
     if "hgnc_id" in row_fields:
-        ht = ht.annotate(
-            hgnc_id=hl.if_else(
-                ht.hgnc_id.startswith("HGNC:"),
-                ht.hgnc_id.replace("HGNC:", ""),
-                ht.hgnc_id,
-            )
-        )
+        ht = ht.annotate(hgnc_id=strip_curie_prefix(ht.hgnc_id, "HGNC:"))
     if "mondo_id" in row_fields:
-        ht = ht.annotate(
-            mondo_id=hl.if_else(
-                ht.mondo_id.startswith("MONDO:"),
-                ht.mondo_id.replace("MONDO:", ""),
-                ht.mondo_id,
-            )
-        )
+        ht = ht.annotate(mondo_id=strip_curie_prefix(ht.mondo_id, "MONDO:"))
 
-    classification_order = {
-        level: i for i, level in enumerate(GENCC_CLASSIFICATION_LEVELS)
-    }
-    ht = ht.annotate(
-        classification_level=hl.literal(classification_order).get(
-            ht.classification, hl.len(GENCC_CLASSIFICATION_LEVELS)
-        )
-    )
-
+    ht = annotate_classification_level(ht, GENCC_CLASSIFICATION_LEVELS)
     if min_classification is not None:
-        min_level = classification_order[min_classification]
-        ht = ht.filter(ht.classification_level <= min_level)
+        ht = filter_min_classification(
+            ht, GENCC_CLASSIFICATION_LEVELS, min_classification
+        )
 
     ht = ht.key_by("hgnc_id", "mondo_id", "submitter")
 


### PR DESCRIPTION
Part of the pre-release code-hardening audit. **PR-4c = builder de-duplication.** Behavior-preserving.

The classification-level annotation and `min_classification` filter were copy-pasted across the `clingen`, `gencc`, and `cosmic_cgc` builders, and the `HGNC:`/`MONDO:` CURIE-prefix stripping was duplicated in `clingen`/`gencc`. This extracts three shared helpers into `core/utils/table_utils.py` and uses them at all sites:

- `strip_curie_prefix(expr, prefix)` — `HGNC:`/`MONDO:` stripping (clingen, gencc)
- `annotate_classification_level(ht, levels)` — adds the ordinal `classification_level` field
- `filter_min_classification(ht, levels, min_classification)` — confidence-threshold filter

## Behavior preservation
The helpers are faithful transcriptions of the inline logic — same `{level: i}` order dict, same `hl.len(levels)` default for unknown values, same `<= min_level` filter predicate, same constants. `cosmic_cgc`'s gene-catalog CURIE strip is deliberately **left inline** because it carries an extra `hl.is_defined` guard and conditional context, so it is not equivalent to the generic helper.

Verified by an adversarial multi-agent review (one agent per builder + one reviewing the helpers) — **all confirmed behavior-equivalent**. The only non-data change is cosmetic: the `cosmic_cgc` `min_classification` log line no longer prints the numeric level ordinal.

## Verification
flake8 (E9,F63,F7,F82,F401,F811) clean; no orphaned references. Net: ~68 lines of duplicated builder logic replaced by 3 documented shared helpers.
