### PR TITLE
refactor: move report-rendering/reconstruction logic out of the CLI layer (PR-6)

### DIFF
--- a/hvantk/algorithms/hgc/qc_report.py
+++ b/hvantk/algorithms/hgc/qc_report.py
@@ -1,0 +1,67 @@
+"""Rendering helpers for HGC quality-control summary reports.
+
+Pure presentation logic kept out of the CLI layer so it can be reused from the
+Python API and unit-tested in isolation. The input is the ``summary_data`` dict
+assembled by ``hvantk hgc qc-summary``:
+
+    {
+        "<qc_type>": {
+            "file": str,
+            "n_samples" | "n_variants": int,
+            "summary_stats": {metric: {stat: value, ...}, ...},
+            "columns": list[str],
+        },
+        ...
+    }
+"""
+
+from typing import Dict
+
+# Order of describe()-style statistics rendered as Markdown table columns.
+_SUMMARY_STAT_COLUMNS = ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
+
+
+def render_qc_summary_markdown(summary_data: Dict[str, dict]) -> str:
+    """Render a QC summary dict into a Markdown report string.
+
+    Parameters
+    ----------
+    summary_data : dict
+        Mapping of ``qc_type`` to a per-type summary dict (see module docstring).
+
+    Returns
+    -------
+    str
+        The Markdown report.
+    """
+    md_content = "# Quality Control Summary Report\n\n"
+
+    for qc_type, data in summary_data.items():
+        md_content += f"## {qc_type.replace('_', ' ').title()}\n\n"
+        md_content += f"- **File**: {data['file']}\n"
+        md_content += (
+            f"- **Count**: {data.get('n_samples', data.get('n_variants', 0)):,}\n"
+        )
+        md_content += f"- **Metrics**: {', '.join(data['columns'])}\n\n"
+
+        if data["summary_stats"]:
+            md_content += "### Summary Statistics\n\n"
+            md_content += (
+                "| Metric | Count | Mean | Std | Min | 25% | 50% | 75% | Max |\n"
+            )
+            md_content += "|--------|--------|--------|--------|--------|--------|--------|--------|--------|\n"
+
+            for metric, stats in data["summary_stats"].items():
+                if isinstance(stats, dict):
+                    row = f"| {metric} |"
+                    for stat in _SUMMARY_STAT_COLUMNS:
+                        value = stats.get(stat, "N/A")
+                        if isinstance(value, (int, float)) and stat != "count":
+                            value = (
+                                f"{value:.3f}" if abs(value) < 1000 else f"{value:.2e}"
+                            )
+                        row += f" {value} |"
+                    md_content += row + "\n"
+            md_content += "\n"
+
+    return md_content

--- a/hvantk/algorithms/ptm/analysis.py
+++ b/hvantk/algorithms/ptm/analysis.py
@@ -56,6 +56,55 @@ class PTMLandscapeResult:
                 lines.append(f"    {cat}: {n:,}")
         return "\n".join(lines)
 
