### PR TITLE
perf: fuse repeated Hail actions into single aggregations (PR-8)

### DIFF
--- a/hvantk/algorithms/enrichex/burden.py
+++ b/hvantk/algorithms/enrichex/burden.py
@@ -651,11 +651,20 @@ def logistic_burden_test(
         ci_upper=hl.exp(result.beta + 1.96 * result.standard_error),
     )
 
-    n_tested = result.count()
+    # Fuse the three result counts into a single Hail action (one Spark job).
+    counts = result.aggregate(
+        hl.struct(
+            n_tested=hl.agg.count(),
+            n_nan_p=hl.agg.count_where(hl.is_nan(result.p_value)),
+            n_nominal=hl.agg.count_where(result.p_value < 0.05),
+        )
+    )
+
+    n_tested = counts.n_tested
     logger.info("Regression complete: %d gene sets tested", n_tested)
 
     # Check for convergence issues (NaN p-values)
-    n_nan_p = result.filter(hl.is_nan(result.p_value)).count()
+    n_nan_p = counts.n_nan_p
     if n_nan_p > 0:
         logger.warning(
             "Logistic regression produced NaN p-values for %d/%d gene sets "
@@ -665,7 +674,7 @@ def logistic_burden_test(
         )
 
     # Report nominally significant results
-    n_nominal = result.filter(result.p_value < 0.05).count()
+    n_nominal = counts.n_nominal
     logger.info("  %d gene sets nominally significant (p < 0.05)", n_nominal)
 
     return result
@@ -744,11 +753,20 @@ def linear_burden_test(
         pass_through=pass_through or [],
     )
 
-    n_tested = result.count()
+    # Fuse the three result counts into a single Hail action (one Spark job).
+    counts = result.aggregate(
+        hl.struct(
+            n_tested=hl.agg.count(),
+            n_nan_p=hl.agg.count_where(hl.is_nan(result.p_value)),
+            n_nominal=hl.agg.count_where(result.p_value < 0.05),
+        )
+    )
+
+    n_tested = counts.n_tested
     logger.info("Regression complete: %d gene sets tested", n_tested)
 
     # Check for convergence issues (NaN p-values)
-    n_nan_p = result.filter(hl.is_nan(result.p_value)).count()
+    n_nan_p = counts.n_nan_p
     if n_nan_p > 0:
         logger.warning(
             "Linear regression produced NaN p-values for %d/%d gene sets "
@@ -758,7 +776,7 @@ def linear_burden_test(
         )
 
     # Report nominally significant results
-    n_nominal = result.filter(result.p_value < 0.05).count()
+    n_nominal = counts.n_nominal
     logger.info("  %d gene sets nominally significant (p < 0.05)", n_nominal)
 
     return result

--- a/hvantk/algorithms/psroc/pipeline.py
+++ b/hvantk/algorithms/psroc/pipeline.py
@@ -1366,14 +1366,24 @@ class PSROCPipeline:
         metrics = self.state.outputs.get("roc_metrics", {})
         missingness = self.state.outputs.get("missingness", {})
 
+        # Fuse the four label counts into a single Hail action (one Spark job).
+        label_counts = ht.aggregate(
+            hl.struct(
+                n_pathogenic=hl.agg.count_where(ht.label == "Pathogenic"),
+                n_benign=hl.agg.count_where(ht.label == "Benign"),
+                n_excluded=hl.agg.count_where(ht.label == "Uncertain/Conflicting"),
+                n_total=hl.agg.count(),
+            )
+        )
+
         result = PSROCResult(
             annotated_ht_path=self.paths["annotated_ht"],
             metrics=metrics,
             missingness=missingness,
-            n_pathogenic=ht.filter(ht.label == "Pathogenic").count(),
-            n_benign=ht.filter(ht.label == "Benign").count(),
-            n_excluded=ht.filter(ht.label == "Uncertain/Conflicting").count(),
-            n_total=ht.count(),
+            n_pathogenic=label_counts.n_pathogenic,
+            n_benign=label_counts.n_benign,
+            n_excluded=label_counts.n_excluded,
+            n_total=label_counts.n_total,
             n_out_of_scope=self._n_out_of_scope,
             n_genes=self._n_genes,
             scores_included=[

--- a/hvantk/algorithms/visualization/qc_report.py
+++ b/hvantk/algorithms/visualization/qc_report.py
@@ -29,9 +29,17 @@ from typing import List, Union, Optional
 import pandas as pd
 import matplotlib
 
-matplotlib.use(
-    "Agg"
-)  # Use non-interactive backend - must be set before importing pyplot
+# Select a non-interactive backend for headless rendering, but only if one is
+# not already active — avoids clobbering an interactive/inline backend the host
+# process (e.g. a notebook) has deliberately set. Matches constraint_plots.py.
+if matplotlib.get_backend().lower() not in {
+    "agg",
+    "module://matplotlib_inline.backend_inline",
+}:
+    try:
+        matplotlib.use("Agg")
+    except Exception:  # pragma: no cover - backend already locked in
+        pass
 import matplotlib.pyplot as plt
 
 from .qc_plots import (

--- a/hvantk/core/streamers/gene_disease_table.py
+++ b/hvantk/core/streamers/gene_disease_table.py
@@ -569,28 +569,45 @@ class GeneDiseaseTableStreamer:
         if ht is None:
             raise ValueError(f"{self.source_name} table not loaded.")
 
-        total_associations = ht.count()
-        unique_genes = len(ht.aggregate(hl.agg.collect_as_set(ht.gene_symbol)))
-        unique_diseases = len(ht.aggregate(hl.agg.collect_as_set(ht.disease_label)))
-        classification_counts = ht.aggregate(hl.agg.counter(ht.classification))
-        moi_counts = ht.aggregate(hl.agg.counter(ht.mode_of_inheritance))
-
         grouping_field = self._grouping_field
-        grouping_counts = ht.aggregate(hl.agg.counter(ht[grouping_field]))
+        date_field = self._date_field
 
-        genes_per_classification = ht.aggregate(
-            hl.agg.group_by(ht.classification, hl.agg.collect_as_set(ht.gene_symbol))
-        )
+        # Fuse all row-wise aggregations into a single Hail action (one Spark
+        # job) instead of ~8 separate ``ht.count()`` / ``ht.aggregate(...)`` calls.
+        agg_exprs = {
+            "total_associations": hl.agg.count(),
+            "all_genes": hl.agg.collect_as_set(ht.gene_symbol),
+            "all_diseases": hl.agg.collect_as_set(ht.disease_label),
+            "classification_counts": hl.agg.counter(ht.classification),
+            "moi_counts": hl.agg.counter(ht.mode_of_inheritance),
+            "grouping_counts": hl.agg.counter(ht[grouping_field]),
+            "genes_by_classification": hl.agg.group_by(
+                ht.classification, hl.agg.collect_as_set(ht.gene_symbol)
+            ),
+            "diseases_by_classification": hl.agg.group_by(
+                ht.classification, hl.agg.collect_as_set(ht.disease_label)
+            ),
+        }
+        if date_field:
+            agg_exprs["last_update"] = hl.agg.max(ht[date_field])
+        agg = ht.aggregate(hl.struct(**agg_exprs))
+
+        total_associations = agg.total_associations
+        unique_genes = len(agg.all_genes)
+        unique_diseases = len(agg.all_diseases)
+        classification_counts = agg.classification_counts
+        moi_counts = agg.moi_counts
+        grouping_counts = agg.grouping_counts
         genes_per_classification = {
-            k: len(v) for k, v in genes_per_classification.items()
+            k: len(v) for k, v in agg.genes_by_classification.items()
         }
-        diseases_per_classification = ht.aggregate(
-            hl.agg.group_by(ht.classification, hl.agg.collect_as_set(ht.disease_label))
-        )
         diseases_per_classification = {
-            k: len(v) for k, v in diseases_per_classification.items()
+            k: len(v) for k, v in agg.diseases_by_classification.items()
         }
+        last_update = agg.last_update if date_field else None
 
+        # Top genes by disease count is a grouped table operation, so it stays
+        # a separate job (cannot be folded into the row aggregation above).
         top_genes_rows = (
             ht.group_by(ht.gene_symbol)
             .aggregate(n_diseases=hl.agg.count())
@@ -600,9 +617,6 @@ class GeneDiseaseTableStreamer:
         top_genes_by_diseases = [
             (row.gene_symbol, row.n_diseases) for row in top_genes_rows
         ]
-
-        date_field = self._date_field
-        last_update = ht.aggregate(hl.agg.max(ht[date_field])) if date_field else None
 
         return {
             "total_associations": total_associations,

--- a/hvantk/skills/hgnc/streamers.py
+++ b/hvantk/skills/hgnc/streamers.py
@@ -633,33 +633,37 @@ class HGNCGeneCatalogStreamer(GeneCatalogStreamer):
 
         Absorbed from ``core/utils/gene_mapper.GeneMapper.get_coverage_stats``.
         """
-        row_fields = set(self._ht.row)
-        stats = {"total_genes": self._ht.count()}
+        ht = self._ht
+        row_fields = set(ht.row)
+
+        # Fuse total + per-field coverage counts into a single Hail action
+        # (one Spark job) instead of one ``filter(...).count()`` per field.
+        agg_exprs = {"total_genes": hl.agg.count()}
 
         if "ensembl_gene_id" in row_fields:
-            stats["with_ensembl"] = self._ht.filter(
-                hl.is_defined(self._ht.ensembl_gene_id)
-                & (self._ht.ensembl_gene_id != "")
-            ).count()
+            agg_exprs["with_ensembl"] = hl.agg.count_where(
+                hl.is_defined(ht.ensembl_gene_id) & (ht.ensembl_gene_id != "")
+            )
 
         if "entrez_id" in row_fields:
-            stats["with_entrez"] = self._ht.filter(
-                hl.is_defined(self._ht.entrez_id) & (self._ht.entrez_id != "")
-            ).count()
+            agg_exprs["with_entrez"] = hl.agg.count_where(
+                hl.is_defined(ht.entrez_id) & (ht.entrez_id != "")
+            )
 
         if "uniprot_ids" in row_fields:
-            stats["with_uniprot"] = self._ht.filter(
-                hl.is_defined(self._ht.uniprot_ids) & (hl.len(self._ht.uniprot_ids) > 0)
-            ).count()
+            agg_exprs["with_uniprot"] = hl.agg.count_where(
+                hl.is_defined(ht.uniprot_ids) & (hl.len(ht.uniprot_ids) > 0)
+            )
 
         if "omim_id" in row_fields:
-            stats["with_omim"] = self._ht.filter(
-                hl.is_defined(self._ht.omim_id) & (hl.len(self._ht.omim_id) > 0)
-            ).count()
+            agg_exprs["with_omim"] = hl.agg.count_where(
+                hl.is_defined(ht.omim_id) & (hl.len(ht.omim_id) > 0)
+            )
 
         if "locus_group" in row_fields:
-            stats["protein_coding"] = self._ht.filter(
-                self._ht.locus_group == "protein-coding gene"
-            ).count()
+            agg_exprs["protein_coding"] = hl.agg.count_where(
+                ht.locus_group == "protein-coding gene"
+            )
 
-        return stats
+        agg = ht.aggregate(hl.struct(**agg_exprs))
+        return {key: agg[key] for key in agg_exprs}


### PR DESCRIPTION
## PR-8 — Hail action fusion (opportunistic perf, behavior-preserving)

Replaces repeated per-record `.count()` / `.aggregate()` Spark jobs with a single fused `ht.aggregate(hl.struct(...))` at five sites, and stops the unconditional import-time matplotlib backend clobber.

| Site | Before | After |
|------|--------|-------|
| `core/streamers/gene_disease_table.py::compute_stats` | ~9 separate actions (`count` + `collect_as_set`x2 + `counter`x3 + `group_by`x2 + `max`) | one fused `hl.struct` aggregate (`last_update` added only when a `date_field` is configured); the grouped top-genes `take()` stays its own job |
| `skills/hgnc/streamers.py::get_coverage_stats` | total + up to 5 `filter(...).count()` | one fused aggregate via `hl.agg.count()` / `hl.agg.count_where(...)` |
| `algorithms/psroc/pipeline.py::_generate_outputs` | 4 label `.count()` | one fused aggregate |
| `algorithms/enrichex/burden.py::logistic_burden_test` | 3 result `.count()` | one fused aggregate (log message order preserved) |
| `algorithms/enrichex/burden.py::linear_burden_test` | 3 result `.count()` | one fused aggregate (log message order preserved) |
| `algorithms/visualization/qc_report.py` | `matplotlib.use("Agg")` unconditionally at import | guarded switch (only if backend isn't already non-interactive/inline), matching `constraint_plots.py` |

### Verification (hl.eval-style; Hail tests are CI-deselected)
- **Equivalence proven on synthetic Hail tables:** `hl.agg.count_where(cond) == filter(cond).count()`, and the fused `hl.struct(...)` aggregate yields identical results to the prior separate `count` / `collect_as_set` / `counter` / `group_by` / `max` calls (all fields match).
- `flake8` (project selection) clean; import smoke OK for all 5 modules; `matplotlib.get_backend()` resolves to `agg` after importing `qc_report`.
- Diffs scoped strictly to the changed functions (no whole-file reformatting churn).

### Scope notes
- Limited to the maintainer-named sites. Plan item 5 (`qc_plots.py` `_prepare_*_qc_data` panel caching) and the `expand_with_aliases` re-collect audit are **deferred** (not in the named scope).
- **Pre-existing, unrelated:** 3 hail-marked tests fail identically on `dev` (`clingen` `test_compute_stats` / `test_get_geneset_per_gcep`; burden `test_build_from_presets_unknown_class`). They are CI-deselected (silently red) and are neither touched nor affected by this PR — flagged separately for a bugfix.
