### PR TITLE
refactor(visualization): consolidate figure helpers into visualization/base (PR-4b)

### DIFF
--- a/hvantk/algorithms/ancestry/plot.py
+++ b/hvantk/algorithms/ancestry/plot.py
@@ -12,8 +12,6 @@ The main plotting function `plot_pca_scatter` supports:
 """
 
 import logging
-from io import BytesIO
-import base64
 from typing import Dict, List, Optional, Tuple, Union, Any
 
 import numpy as np
@@ -703,7 +701,7 @@ def plot_confusion_matrix(
 
 
 def encode_figure_to_base64(fig, format: str = "png", dpi: int = 150) -> str:
-    """Encode matplotlib figure to base64 string for HTML embedding.
+    """Encode matplotlib figure to a base64 data-URI string for HTML embedding.
 
     Parameters
     ----------
@@ -717,14 +715,16 @@ def encode_figure_to_base64(fig, format: str = "png", dpi: int = 150) -> str:
     Returns
     -------
     str
-        Base64-encoded image string.
+        Data-URI string (``data:image/{format};base64,...``) suitable for an
+        HTML ``<img src=...>`` attribute.
     """
-    buffer = BytesIO()
-    fig.savefig(buffer, format=format, dpi=dpi, bbox_inches="tight")
-    buffer.seek(0)
-    img_str = base64.b64encode(buffer.read()).decode("utf-8")
-    buffer.close()
-    return f"data:image/{format};base64,{img_str}"
+    # Imported lazily so that importing this module does not require matplotlib
+    # (kept optional via ``_get_matplotlib``); ``base`` imports it eagerly.
+    from hvantk.algorithms.visualization.base import (
+        encode_figure_to_base64 as _encode,
+    )
+
+    return _encode(fig, format=format, dpi=dpi, as_data_uri=True)
 
 
 def close_figure(fig) -> None:

--- a/hvantk/algorithms/enrichex/__init__.py
+++ b/hvantk/algorithms/enrichex/__init__.py
@@ -79,8 +79,8 @@ from hvantk.core.utils.gene_sets import (
     load_gene_sets_from_dict,
     load_marker_genes,
 )