+    def to_dict(self) -> dict:
+        """Serialize to the nested JSON shape written as landscape_summary.json."""
+        return {
+            "n_variants": self.n_variants,
+            "n_pathogenic": self.n_pathogenic,
+            "n_benign": self.n_benign,
+            "ptm_site": {
+                "pathogenic": self.n_ptm_site_pathogenic,
+                "benign": self.n_ptm_site_benign,
+            },
+            "ptm_proximal": {
+                "pathogenic": self.n_ptm_proximal_pathogenic,
+                "benign": self.n_ptm_proximal_benign,
+            },
+            "enrichment": {
+                "odds_ratio": self.enrichment_odds_ratio,
+                "ci_low": self.enrichment_ci_low,
+                "ci_high": self.enrichment_ci_high,
+                "p_value": self.enrichment_p_value,
+            },
+            "overlap_by_category": self.overlap_by_category,
+            "category_enrichment": self.category_enrichment,
+            "distance_distribution": {
+                str(k): v for k, v in self.distance_distribution.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PTMLandscapeResult":
+        """Reconstruct from the nested JSON shape produced by :meth:`to_dict`."""
+        return cls(
+            n_variants=data.get("n_variants", 0),
+            n_pathogenic=data.get("n_pathogenic", 0),
+            n_benign=data.get("n_benign", 0),
+            n_ptm_site_pathogenic=data.get("ptm_site", {}).get("pathogenic", 0),
+            n_ptm_proximal_pathogenic=data.get("ptm_proximal", {}).get("pathogenic", 0),
+            n_ptm_site_benign=data.get("ptm_site", {}).get("benign", 0),
+            n_ptm_proximal_benign=data.get("ptm_proximal", {}).get("benign", 0),
+            enrichment_odds_ratio=data.get("enrichment", {}).get("odds_ratio", 0.0),
+            enrichment_ci_low=data.get("enrichment", {}).get("ci_low", 0.0),
+            enrichment_ci_high=data.get("enrichment", {}).get("ci_high", float("inf")),
+            enrichment_p_value=data.get("enrichment", {}).get("p_value", 1.0),
+            overlap_by_category=data.get("overlap_by_category", {}),
+            category_enrichment=data.get("category_enrichment", {}),
+            distance_distribution={
+                int(k): v for k, v in data.get("distance_distribution", {}).items()
+            },
+        )
+
 
 @dataclass
 class PTMPopulationResult:
@@ -95,6 +144,45 @@ class PTMPopulationResult:
         elif self.ccr_mean_non_ptm is not None:
             lines.append(f"  Mean CCR: non-PTM={self.ccr_mean_non_ptm:.1f}")
         return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        """Serialize to the nested JSON shape written as population_summary.json."""
+        return {
+            "n_variants": self.n_variants,
+            "n_ptm_site": self.n_ptm_site,
+            "n_ptm_proximal": self.n_ptm_proximal,
+            "n_non_ptm": self.n_non_ptm,
+            "mean_af": {
+                "ptm_site": self.mean_af_ptm_site,
+                "ptm_proximal": self.mean_af_ptm_proximal,
+                "non_ptm": self.mean_af_non_ptm,
+            },
+            "n_zero_af_ptm": self.n_zero_af_ptm,
+            "ptm_site_afs": self.ptm_site_afs,
+            "proximal_afs": self.proximal_afs,
+            "non_ptm_afs": self.non_ptm_afs,
+            "ccr_mean_ptm": self.ccr_mean_ptm,
+            "ccr_mean_non_ptm": self.ccr_mean_non_ptm,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PTMPopulationResult":
+        """Reconstruct from the nested JSON shape produced by :meth:`to_dict`."""
+        return cls(
+            n_variants=data.get("n_variants", 0),
+            n_ptm_site=data.get("n_ptm_site", 0),
+            n_ptm_proximal=data.get("n_ptm_proximal", 0),
+            n_non_ptm=data.get("n_non_ptm", 0),
+            mean_af_ptm_site=data.get("mean_af", {}).get("ptm_site", 0.0),
+            mean_af_ptm_proximal=data.get("mean_af", {}).get("ptm_proximal", 0.0),
+            mean_af_non_ptm=data.get("mean_af", {}).get("non_ptm", 0.0),
+            n_zero_af_ptm=data.get("n_zero_af_ptm", 0),
+            ptm_site_afs=data.get("ptm_site_afs", []),
+            proximal_afs=data.get("proximal_afs", []),
+            non_ptm_afs=data.get("non_ptm_afs", []),
+            ccr_mean_ptm=data.get("ccr_mean_ptm"),
+            ccr_mean_non_ptm=data.get("ccr_mean_non_ptm"),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -395,34 +483,7 @@ def ptm_landscape(
 
     # Write JSON summary
     with open(os.path.join(output_dir, "landscape_summary.json"), "w") as f:
-        json.dump(
-            {
-                "n_variants": result.n_variants,
-                "n_pathogenic": result.n_pathogenic,
-                "n_benign": result.n_benign,
-                "ptm_site": {
-                    "pathogenic": result.n_ptm_site_pathogenic,
-                    "benign": result.n_ptm_site_benign,
-                },
-                "ptm_proximal": {
-                    "pathogenic": result.n_ptm_proximal_pathogenic,
-                    "benign": result.n_ptm_proximal_benign,
-                },
-                "enrichment": {
-                    "odds_ratio": result.enrichment_odds_ratio,
-                    "ci_low": result.enrichment_ci_low,
-                    "ci_high": result.enrichment_ci_high,
-                    "p_value": result.enrichment_p_value,
-                },
-                "overlap_by_category": result.overlap_by_category,
-                "category_enrichment": result.category_enrichment,
-                "distance_distribution": {
-                    str(k): v for k, v in result.distance_distribution.items()
-                },
-            },
-            f,
-            indent=2,
-        )
+        json.dump(result.to_dict(), f, indent=2)
 
     logger.info(result.summary())
     return result
@@ -543,27 +604,7 @@ def ptm_population(
 
     # Write JSON summary
     with open(os.path.join(output_dir, "population_summary.json"), "w") as f:
-        json.dump(
-            {
-                "n_variants": result.n_variants,
-                "n_ptm_site": result.n_ptm_site,
-                "n_ptm_proximal": result.n_ptm_proximal,
-                "n_non_ptm": result.n_non_ptm,
-                "mean_af": {
-                    "ptm_site": result.mean_af_ptm_site,
-                    "ptm_proximal": result.mean_af_ptm_proximal,
-                    "non_ptm": result.mean_af_non_ptm,
-                },
-                "n_zero_af_ptm": result.n_zero_af_ptm,
-                "ptm_site_afs": result.ptm_site_afs,
-                "proximal_afs": result.proximal_afs,
-                "non_ptm_afs": result.non_ptm_afs,
-                "ccr_mean_ptm": result.ccr_mean_ptm,
-                "ccr_mean_non_ptm": result.ccr_mean_non_ptm,
-            },
-            f,
-            indent=2,
-        )
+        json.dump(result.to_dict(), f, indent=2)
 
     logger.info(result.summary())
     return result

--- a/hvantk/tools/hgc/qc_cli.py
+++ b/hvantk/tools/hgc/qc_cli.py
@@ -491,46 +491,9 @@ def qc_summary(ctx, qc_dir, sample_file, variant_file, output, format):
                     json.dump(summary_data, f, indent=2)
 
             elif format == "markdown":
-                # Generate markdown report
-                md_content = "# Quality Control Summary Report\n\n"
+                from hvantk.algorithms.hgc.qc_report import render_qc_summary_markdown
 
-                for qc_type, data in summary_data.items():
-                    md_content += f"## {qc_type.replace('_', ' ').title()}\n\n"
-                    md_content += f"- **File**: {data['file']}\n"
-                    md_content += f"- **Count**: {data.get('n_samples', data.get('n_variants', 0)):,}\n"
-                    md_content += f"- **Metrics**: {', '.join(data['columns'])}\n\n"
-
-                    if data["summary_stats"]:
-                        md_content += "### Summary Statistics\n\n"
-                        md_content += "| Metric | Count | Mean | Std | Min | 25% | 50% | 75% | Max |\n"
-                        md_content += "|--------|--------|--------|--------|--------|--------|--------|--------|--------|\n"
-
-                        for metric, stats in data["summary_stats"].items():
-                            if isinstance(stats, dict):
-                                row = f"| {metric} |"
-                                for stat in [
-                                    "count",
-                                    "mean",
-                                    "std",
-                                    "min",
-                                    "25%",
-                                    "50%",
-                                    "75%",
-                                    "max",
-                                ]:
-                                    value = stats.get(stat, "N/A")
-                                    if (
-                                        isinstance(value, (int, float))
-                                        and stat != "count"
-                                    ):
-                                        value = (
-                                            f"{value:.3f}"
-                                            if abs(value) < 1000
-                                            else f"{value:.2e}"
-                                        )
-                                    row += f" {value} |"
-                                md_content += row + "\n"
-                        md_content += "\n"
+                md_content = render_qc_summary_markdown(summary_data)
 
                 with open(output_path, "w") as f:
                     f.write(md_content)

--- a/hvantk/tools/ptm/ptm_cli.py
+++ b/hvantk/tools/ptm/ptm_cli.py
@@ -473,48 +473,13 @@ def ptm_report(ctx, output, landscape_json, population_json, title, description)
         if landscape_json:
             with open(landscape_json) as f:
                 data = json.load(f)
-            landscape_result = PTMLandscapeResult(
-                n_variants=data.get("n_variants", 0),
-                n_pathogenic=data.get("n_pathogenic", 0),
-                n_benign=data.get("n_benign", 0),
-                n_ptm_site_pathogenic=data.get("ptm_site", {}).get("pathogenic", 0),
-                n_ptm_proximal_pathogenic=data.get("ptm_proximal", {}).get(
-                    "pathogenic", 0
-                ),
-                n_ptm_site_benign=data.get("ptm_site", {}).get("benign", 0),
-                n_ptm_proximal_benign=data.get("ptm_proximal", {}).get("benign", 0),
-                enrichment_odds_ratio=data.get("enrichment", {}).get("odds_ratio", 0.0),
-                enrichment_ci_low=data.get("enrichment", {}).get("ci_low", 0.0),
-                enrichment_ci_high=data.get("enrichment", {}).get(
-                    "ci_high", float("inf")
-                ),
-                enrichment_p_value=data.get("enrichment", {}).get("p_value", 1.0),
-                overlap_by_category=data.get("overlap_by_category", {}),
-                category_enrichment=data.get("category_enrichment", {}),
-                distance_distribution={
-                    int(k): v for k, v in data.get("distance_distribution", {}).items()
-                },
-            )
+            landscape_result = PTMLandscapeResult.from_dict(data)
 
         population_result = None
         if population_json:
             with open(population_json) as f:
                 data = json.load(f)
-            population_result = PTMPopulationResult(
-                n_variants=data.get("n_variants", 0),
-                n_ptm_site=data.get("n_ptm_site", 0),
-                n_ptm_proximal=data.get("n_ptm_proximal", 0),
-                n_non_ptm=data.get("n_non_ptm", 0),
-                mean_af_ptm_site=data.get("mean_af", {}).get("ptm_site", 0.0),
-                mean_af_ptm_proximal=data.get("mean_af", {}).get("ptm_proximal", 0.0),
-                mean_af_non_ptm=data.get("mean_af", {}).get("non_ptm", 0.0),
-                n_zero_af_ptm=data.get("n_zero_af_ptm", 0),
-                ptm_site_afs=data.get("ptm_site_afs", []),
-                proximal_afs=data.get("proximal_afs", []),
-                non_ptm_afs=data.get("non_ptm_afs", []),
-                ccr_mean_ptm=data.get("ccr_mean_ptm"),
-                ccr_mean_non_ptm=data.get("ccr_mean_non_ptm"),
-            )
+            population_result = PTMPopulationResult.from_dict(data)
 
         generate_report(
             output_path=output,


### PR DESCRIPTION
## PR-6 — move business logic out of the CLI layer into `algorithms/`

Two behavior-preserving extractions, both moving logic from `tools/` (CLI) into `algorithms/`:

### 1. `hgc qc-summary` Markdown rendering
Extracted the Markdown report assembly out of the `qc_summary` command body into a new pure function:
`hvantk/algorithms/hgc/qc_report.py::render_qc_summary_markdown(summary_data) -> str`.
The CLI now calls it and writes the returned string. Output verified **byte-identical** to the prior inline logic (across stats-present / empty-stats / big-value `:.2e` / small-value `:.3f` / missing-stat `N/A` / non-dict-entry cases).

### 2. PTM result (de)serialization
Added a symmetric `to_dict()` / `from_dict()` pair to `PTMLandscapeResult` and `PTMPopulationResult` in `hvantk/algorithms/ptm/analysis.py`:
- `ptm_cli`'s manual ~45-line field-by-field reconstruction is replaced by `PTM*Result.from_dict(data)`.
- `analysis.py`'s two `json.dump(...)` write-blocks now use `result.to_dict()`, so the nested JSON schema lives in **one place** instead of being duplicated between the writer and the CLI reader.
- Round-trip (`from_dict(to_dict(x)) == x`, incl. `distance_distribution` int↔str keys) and exact JSON-shape equivalence with the prior inline serialization verified.

### Deferred (intentionally not in this PR)
- `tools/ancestry/` `_is_cloud_uri` hoist — an intra-CLI tidy, not a layer move; low value.
- `genesets_cli` error-exit standardization — would change observable exit/output semantics, so it is **not** behavior-preserving and is out of scope for these refactor PRs.

### Verification
- `flake8` (project selection) clean; my edited regions are `black`-compliant (no unrelated whole-file reformatting churn).
- 28 targeted tests pass: `hvantk/tests/hgc/test_cli_qc.py` (16) + `hvantk/tests/test_ptm.py` (12). Import smoke OK.