### PR TITLE
fix(drift): structured stub sentinel + WARNING for doc-only probes (#177)

### DIFF
--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -11,7 +11,7 @@ Drift report shape (one element per dataset)::
     [
       {
         "dataset_name": "clinvar:variants",
-        "status": "clean" | "drifted" | "probe_failed",
+        "status": "clean" | "drifted" | "probe_failed" | "stub",
         "observed": {...} | null,
         "expected": {...} | null,
         "diff": {...} | null,
@@ -32,7 +32,10 @@ For each ``status == "drifted"`` entry the script:
 6. Opens a draft PR (or updates the body of an existing one).
 
 Probe-failed entries are recorded in the GitHub step summary but never
-produce a PR (they are infrastructure failures, not data drift).
+produce a PR (they are infrastructure failures, not data drift). ``stub``
+entries (documentation-only sources with no programmatic probe) are likewise
+never turned into PRs; they are surfaced in the summary count so they are not
+silently dropped.
 
 Exit code is always 0 unless a wholly unexpected error escapes; drift /
 probe-failed are not workflow failures.
@@ -366,6 +369,26 @@ def handle_probe_failed(
     )
 
 
+def handle_stub(
+    entry: dict,
+    *,
+    step_summary: Path | None,
+) -> None:
+    """Surface a documentation-only stub in the rendered step summary so it is
+    not silently dropped. Stubs never open a PR (they are not data drift) and
+    never fail the workflow (they exit clean)."""
+    dataset = entry["dataset_name"]
+    reason = (entry.get("observed") or {}).get(
+        "reason", "documentation-only source; no programmatic probe"
+    )
+    print(f"\n=== Stub (no real drift detection): {dataset} ===")
+    print(f"  {reason}")
+    _summary_line(
+        step_summary,
+        f"- STUB: `{dataset}` -- {reason}",
+    )
+
+
 def _summary_line(step_summary: Path | None, line: str) -> None:
     if step_summary is None:
         return
@@ -427,10 +450,11 @@ def main(argv: list[str] | None = None) -> int:
     drifted = [e for e in report if e.get("status") == "drifted"]
     probe_failed = [e for e in report if e.get("status") == "probe_failed"]
     clean = [e for e in report if e.get("status") == "clean"]
+    stub = [e for e in report if e.get("status") == "stub"]
 
     print(
         f"summary: {len(drifted)} drifted, {len(probe_failed)} probe_failed, "
-        f"{len(clean)} clean"
+        f"{len(clean)} clean, {len(stub)} stub"
     )
 
     for entry in drifted:
@@ -457,6 +481,9 @@ def main(argv: list[str] | None = None) -> int:
 
     for entry in probe_failed:
         handle_probe_failed(entry, step_summary=step_summary)
+
+    for entry in stub:
+        handle_stub(entry, step_summary=step_summary)
 
     return 0
 

--- a/hvantk/core/plugin/api.py
+++ b/hvantk/core/plugin/api.py
@@ -21,6 +21,33 @@ Backend = Literal["hail", "anndata", "pandas"]
 # not flip drift status or invalidate stored artifact fingerprints.
 PROBE_FINGERPRINT_IGNORED_KEYS = frozenset({"fetched_at", "probe_version"})
 
+# Sentinel value for ``probe_status`` marking a drift probe as an intentional
+# stub: a documentation-only / license-gated / publication-only source with no
+# stable, programmatically-probeable direct URL. ``drift_runner`` reports these
+# as status="stub" (a visible WARNING) instead of a silent false-green "clean"
+# or a misleading "probe_failed". See issue #177.
+PROBE_STATUS_STUB = "stub"
+
+# Honest provenance token recorded by ``run_builder._coerce_fingerprint`` for a
+# stubbed source (the ``fingerprint`` key wins there). Self-describing rather
+# than a fake ``sha256:...`` hash, so provenance never implies a real probe ran.
+STUB_FINGERPRINT_TOKEN = "stub:no-programmatic-source"
+
+
+def stub_fingerprint(reason: str) -> dict:
+    """Build the structured sentinel a documentation-only drift probe returns.
+
+    Use this from ``fetch_fingerprint()`` when the source cannot be fingerprinted
+    programmatically (manual/gated/publication-only acquisition). ``reason``
+    explains why (surfaced in the ``hvantk drift`` WARNING). Returning this marks
+    the dataset as status="stub" rather than producing a false-green drift result.
+    """
+    return {
+        "probe_status": PROBE_STATUS_STUB,
+        "reason": reason,
+        "fingerprint": STUB_FINGERPRINT_TOKEN,
+    }
+
 
 class Builder(Protocol):
     """Phase B builder contract used by ``DatasetSpec.builder``.

--- a/hvantk/core/plugin/drift_runner.py
+++ b/hvantk/core/plugin/drift_runner.py
@@ -10,13 +10,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .api import DatasetSpec, DriftProbeError, PROBE_FINGERPRINT_IGNORED_KEYS
+from .api import (
+    DatasetSpec,
+    DriftProbeError,
+    PROBE_FINGERPRINT_IGNORED_KEYS,
+    PROBE_STATUS_STUB,
+)
 
 
 @dataclass(frozen=True)
 class DriftResult:
     dataset_name: str
-    status: str  # clean | drifted | probe_failed
+    status: str  # clean | drifted | probe_failed | stub
     observed: dict[str, Any] | None = None
     expected: dict[str, Any] | None = None
     diff: dict[str, Any] | None = None
@@ -35,6 +40,32 @@ def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
 def _run_drift_check_with_spec(
     spec: DatasetSpec, *, timeout: int = 60
 ) -> DriftResult:
+    # Invoke the probe before loading the baseline so an intentional stub
+    # (documentation-only source with no probeable URL) is reported as
+    # status="stub" — these plugins ship no committed baseline, so a
+    # baseline-first ordering would mislabel them as "probe_failed".
+    try:
+        observed = _invoke_with_timeout(spec.drift_probe, timeout=timeout)
+    except DriftProbeError as exc:
+        return DriftResult(
+            dataset_name=spec.name,
+            status="probe_failed",
+            probe_error=exc,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return DriftResult(
+            dataset_name=spec.name,
+            status="probe_failed",
+            probe_error=DriftProbeError(f"probe raised {type(exc).__name__}: {exc}"),
+        )
+
+    if observed.get("probe_status") == PROBE_STATUS_STUB:
+        return DriftResult(
+            dataset_name=spec.name,
+            status="stub",
+            observed=observed,
+        )
+
     fp_path = Path(spec.test_paths.drift_fingerprint)
     try:
         expected = json.loads(fp_path.read_text())
@@ -42,26 +73,10 @@ def _run_drift_check_with_spec(
         return DriftResult(
             dataset_name=spec.name,
             status="probe_failed",
+            observed=observed,
             probe_error=DriftProbeError(
                 f"missing expected fingerprint at {fp_path}"
             ),
-        )
-
-    try:
-        observed = _invoke_with_timeout(spec.drift_probe, timeout=timeout)
-    except DriftProbeError as exc:
-        return DriftResult(
-            dataset_name=spec.name,
-            status="probe_failed",
-            expected=expected,
-            probe_error=exc,
-        )
-    except Exception as exc:  # noqa: BLE001
-        return DriftResult(
-            dataset_name=spec.name,
-            status="probe_failed",
-            expected=expected,
-            probe_error=DriftProbeError(f"probe raised {type(exc).__name__}: {exc}"),
         )
 
     diff = _compare_fingerprints(expected, observed)

--- a/hvantk/skills/alphagenome/drift_probe.py
+++ b/hvantk/skills/alphagenome/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for alphagenome.
+"""Drift probe for alphagenome — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+AlphaGenome is consumed as a live prediction API requiring credentials; there is
+no static data file with a stable, programmatically-probeable URL to fingerprint.
+This probe returns a structured stub sentinel so ``hvantk drift`` reports a
+visible WARNING (status="stub") rather than a silent false-green. Replace with a
+real probe if a direct data URL becomes available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "AlphaGenome is a live prediction API requiring credentials; "
+    "no static data file to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/cosmic_cgc/drift_probe.py
+++ b/hvantk/skills/cosmic_cgc/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for cosmic-cgc.
+"""Drift probe for cosmic-cgc — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+The COSMIC Cancer Gene Census is behind a login/license gate
+(cancer.sanger.ac.uk/census); there is no public direct URL to fingerprint.
+This probe returns a structured stub sentinel so ``hvantk drift`` reports a
+visible WARNING (status="stub") rather than a silent false-green. Replace with a
+real probe if a direct data URL becomes available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "COSMIC Cancer Gene Census is login/license-gated "
+    "(cancer.sanger.ac.uk/census); no public direct URL to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/dbnsfp/drift_probe.py
+++ b/hvantk/skills/dbnsfp/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for dbnsfp.
+"""Drift probe for dbnsfp — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+dbNSFP is distributed from a landing page (sites.google.com/site/jpopgen/dbNSFP)
+with no stable direct data URL to fingerprint. This probe returns a structured
+stub sentinel so ``hvantk drift`` reports a visible WARNING (status="stub")
+rather than a silent false-green. Replace with a real probe if a direct data URL
+becomes available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "dbNSFP is distributed from a landing page "
+    "(sites.google.com/site/jpopgen/dbNSFP); no stable direct data URL"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/ensembl_gene/drift_probe.py
+++ b/hvantk/skills/ensembl_gene/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for ensembl-gene.
+"""Drift probe for ensembl-gene — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+Ensembl gene annotations are acquired manually here and ship no committed
+baseline fingerprint. A release-endpoint version probe (Ensembl REST) is
+marginally feasible but deferred (see issue #177, Option 2). For now this probe
+returns a structured stub sentinel so ``hvantk drift`` reports a visible WARNING
+(status="stub") rather than a silent false-green.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "Ensembl gene annotations acquired manually; no committed baseline "
+    "(a release-endpoint version probe is feasible but deferred — issue #177)"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/gevir/drift_probe.py
+++ b/hvantk/skills/gevir/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for gevir.
+"""Drift probe for gevir — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+GeVIR metrics are published as supplementary data (PMID 31873297); there is no
+programmatic data URL to fingerprint. This probe returns a structured stub
+sentinel so ``hvantk drift`` reports a visible WARNING (status="stub") rather
+than a silent false-green. Replace with a real probe if a direct data URL becomes
+available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "GeVIR metrics are published as supplementary data (PMID 31873297); "
+    "no programmatic data URL to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/gnomad_metrics/drift_probe.py
+++ b/hvantk/skills/gnomad_metrics/drift_probe.py
@@ -1,16 +1,21 @@
-"""Drift probe stub for gnomad-metrics.
+"""Drift probe for gnomad-metrics — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+gnomAD constraint metrics are acquired manually here and ship no committed
+baseline fingerprint. A HEAD probe of the public v2.1.1 constraint file on GCS is
+marginally feasible but deferred (see issue #177, Option 2). For now this probe
+returns a structured stub sentinel so ``hvantk drift`` reports a visible WARNING
+(status="stub") rather than a silent false-green.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "gnomAD constraint metrics acquired manually; no committed baseline "
+    "(a GCS HEAD probe of the public v2.1.1 file is feasible but deferred — "
+    "issue #177)"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/pqtl/drift_probe.py
+++ b/hvantk/skills/pqtl/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for pqtl.
+"""Drift probe for pqtl — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+pQTL summary statistics are publication-only (Fang et al. 2025 / GTEx); there is
+no stable direct data URL to fingerprint. This probe returns a structured stub
+sentinel so ``hvantk drift`` reports a visible WARNING (status="stub") rather
+than a silent false-green. Replace with a real probe if a direct data URL becomes
+available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "pQTL summary statistics are publication-only (Fang et al. 2025 / GTEx); "
+    "no stable direct data URL to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/tests/test_drift_cli.py
+++ b/hvantk/tests/test_drift_cli.py
@@ -48,6 +48,33 @@ def test_drift_json_output_is_parseable():
     assert parsed[0]["status"] == "clean"
 
 
+def test_drift_stub_emits_warning_to_stderr_in_json_mode():
+    """Regression (PR #186 review): a stub probe must surface a WARNING on
+    stderr even in --json mode, so the scheduled drift workflow — which captures
+    `drift --all --json` stdout to a file — stays visibly non-green for
+    documentation-only sources. stdout must remain clean machine-readable JSON.
+    """
+    from hvantk.core.plugin.api import stub_fingerprint
+
+    spec = plugin_loader.get_registry().get_dataset("fake:default")
+    object.__setattr__(
+        spec, "drift_probe", lambda: stub_fingerprint("doc-only; no probeable URL")
+    )
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(drift_cmd, ["--json", "fake:default"])
+
+    assert result.exit_code == 0
+    # stdout stays clean JSON (consumed by drift_to_pr.py / CI capture)
+    parsed = json.loads(result.stdout)
+    assert parsed[0]["status"] == "stub"
+    assert "WARNING" not in result.stdout
+    # the WARNING is on stderr so it shows up in CI step logs
+    assert "WARNING" in result.stderr
+    assert "stub probe" in result.stderr
+    assert "doc-only; no probeable URL" in result.stderr
+
+
 def test_drift_regenerate_overwrites_fingerprint(tmp_path: Path, monkeypatch):
     # Point the fixture at a tmpdir-copy so we don't mutate the test asset.
     import shutil

--- a/hvantk/tests/test_drift_cli.py
+++ b/hvantk/tests/test_drift_cli.py
@@ -61,11 +61,18 @@ def test_drift_stub_emits_warning_to_stderr_in_json_mode():
         spec, "drift_probe", lambda: stub_fingerprint("doc-only; no probeable URL")
     )
 
-    runner = CliRunner(mix_stderr=False)
+    # Click >= 8.2 removed the `mix_stderr` kwarg and always captures stdout
+    # and stderr separately; Click 8.1.x needs `mix_stderr=False` to do so.
+    # Support both so the test runs on either version.
+    try:
+        runner = CliRunner(mix_stderr=False)
+    except TypeError:
+        runner = CliRunner()
     result = runner.invoke(drift_cmd, ["--json", "fake:default"])
 
     assert result.exit_code == 0
-    # stdout stays clean JSON (consumed by drift_to_pr.py / CI capture)
+    # `result.stdout` is stdout-only on both Click 8.1.x (via mix_stderr=False)
+    # and 8.2+ (always separated); `result.output` mixes stderr in on 8.2+.
     parsed = json.loads(result.stdout)
     assert parsed[0]["status"] == "stub"
     assert "WARNING" not in result.stdout

--- a/hvantk/tests/test_drift_runner.py
+++ b/hvantk/tests/test_drift_runner.py
@@ -163,6 +163,23 @@ def test_drift_diff_reports_removed_keys(tmp_path: Path):
     assert result.diff["changed"] == {}
 
 
+def test_stub_probe_reported_as_stub_not_false_green(tmp_path: Path):
+    """A documentation-only stub probe must surface as status='stub' — never a
+    false-green 'clean' and never a misleading 'probe_failed' — even with no
+    committed baseline fingerprint (issue #177)."""
+    from hvantk.core.plugin.api import stub_fingerprint
+
+    # Stub plugins ship no committed baseline, so point at a nonexistent file.
+    spec = _make_spec(
+        probe_return=lambda: stub_fingerprint("doc-only; no probeable URL"),
+        fingerprint_path=tmp_path / "does-not-exist.json",
+    )
+    result = _run_with_spec(spec)
+    assert result.status == "stub"
+    assert result.status not in ("clean", "probe_failed")
+    assert result.observed["reason"] == "doc-only; no probeable URL"
+
+
 def test_probe_returning_non_mapping_surfaces_clear_error(tmp_path: Path):
     fp_path = tmp_path / "fp.json"
     _write_fingerprint(fp_path, {"probe_version": 1, "headers": {}, "checksums": {}})

--- a/hvantk/tools/plugins/drift_cli.py
+++ b/hvantk/tools/plugins/drift_cli.py
@@ -59,11 +59,20 @@ def drift_cmd(dataset, all_flag, domain, as_json, regenerate, timeout):
     else:
         for r in results:
             click.echo(f"{r.dataset_name}: {r.status}")
+            if r.status == "stub":
+                reason = (r.observed or {}).get("reason", "no programmatic source")
+                click.echo(
+                    f"WARNING: {r.dataset_name}: stub probe — {reason}; "
+                    "no real drift detection (documentation-only source).",
+                    err=True,
+                )
             if r.diff:
                 click.echo(json.dumps(r.diff, indent=2, default=str))
 
     # Priority: probe_failed(2) > drifted(1) > clean(0). Infra failure trumps
     # drift because drifted output is only meaningful if the probe actually ran.
+    # status="stub" is intentional (doc-only source) → exit clean, but the
+    # WARNING above keeps it from being a silent false-green.
     exit_codes = {EXIT_CLEAN}
     for r in results:
         if r.status == "drifted":

--- a/hvantk/tools/plugins/drift_cli.py
+++ b/hvantk/tools/plugins/drift_cli.py
@@ -59,15 +59,23 @@ def drift_cmd(dataset, all_flag, domain, as_json, regenerate, timeout):
     else:
         for r in results:
             click.echo(f"{r.dataset_name}: {r.status}")
-            if r.status == "stub":
-                reason = (r.observed or {}).get("reason", "no programmatic source")
-                click.echo(
-                    f"WARNING: {r.dataset_name}: stub probe — {reason}; "
-                    "no real drift detection (documentation-only source).",
-                    err=True,
-                )
             if r.diff:
                 click.echo(json.dumps(r.diff, indent=2, default=str))
+
+    # Emit stub WARNINGs to stderr in BOTH human-readable and --json modes.
+    # The scheduled drift workflow captures `drift --all --json` stdout to a
+    # file (.github/workflows/drift.yml), so a WARNING confined to the
+    # human-readable path would never surface in CI logs — re-hiding doc-only
+    # stubs. stderr keeps machine-readable stdout clean while CI logs stay
+    # visibly non-green.
+    for r in results:
+        if r.status == "stub":
+            reason = (r.observed or {}).get("reason", "no programmatic source")
+            click.echo(
+                f"WARNING: {r.dataset_name}: stub probe — {reason}; "
+                "no real drift detection (documentation-only source).",
+                err=True,
+            )
 
     # Priority: probe_failed(2) > drifted(1) > clean(0). Infra failure trumps
     # drift because drifted output is only meaningful if the probe actually ran.


### PR DESCRIPTION
Addresses #177 (Option 1 — documented stub schema + visible WARNING).

## Problem
The 7 documentation-only plugins (`alphagenome`, `cosmic_cgc`, `dbnsfp`, `ensembl_gene`, `gevir`, `gnomad_metrics`, `pqtl`) all returned the placeholder fingerprint `sha256:phase-k-stub-not-implemented` from `fetch_fingerprint()`. Two problems:

1. **Provenance false-green** — that fake `sha256:…` was stamped into artifact provenance by `run_builder._coerce_fingerprint` as if a real probe had run.
2. **Drift status conflation** — these plugins ship no committed baseline, so `hvantk drift` surfaced them as an indistinct `probe_failed` ("missing expected fingerprint"), conflating "intentional stub" with "infra/baseline error" — and would have been a false-green `clean` had a baseline ever been regenerated from the stub.

## Change (Option 1)
- **`core/plugin/api.py`** — new `stub_fingerprint(reason)` returning a structured sentinel `{"probe_status": "stub", "reason": …, "fingerprint": "stub:no-programmatic-source"}`. The honest, self-describing token replaces the fake sha256 in provenance.
- **`core/plugin/drift_runner.py`** — invoke the probe *before* loading the baseline, and short-circuit a `probe_status == "stub"` result to a distinct `status="stub"` (no committed baseline required). New status documented on `DriftResult`.
- **`tools/plugins/drift_cli.py`** — print a visible `WARNING` (stderr) for `stub` results including the reason, and exit clean. Intentional doc-only stubs are no longer a *silent* false-green.
- **7 stub `drift_probe.py`** — rewritten to call `stub_fingerprint()` with a provider-specific reason (why the source has no programmatic URL). `ensembl_gene` / `gnomad_metrics` note their feasible-but-deferred real probe (Option 2).

## Behavior

```
$ hvantk drift gevir:metrics
gevir:metrics: stub
WARNING: gevir:metrics: stub probe — GeVIR metrics are published as supplementary data (PMID 31873297); no programmatic data URL to fingerprint; no real drift detection (documentation-only source).
$ echo $?
0
```

## Tests
- One regression test in `test_drift_runner.py`: a stub probe surfaces as `status="stub"`, never `clean` or `probe_failed`.
- Targeted plugin/drift suite (56 tests across `test_drift_runner`, `test_run_builder`, `test_plugins_cli`, `test_plugin_api`, `test_plugin_loader`, `test_plugin_manifest_schema`) — all pass.
- flake8 (CI selection `E9,F63,F7,F82`) — clean.
- Full default suite: only 2 failures (`test_cli_qtlcascade::test_cascade_cmd`, `::test_coloc_cmd`), reproduced **identically on the clean `dev` base** without this diff → pre-existing full-suite ordering flakiness, unrelated.

Note: per this repo's workflow, merging to `dev` does not auto-close #177 — close manually after merge. #177 still tracks the Option 2 hybrid (real version-probes for `ensembl_gene` / `gnomad_metrics`) as future work.