+from hvantk.algorithms.visualization.base import encode_figure_to_base64
 from hvantk.algorithms.enrichex.plot import (
-    encode_figure_to_base64,
     plot_burden_forest,
     plot_burden_volcano,
     plot_celltype_burden_heatmap,
@@ -93,7 +93,11 @@ from hvantk.algorithms.enrichex.overlap import (
     compute_overlap_enrichment,
     compute_overlap_enrichment_pandas,
 )
-from hvantk.algorithms.enrichex.pipeline import BurdenConfig, BurdenPipeline, BurdenRunResult
+from hvantk.algorithms.enrichex.pipeline import (
+    BurdenConfig,
+    BurdenPipeline,
+    BurdenRunResult,
+)
 from hvantk.algorithms.enrichex.report import generate_report
 from hvantk.algorithms.enrichex.simulation import check_type_i_error
 

--- a/hvantk/algorithms/enrichex/plot.py
+++ b/hvantk/algorithms/enrichex/plot.py
@@ -9,17 +9,16 @@ required beyond the existing hvantk[viz] extra.
 
 from __future__ import annotations
 
-import base64
-import io
 import logging
 from itertools import cycle
-from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import numpy as np
 import pandas as pd
+
+from hvantk.algorithms.visualization.base import save_figure_to_path
 
 try:  # seaborn is optional but provides nicer defaults when present
     import seaborn as sns
@@ -232,7 +231,7 @@ def plot_enrichment_dotplot(
     _add_size_legend(ax, size_by=size_by, values=df[size_by], size_range=size_range)
     fig.tight_layout()
 
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -424,7 +423,7 @@ def plot_burden_forest(
         ax.add_artist(legend)
 
     fig.tight_layout()
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -560,7 +559,7 @@ def plot_enrichment_barplot(
     ax.grid(axis="x" if orientation == "horizontal" else "y", linestyle="--", alpha=0.4)
     fig.tight_layout()
 
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -611,7 +610,7 @@ def plot_celltype_burden_heatmap(
             message="No data available",
             figsize=figsize,
         )
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
         return fig
 
     required_cols = {"gene_set_name", "variant_class", "collection"}
@@ -632,7 +631,7 @@ def plot_celltype_burden_heatmap(
             message="No data after filtering by variant classes",
             figsize=figsize,
         )
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
         return fig
 
     # Sort by collection then gene_set_name for grouping
@@ -726,7 +725,7 @@ def plot_celltype_burden_heatmap(
     ax.set_title(title or "Cell-Type Burden Heatmap")
     fig.tight_layout()
 
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -779,7 +778,7 @@ def plot_burden_volcano(
             message="No data available",
             figsize=figsize,
         )
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
         return fig
 
     p_col = _resolve_pvalue_column(results_df)
@@ -884,7 +883,7 @@ def plot_burden_volcano(
     ax.set_title(title or "Burden Volcano Plot")
     fig.tight_layout()
 
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -937,7 +936,7 @@ def plot_celltype_forest(
             message="No data available",
             figsize=figsize,
         )
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
         return fig
 
     # Filter to the requested cell type
@@ -947,7 +946,7 @@ def plot_celltype_forest(
             message="Missing gene_set_name column",
             figsize=figsize,
         )
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
         return fig
 
     df = results_df[results_df["gene_set_name"] == cell_type].copy()
@@ -957,7 +956,7 @@ def plot_celltype_forest(
             message=f"No data for cell type '{cell_type}'",
             figsize=figsize,
         )
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
         return fig
 
     required_cols = {"variant_class", effect_col, "ci_lower", "ci_upper"}
@@ -1038,22 +1037,8 @@ def plot_celltype_forest(
     ax.legend(handles=handles, loc="best", frameon=False)
 
     fig.tight_layout()
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
-
-
-def encode_figure_to_base64(
-    fig: plt.Figure,
-    format: str = "png",
-    dpi: int = 200,
-) -> str:
-    """
-    Convert a matplotlib figure to a base64-encoded image string.
-    """
-    buffer = io.BytesIO()
-    fig.savefig(buffer, format=format, dpi=dpi, bbox_inches="tight")
-    buffer.seek(0)
-    return base64.b64encode(buffer.read()).decode("utf-8")
 
 
 def _empty_figure(
@@ -1083,7 +1068,7 @@ def _empty_figure(
         spine.set_visible(False)
     fig.tight_layout()
     if output_path is not None:
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -1202,15 +1187,6 @@ def _add_size_legend(
         bbox_to_anchor=(1.02, 0.2),
         frameon=False,
     )
-
-
-def _save_figure(fig: plt.Figure, output_path: str, format: str, dpi: int) -> None:
-    path = Path(output_path)
-    if path.suffix.lower() != f".{format.lower()}":
-        path = path.with_suffix(f".{format}")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(path, dpi=dpi, bbox_inches="tight", format=format)
-    logger.info("Saved figure to %s", path)
 
 
 def _categorical_palette(categories: Iterable[str]) -> Dict[str, str]:

--- a/hvantk/algorithms/enrichex/report.py
+++ b/hvantk/algorithms/enrichex/report.py
@@ -19,8 +19,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from hvantk.core.utils.gene_sets import GeneSetCollection
+from hvantk.algorithms.visualization.base import encode_figure_to_base64
 from hvantk.algorithms.enrichex.plot import (
-    encode_figure_to_base64,
     plot_burden_forest,
     plot_enrichment_dotplot,
 )

--- a/hvantk/algorithms/ptm/__init__.py
+++ b/hvantk/algorithms/ptm/__init__.py
@@ -44,17 +44,26 @@ _LAZY_MODULES = {
     "CodonMapping": ("hvantk.algorithms.ptm.mapper", "CodonMapping"),
     "GTFData": ("hvantk.algorithms.ptm.mapper", "GTFData"),
     "parse_ensembl_gtf": ("hvantk.algorithms.ptm.mapper", "parse_ensembl_gtf"),
-    "map_residue_to_genomic": ("hvantk.algorithms.ptm.mapper", "map_residue_to_genomic"),
+    "map_residue_to_genomic": (
+        "hvantk.algorithms.ptm.mapper",
+        "map_residue_to_genomic",
+    ),
     "map_protein_sites": ("hvantk.algorithms.ptm.mapper", "map_protein_sites"),
     "resolve_transcript": ("hvantk.algorithms.ptm.mapper", "resolve_transcript"),
     # pipeline
     "PTMBuildConfig": ("hvantk.algorithms.ptm.pipeline", "PTMBuildConfig"),
     "PTMBuildResult": ("hvantk.algorithms.ptm.pipeline", "PTMBuildResult"),
-    "ptm_build_pipeline_core": ("hvantk.algorithms.ptm.pipeline", "ptm_build_pipeline_core"),
+    "ptm_build_pipeline_core": (
+        "hvantk.algorithms.ptm.pipeline",
+        "ptm_build_pipeline_core",
+    ),
     "map_ptm_sites": ("hvantk.algorithms.ptm.pipeline", "map_ptm_sites"),
     "download_ensembl_gtf": ("hvantk.algorithms.ptm.pipeline", "download_ensembl_gtf"),
     # annotate (requires Hail)
-    "annotate_variants_with_ptm": ("hvantk.algorithms.ptm.annotate", "annotate_variants_with_ptm"),
+    "annotate_variants_with_ptm": (
+        "hvantk.algorithms.ptm.annotate",
+        "annotate_variants_with_ptm",
+    ),
     # analysis (requires Hail)
     "PTMLandscapeResult": ("hvantk.algorithms.ptm.analysis", "PTMLandscapeResult"),
     "PTMPopulationResult": ("hvantk.algorithms.ptm.analysis", "PTMPopulationResult"),
@@ -71,10 +80,19 @@ _LAZY_MODULES = {
     ),
     # plot
     "plot_landscape_summary": ("hvantk.algorithms.ptm.plot", "plot_landscape_summary"),
-    "plot_overlap_by_category": ("hvantk.algorithms.ptm.plot", "plot_overlap_by_category"),
-    "plot_distance_distribution": ("hvantk.algorithms.ptm.plot", "plot_distance_distribution"),
+    "plot_overlap_by_category": (
+        "hvantk.algorithms.ptm.plot",
+        "plot_overlap_by_category",
+    ),
+    "plot_distance_distribution": (
+        "hvantk.algorithms.ptm.plot",
+        "plot_distance_distribution",
+    ),
     "plot_population_af": ("hvantk.algorithms.ptm.plot", "plot_population_af"),
-    "encode_figure_to_base64": ("hvantk.algorithms.ptm.plot", "encode_figure_to_base64"),
+    "encode_figure_to_base64": (
+        "hvantk.algorithms.visualization.base",
+        "encode_figure_to_base64",
+    ),
     # report
     "generate_report": ("hvantk.algorithms.ptm.report", "generate_report"),
     # Phase-2 atlas facade
@@ -95,7 +113,10 @@ _LAZY_MODULES = {
         "run_binned_interaction_lmm",
     ),
     # Phase-2 report writer
-    "generate_phase2_report": ("hvantk.algorithms.ptm.report", "generate_phase2_report"),
+    "generate_phase2_report": (
+        "hvantk.algorithms.ptm.report",
+        "generate_phase2_report",
+    ),
 }
 
 
@@ -107,6 +128,7 @@ def __getattr__(name: str):
         globals()[name] = val  # cache for subsequent access
         return val
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Annotation

--- a/hvantk/algorithms/ptm/plot.py
+++ b/hvantk/algorithms/ptm/plot.py
@@ -14,14 +14,13 @@ Plot functions:
 
 from __future__ import annotations
 
-import base64
-import io
 import logging
-from pathlib import Path
 from typing import Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+from hvantk.algorithms.visualization.base import save_figure_to_path
 
 try:
     import seaborn as sns
@@ -195,7 +194,7 @@ def plot_landscape_summary(
         title or "PTM-Variant Landscape Summary", fontsize=13, fontweight="bold"
     )
     fig.tight_layout()
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -244,7 +243,7 @@ def plot_overlap_by_category(
     ax.set_title(title or "P/LP Variants by PTM Category")
     ax.grid(axis="x", linestyle="--", alpha=0.4)
     fig.tight_layout()
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -296,7 +295,7 @@ def plot_distance_distribution(
     ax.set_xticks(distances)
     ax.grid(axis="y", linestyle="--", alpha=0.4)
     fig.tight_layout()
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -435,7 +434,7 @@ def plot_population_af(
         fontweight="bold",
     )
     fig.tight_layout()
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
@@ -522,9 +521,9 @@ def plot_source_overlap(
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize)
 
     # Color scheme
-    c_up = "#2196F3"       # blue - UniProt
-    c_both = "#9C27B0"     # purple - overlap
-    c_pa = "#FF9800"       # orange - PeptideAtlas
+    c_up = "#2196F3"  # blue - UniProt
+    c_both = "#9C27B0"  # purple - overlap
+    c_pa = "#FF9800"  # orange - PeptideAtlas
 
     # --- Left panel: site counts by category ---
     categories = ["UniProt\nonly", "Both", "PeptideAtlas\nonly"]
@@ -577,8 +576,16 @@ def plot_source_overlap(
             median.set_color("black")
             median.set_linewidth(2)
     else:
-        ax2.text(0.5, 0.5, "No PeptideAtlas\ndata", ha="center", va="center",
-                 transform=ax2.transAxes, fontsize=12, color="#888888")
+        ax2.text(
+            0.5,
+            0.5,
+            "No PeptideAtlas\ndata",
+            ha="center",
+            va="center",
+            transform=ax2.transAxes,
+            fontsize=12,
+            color="#888888",
+        )
 
     ax2.set_ylabel("log$_{10}$(n_observations)")
     ax2.set_title("PeptideAtlas Evidence")
@@ -607,34 +614,13 @@ def plot_source_overlap(
         fontweight="bold",
     )
     fig.tight_layout()
-    _save_figure(fig, output_path, format=format, dpi=dpi)
+    save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig
 
 
 # ---------------------------------------------------------------------------
 # Utilities
 # ---------------------------------------------------------------------------
-
-
-def encode_figure_to_base64(
-    fig: plt.Figure,
-    format: str = "png",
-    dpi: int = 200,
-) -> str:
-    """Convert a matplotlib figure to a base64-encoded image string."""
-    buffer = io.BytesIO()
-    fig.savefig(buffer, format=format, dpi=dpi, bbox_inches="tight")
-    buffer.seek(0)
-    return base64.b64encode(buffer.read()).decode("utf-8")
-
-
-def _save_figure(fig: plt.Figure, output_path: str, format: str, dpi: int) -> None:
-    path = Path(output_path)
-    if path.suffix.lower() != f".{format.lower()}":
-        path = path.with_suffix(f".{format}")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(path, dpi=dpi, bbox_inches="tight", format=format)
-    logger.info("Saved figure to %s", path)
 
 
 def _empty_figure(
@@ -664,5 +650,5 @@ def _empty_figure(
         spine.set_visible(False)
     fig.tight_layout()
     if output_path is not None:
-        _save_figure(fig, output_path, format=format, dpi=dpi)
+        save_figure_to_path(fig, output_path, format=format, dpi=dpi)
     return fig

--- a/hvantk/algorithms/ptm/report.py
+++ b/hvantk/algorithms/ptm/report.py
@@ -16,8 +16,8 @@ from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING
 import matplotlib.pyplot as plt
 
 from hvantk.algorithms.ptm.analysis import PTMLandscapeResult, PTMPopulationResult
+from hvantk.algorithms.visualization.base import encode_figure_to_base64
 from hvantk.algorithms.ptm.plot import (
-    encode_figure_to_base64,
     plot_distance_distribution,
     plot_landscape_summary,
     plot_overlap_by_category,
@@ -698,8 +698,7 @@ def _build_phase2_binned_section(results: Sequence["BinnedLMMResult"]) -> str:
 
     if not body_rows:
         body_rows = (
-            f"<tr><td colspan='{3 + 3 * len(all_bins) + 2}'>"
-            "(no results)</td></tr>"
+            f"<tr><td colspan='{3 + 3 * len(all_bins) + 2}'>" "(no results)</td></tr>"
         )
 
     return (

--- a/hvantk/algorithms/qtlcascade/plot.py
+++ b/hvantk/algorithms/qtlcascade/plot.py
@@ -5,10 +5,7 @@ All functions return ``matplotlib.figure.Figure`` objects and optionally
 save to disk.  Plot styling follows the enrichex/psroc conventions.
 """
 
-import io
-import base64
 import logging
-from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -42,21 +39,19 @@ def _require_matplotlib():
 
 def _save_figure(fig, output_path: Optional[str], dpi: int = 300):
     """Save figure to disk if *output_path* is provided."""
-    if output_path:
-        p = Path(output_path)
-        p.parent.mkdir(parents=True, exist_ok=True)
-        fig.savefig(str(p), dpi=dpi, bbox_inches="tight")
-        logger.info("Saved plot: %s", p)
+    # Imported lazily so importing this module stays matplotlib-optional.
+    from hvantk.algorithms.visualization.base import save_figure_to_path
+
+    save_figure_to_path(fig, output_path, dpi=dpi)
 
 
 def encode_figure_to_base64(fig) -> str:
     """Encode a matplotlib figure as a base64 PNG for HTML embedding."""
-    buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=300, bbox_inches="tight")
-    buf.seek(0)
-    encoded = base64.b64encode(buf.read()).decode("utf-8")
-    buf.close()
-    return encoded
+    from hvantk.algorithms.visualization.base import (
+        encode_figure_to_base64 as _encode,
+    )
+
+    return _encode(fig, dpi=300)
 
 
 # ---------------------------------------------------------------------------

--- a/hvantk/algorithms/qtlcascade/plot.py
+++ b/hvantk/algorithms/qtlcascade/plot.py
@@ -39,6 +39,8 @@ def _require_matplotlib():
 
 def _save_figure(fig, output_path: Optional[str], dpi: int = 300):
     """Save figure to disk if *output_path* is provided."""
+    if not output_path:
+        return
     # Imported lazily so importing this module stays matplotlib-optional.
     from hvantk.algorithms.visualization.base import save_figure_to_path
 

--- a/hvantk/algorithms/visualization/__init__.py
+++ b/hvantk/algorithms/visualization/__init__.py
@@ -7,6 +7,8 @@ This module provides functions and classes for visualizing multiomics data.
 from .base import (
     set_default_style,
     save_figure,
+    save_figure_to_path,
+    encode_figure_to_base64,
     get_colors,
     add_figure_labels,
 )
@@ -127,6 +129,8 @@ def plot_interactive_sample_scatter(*args, **kwargs):
 __all__ = [
     "set_default_style",
     "save_figure",
+    "save_figure_to_path",
+    "encode_figure_to_base64",
     "get_colors",
     "add_figure_labels",
     "visualize_expression_distribution",

--- a/hvantk/algorithms/visualization/base.py
+++ b/hvantk/algorithms/visualization/base.py
@@ -248,7 +248,7 @@ def add_figure_labels(
         )
 
 
-_FORMAT_MIME_TYPES: dict = {
+_FORMAT_MIME_TYPES: dict[str, str] = {
     "png": "image/png",
     "jpg": "image/jpeg",
     "jpeg": "image/jpeg",

--- a/hvantk/algorithms/visualization/base.py
+++ b/hvantk/algorithms/visualization/base.py
@@ -5,10 +5,17 @@ This module provides foundational functions for visualization settings,
 styling, and common operations used across different visualization types.
 """
 
+import base64
+import io
+import logging
 import os
+from pathlib import Path
+
 import matplotlib.pyplot as plt
 import matplotlib as mpl
-from typing import Optional, Union, Tuple, Dict, Any, List
+from typing import Optional, Union, Tuple, Dict, List
+
+logger = logging.getLogger(__name__)
 
 
 def set_default_style(
@@ -239,3 +246,76 @@ def add_figure_labels(
             fontweight=fontweight,
             **kwargs,
         )
+
+
+def encode_figure_to_base64(
+    fig: plt.Figure,
+    format: str = "png",
+    dpi: int = 200,
+    *,
+    as_data_uri: bool = False,
+) -> str:
+    """Convert a matplotlib figure to a base64-encoded image string.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to encode.
+    format : str
+        Image format ('png', 'svg', etc.).
+    dpi : int
+        Resolution for raster formats.
+    as_data_uri : bool, keyword-only
+        When True, wrap the payload as ``data:image/{format};base64,{payload}``
+        for direct embedding in an HTML ``<img src=...>`` attribute. When False
+        (default), return the raw base64 payload.
+
+    Returns
+    -------
+    str
+        The base64 payload, optionally wrapped as a data URI.
+    """
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format=format, dpi=dpi, bbox_inches="tight")
+    buffer.seek(0)
+    payload = base64.b64encode(buffer.read()).decode("utf-8")
+    buffer.close()
+    if as_data_uri:
+        return f"data:image/{format};base64,{payload}"
+    return payload
+
+
+def save_figure_to_path(
+    fig: plt.Figure,
+    output_path: Optional[str],
+    format: Optional[str] = None,
+    dpi: int = 300,
+) -> None:
+    """Save a figure to a single output path.
+
+    No-op when ``output_path`` is falsy. When ``format`` is provided, the path's
+    suffix is normalized to match it and the format is passed explicitly to
+    :meth:`savefig`; otherwise the path's own suffix determines the format.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to save.
+    output_path : str or None
+        Destination path. If falsy, nothing is written.
+    format : str, optional
+        Explicit export format. If given, the path suffix is normalized to it.
+    dpi : int
+        Resolution in dots per inch.
+    """
+    if not output_path:
+        return
+    path = Path(output_path)
+    if format is not None and path.suffix.lower() != f".{format.lower()}":
+        path = path.with_suffix(f".{format}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if format is not None:
+        fig.savefig(path, dpi=dpi, bbox_inches="tight", format=format)
+    else:
+        fig.savefig(str(path), dpi=dpi, bbox_inches="tight")
+    logger.info("Saved figure to %s", path)

--- a/hvantk/algorithms/visualization/base.py
+++ b/hvantk/algorithms/visualization/base.py
@@ -248,6 +248,18 @@ def add_figure_labels(
         )
 
 
+_FORMAT_MIME_TYPES: dict = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "svg": "image/svg+xml",
+    "pdf": "application/pdf",
+    "tiff": "image/tiff",
+    "tif": "image/tiff",
+    "webp": "image/webp",
+}
+
+
 def encode_figure_to_base64(
     fig: plt.Figure,
     format: str = "png",
@@ -262,7 +274,8 @@ def encode_figure_to_base64(
     fig : matplotlib.figure.Figure
         The figure to encode.
     format : str
-        Image format ('png', 'svg', etc.).
+        Image format ('png', 'svg', etc.). Leading dots are stripped and the
+        value is lowercased.
     dpi : int
         Resolution for raster formats.
     as_data_uri : bool, keyword-only
@@ -275,13 +288,15 @@ def encode_figure_to_base64(
     str
         The base64 payload, optionally wrapped as a data URI.
     """
+    format = format.lstrip(".").lower()
     buffer = io.BytesIO()
     fig.savefig(buffer, format=format, dpi=dpi, bbox_inches="tight")
     buffer.seek(0)
     payload = base64.b64encode(buffer.read()).decode("utf-8")
     buffer.close()
     if as_data_uri:
-        return f"data:image/{format};base64,{payload}"
+        mime = _FORMAT_MIME_TYPES.get(format, f"image/{format}")
+        return f"data:{mime};base64,{payload}"
     return payload
 
 
@@ -310,8 +325,10 @@ def save_figure_to_path(
     """
     if not output_path:
         return
+    if format is not None:
+        format = format.lstrip(".").lower()
     path = Path(output_path)
-    if format is not None and path.suffix.lower() != f".{format.lower()}":
+    if format is not None and path.suffix.lower() != f".{format}":
         path = path.with_suffix(f".{format}")
     path.parent.mkdir(parents=True, exist_ok=True)
     if format is not None:

--- a/hvantk/tests/enrichex/test_plot.py
+++ b/hvantk/tests/enrichex/test_plot.py
@@ -7,8 +7,8 @@ import pytest
 
 matplotlib.use("Agg")
 
+from hvantk.algorithms.visualization.base import encode_figure_to_base64
 from hvantk.algorithms.enrichex.plot import (
-    encode_figure_to_base64,
     plot_burden_forest,
     plot_burden_volcano,
     plot_celltype_burden_heatmap,


### PR DESCRIPTION
## PR-4b — complete the plotting-helper consolidation

Moves the duplicated `encode_figure_to_base64` / `_save_figure` helpers into a single canonical home — `algorithms/visualization/base.py` — and migrates **all** consumers in one pass (the partial pass was deliberately deferred because it worsened clarity).

### What `base.py` provides now
- `encode_figure_to_base64(fig, format="png", dpi=200, *, as_data_uri=False)` — raw base64 by default; data-URI (`data:image/{format};base64,…`) when `as_data_uri=True`.
- `save_figure_to_path(fig, output_path, format=None, dpi=300)` — no-op on a falsy path; normalizes the suffix when `format` is given, else uses the path's own suffix. Covers both prior `_save_figure` signatures.

### Per-consumer migration
| Module | Prior behavior | Migration |
|--------|----------------|-----------|
| enrichex, ptm | `dpi=200`, raw base64 (identical to canonical) | source `encode_figure_to_base64` directly from `base`; `_save_figure` → `save_figure_to_path`; `__init__` / `report.py` / tests import encode from `base` |
| ancestry | `dpi=150`, returns **data-URI** | thin wrapper delegating to `base(..., as_data_uri=True)`; lazy import keeps the module matplotlib-optional |
| qtlcascade | `dpi=300`, `(fig)`-only signature | thin wrapper delegating to `base(..., dpi=300)`; lazy import keeps it matplotlib-optional |

The two divergent consumers keep thin wrappers (not direct re-imports) precisely because their defaults differ; the wrappers preserve each module's exact public behavior and import-time optionality.

### Verification (behavior-preserving only)
- Confirmed raw vs data-URI outputs, dpi passthrough, suffix normalization, and no-op-on-falsy all match the prior per-module helpers.
- `pytest hvantk/tests/enrichex/test_plot.py hvantk/tests/ancestry/test_plot.py` → **41 passed**.
- Import smoke + re-export identity (`enrichex.encode_figure_to_base64 is base.encode_figure_to_base64`; ptm lazy re-export resolves to `base`).
- flake8 (project selection `E9,F63,F7,F82`) clean; `black`-formatted. Removed now-unused `io` / `base64` / `Path` imports.