### PR TITLE
Fix documentation and deduplication issues

### DIFF
--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -11,7 +11,7 @@ Drift report shape (one element per dataset)::
     [
       {
         "dataset_name": "clinvar:variants",
-        "status": "clean" | "drifted" | "probe_failed",
+        "status": "clean" | "drifted" | "probe_failed" | "stub",
         "observed": {...} | null,
         "expected": {...} | null,
         "diff": {...} | null,
@@ -32,7 +32,10 @@ For each ``status == "drifted"`` entry the script:
 6. Opens a draft PR (or updates the body of an existing one).
 
 Probe-failed entries are recorded in the GitHub step summary but never
-produce a PR (they are infrastructure failures, not data drift).
+produce a PR (they are infrastructure failures, not data drift). ``stub``
+entries (documentation-only sources with no programmatic probe) are likewise
+never turned into PRs; they are surfaced in the summary count so they are not
+silently dropped.
 
 Exit code is always 0 unless a wholly unexpected error escapes; drift /
 probe-failed are not workflow failures.
@@ -366,6 +369,26 @@ def handle_probe_failed(
     )
 
 
+def handle_stub(
+    entry: dict,
+    *,
+    step_summary: Path | None,
+) -> None:
+    """Surface a documentation-only stub in the rendered step summary so it is
+    not silently dropped. Stubs never open a PR (they are not data drift) and
+    never fail the workflow (they exit clean)."""
+    dataset = entry["dataset_name"]
+    reason = (entry.get("observed") or {}).get(
+        "reason", "documentation-only source; no programmatic probe"
+    )
+    print(f"\n=== Stub (no real drift detection): {dataset} ===")
+    print(f"  {reason}")
+    _summary_line(
+        step_summary,
+        f"- STUB: `{dataset}` -- {reason}",
+    )
+
+
 def _summary_line(step_summary: Path | None, line: str) -> None:
     if step_summary is None:
         return
@@ -427,10 +450,11 @@ def main(argv: list[str] | None = None) -> int:
     drifted = [e for e in report if e.get("status") == "drifted"]
     probe_failed = [e for e in report if e.get("status") == "probe_failed"]
     clean = [e for e in report if e.get("status") == "clean"]
+    stub = [e for e in report if e.get("status") == "stub"]
 
     print(
         f"summary: {len(drifted)} drifted, {len(probe_failed)} probe_failed, "
-        f"{len(clean)} clean"
+        f"{len(clean)} clean, {len(stub)} stub"
     )
 
     for entry in drifted:
@@ -457,6 +481,9 @@ def main(argv: list[str] | None = None) -> int:
 
     for entry in probe_failed:
         handle_probe_failed(entry, step_summary=step_summary)
+
+    for entry in stub:
+        handle_stub(entry, step_summary=step_summary)
 
     return 0
 

--- a/hvantk/algorithms/enrichex/burden.py
+++ b/hvantk/algorithms/enrichex/burden.py
@@ -281,7 +281,11 @@ def _build_gene_to_sets_ht(gene_sets: Dict[str, List[str]]) -> "hl.Table":
     """Build a ``gene -> [gene_set_ids]`` table from the gene-set definitions."""
     gene_to_sets: Dict[str, List[str]] = {}
     for gs_name, genes in gene_sets.items():
-        for gene in genes:
+        # dict.fromkeys dedups within a single set while preserving order, so a
+        # gene listed twice in one set is not double-counted after explode_rows
+        # (n_genes_found / burden). set() would lose order; the canonical
+        # parse_geneset_tsv already dedups upstream, so this guards other callers.
+        for gene in dict.fromkeys(genes):
             if gene not in gene_to_sets:
                 gene_to_sets[gene] = []
             gene_to_sets[gene].append(gs_name)
@@ -393,6 +397,16 @@ def compute_geneset_burden_mt(
     >>> mt_burden = compute_geneset_burden_mt(mt, gene_sets, variant_filter=vf)
     """
     _require_hail()
+
+    # Normalize each set's gene list (dedup within set, order-preserving) up
+    # front so the min_gene_set_size filter, gene_set_size, gene_coverage_pct,
+    # and the gene->set membership are all derived from the same deduped genes.
+    # No-op for the canonical pipeline (parse_geneset_tsv already dedups); this
+    # only affects callers passing raw, duplicate-containing lists, where the
+    # deduped membership would otherwise disagree with len()-based sizes.
+    gene_sets = {
+        name: list(dict.fromkeys(genes)) for name, genes in gene_sets.items()
+    }
 
     # Pre-filter gene sets by minimum size
     if min_gene_set_size > 0:

--- a/hvantk/algorithms/hgc/qc_report.py
+++ b/hvantk/algorithms/hgc/qc_report.py
@@ -57,8 +57,13 @@ def render_qc_summary_markdown(summary_data: Dict[str, dict]) -> str:
                     for stat in _SUMMARY_STAT_COLUMNS:
                         value = stats.get(stat, "N/A")
                         if isinstance(value, (int, float)) and stat != "count":
+                            # Use scientific notation for very small magnitudes
+                            # (e.g. tiny HWE p-values) so they don't collapse to
+                            # "0.000"; keep an exact 0 as "0.000".
                             value = (
-                                f"{value:.3f}" if abs(value) < 1000 else f"{value:.2e}"
+                                f"{value:.3f}"
+                                if value == 0 or 1e-3 <= abs(value) < 1000
+                                else f"{value:.2e}"
                             )
                         row += f" {value} |"
                     md_content += row + "\n"

--- a/hvantk/core/plugin/api.py
+++ b/hvantk/core/plugin/api.py
@@ -21,6 +21,33 @@ Backend = Literal["hail", "anndata", "pandas"]
 # not flip drift status or invalidate stored artifact fingerprints.
 PROBE_FINGERPRINT_IGNORED_KEYS = frozenset({"fetched_at", "probe_version"})
 
+# Sentinel value for ``probe_status`` marking a drift probe as an intentional
+# stub: a documentation-only / license-gated / publication-only source with no
+# stable, programmatically-probeable direct URL. ``drift_runner`` reports these
+# as status="stub" (a visible WARNING) instead of a silent false-green "clean"
+# or a misleading "probe_failed". See issue #177.
+PROBE_STATUS_STUB = "stub"
+
+# Honest provenance token recorded by ``run_builder._coerce_fingerprint`` for a
+# stubbed source (the ``fingerprint`` key wins there). Self-describing rather
+# than a fake ``sha256:...`` hash, so provenance never implies a real probe ran.
+STUB_FINGERPRINT_TOKEN = "stub:no-programmatic-source"
+
+
+def stub_fingerprint(reason: str) -> dict:
+    """Build the structured sentinel a documentation-only drift probe returns.
+
+    Use this from ``fetch_fingerprint()`` when the source cannot be fingerprinted
+    programmatically (manual/gated/publication-only acquisition). ``reason``
+    explains why (surfaced in the ``hvantk drift`` WARNING). Returning this marks
+    the dataset as status="stub" rather than producing a false-green drift result.
+    """
+    return {
+        "probe_status": PROBE_STATUS_STUB,
+        "reason": reason,
+        "fingerprint": STUB_FINGERPRINT_TOKEN,
+    }
+
 
 class Builder(Protocol):
     """Phase B builder contract used by ``DatasetSpec.builder``.

--- a/hvantk/core/plugin/drift_runner.py
+++ b/hvantk/core/plugin/drift_runner.py
@@ -10,13 +10,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .api import DatasetSpec, DriftProbeError, PROBE_FINGERPRINT_IGNORED_KEYS
+from .api import (
+    DatasetSpec,
+    DriftProbeError,
+    PROBE_FINGERPRINT_IGNORED_KEYS,
+    PROBE_STATUS_STUB,
+)
 
 
 @dataclass(frozen=True)
 class DriftResult:
     dataset_name: str
-    status: str  # clean | drifted | probe_failed
+    status: str  # clean | drifted | probe_failed | stub
     observed: dict[str, Any] | None = None
     expected: dict[str, Any] | None = None
     diff: dict[str, Any] | None = None
@@ -35,6 +40,32 @@ def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
 def _run_drift_check_with_spec(
     spec: DatasetSpec, *, timeout: int = 60
 ) -> DriftResult:
+    # Invoke the probe before loading the baseline so an intentional stub
+    # (documentation-only source with no probeable URL) is reported as
+    # status="stub" — these plugins ship no committed baseline, so a
+    # baseline-first ordering would mislabel them as "probe_failed".
+    try:
+        observed = _invoke_with_timeout(spec.drift_probe, timeout=timeout)
+    except DriftProbeError as exc:
+        return DriftResult(
+            dataset_name=spec.name,
+            status="probe_failed",
+            probe_error=exc,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return DriftResult(
+            dataset_name=spec.name,
+            status="probe_failed",
+            probe_error=DriftProbeError(f"probe raised {type(exc).__name__}: {exc}"),
+        )
+
+    if observed.get("probe_status") == PROBE_STATUS_STUB:
+        return DriftResult(
+            dataset_name=spec.name,
+            status="stub",
+            observed=observed,
+        )
+
     fp_path = Path(spec.test_paths.drift_fingerprint)
     try:
         expected = json.loads(fp_path.read_text())
@@ -42,26 +73,10 @@ def _run_drift_check_with_spec(
         return DriftResult(
             dataset_name=spec.name,
             status="probe_failed",
+            observed=observed,
             probe_error=DriftProbeError(
                 f"missing expected fingerprint at {fp_path}"
             ),
-        )
-
-    try:
-        observed = _invoke_with_timeout(spec.drift_probe, timeout=timeout)
-    except DriftProbeError as exc:
-        return DriftResult(
-            dataset_name=spec.name,
-            status="probe_failed",
-            expected=expected,
-            probe_error=exc,
-        )
-    except Exception as exc:  # noqa: BLE001
-        return DriftResult(
-            dataset_name=spec.name,
-            status="probe_failed",
-            expected=expected,
-            probe_error=DriftProbeError(f"probe raised {type(exc).__name__}: {exc}"),
         )
 
     diff = _compare_fingerprints(expected, observed)

--- a/hvantk/core/plugin/drift_runner.py
+++ b/hvantk/core/plugin/drift_runner.py
@@ -37,6 +37,25 @@ def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
     return _run_drift_check_with_spec(spec, timeout=timeout)
 
 
+def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
+    """Build a probe_failed result, also flagging a missing baseline fingerprint.
+
+    The probe runs before the baseline is read (so intentional stubs classify
+    correctly). Without this, a plugin whose probe fails AND ships no committed
+    baseline would surface only the probe error and silently hide the
+    missing-fingerprint configuration issue. The underlying probe error is
+    preserved either way.
+    """
+    fp_path = Path(spec.test_paths.drift_fingerprint)
+    if not fp_path.exists():
+        exc = DriftProbeError(
+            f"{exc}; additionally, expected fingerprint is missing at {fp_path}"
+        )
+    return DriftResult(
+        dataset_name=spec.name, status="probe_failed", probe_error=exc
+    )
+
+
 def _run_drift_check_with_spec(
     spec: DatasetSpec, *, timeout: int = 60
 ) -> DriftResult:
@@ -47,16 +66,10 @@ def _run_drift_check_with_spec(
     try:
         observed = _invoke_with_timeout(spec.drift_probe, timeout=timeout)
     except DriftProbeError as exc:
-        return DriftResult(
-            dataset_name=spec.name,
-            status="probe_failed",
-            probe_error=exc,
-        )
+        return _probe_failed(spec, exc)
     except Exception as exc:  # noqa: BLE001
-        return DriftResult(
-            dataset_name=spec.name,
-            status="probe_failed",
-            probe_error=DriftProbeError(f"probe raised {type(exc).__name__}: {exc}"),
+        return _probe_failed(
+            spec, DriftProbeError(f"probe raised {type(exc).__name__}: {exc}")
         )
 
     if observed.get("probe_status") == PROBE_STATUS_STUB:

--- a/hvantk/skills/alphagenome/drift_probe.py
+++ b/hvantk/skills/alphagenome/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for alphagenome.
+"""Drift probe for alphagenome — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+AlphaGenome is consumed as a live prediction API requiring credentials; there is
+no static data file with a stable, programmatically-probeable URL to fingerprint.
+This probe returns a structured stub sentinel so ``hvantk drift`` reports a
+visible WARNING (status="stub") rather than a silent false-green. Replace with a
+real probe if a direct data URL becomes available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "AlphaGenome is a live prediction API requiring credentials; "
+    "no static data file to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/clingen/catalog/datasets.json
+++ b/hvantk/skills/clingen/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "ClinGen_GeneDisease",
     "description": "Curated gene-disease associations with evidence-based classifications from ClinGen. Includes classification levels (Definitive, Strong, Moderate, Limited), mode of inheritance, and MONDO disease ontology mappings.",
     "pubmedid": "28552198",
-    "data_source": "Custom",
+    "data_source": "ClinGen",
     "last_updated": "2026-03-06T00:00:00.000000",
     "update_frequency": "monthly",
     "organism": "Homo sapiens",

--- a/hvantk/skills/clinvar/catalog/datasets.json
+++ b/hvantk/skills/clinvar/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "ClinVar_latest",
     "description": "Public archive of reports of the relationships among human variations and phenotypes, with supporting evidence. ClinVar facilitates access to and communication about the relationships asserted between human variation and observed health status.",
     "pubmedid": "24234437",
-    "data_source": "Custom",
+    "data_source": "ClinVar",
     "last_updated": "2025-09-23T16:30:00.000000",
     "update_frequency": "monthly",
     "organism": "Homo sapiens",

--- a/hvantk/skills/cosmic_cgc/drift_probe.py
+++ b/hvantk/skills/cosmic_cgc/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for cosmic-cgc.
+"""Drift probe for cosmic-cgc — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+The COSMIC Cancer Gene Census is behind a login/license gate
+(cancer.sanger.ac.uk/census); there is no public direct URL to fingerprint.
+This probe returns a structured stub sentinel so ``hvantk drift`` reports a
+visible WARNING (status="stub") rather than a silent false-green. Replace with a
+real probe if a direct data URL becomes available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "COSMIC Cancer Gene Census is login/license-gated "
+    "(cancer.sanger.ac.uk/census); no public direct URL to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/dbnsfp/catalog/datasets.json
+++ b/hvantk/skills/dbnsfp/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "dbNSFP_v4.7",
     "description": "Comprehensive database of functional predictions and annotations for human nonsynonymous and splice-site SNVs. Includes prediction scores from SIFT, PolyPhen2, CADD, GERP++, PhyloP, PhastCons, and many others for variant pathogenicity assessment.",
     "pubmedid": "21520341",
-    "data_source": "Custom",
+    "data_source": "dbNSFP",
     "last_updated": "2025-09-23T16:30:00.000000",
     "update_frequency": "quarterly",
     "organism": "Homo sapiens",

--- a/hvantk/skills/dbnsfp/drift_probe.py
+++ b/hvantk/skills/dbnsfp/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for dbnsfp.
+"""Drift probe for dbnsfp — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+dbNSFP is distributed from a landing page (sites.google.com/site/jpopgen/dbNSFP)
+with no stable direct data URL to fingerprint. This probe returns a structured
+stub sentinel so ``hvantk drift`` reports a visible WARNING (status="stub")
+rather than a silent false-green. Replace with a real probe if a direct data URL
+becomes available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "dbNSFP is distributed from a landing page "
+    "(sites.google.com/site/jpopgen/dbNSFP); no stable direct data URL"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/ensembl_gene/catalog/datasets.json
+++ b/hvantk/skills/ensembl_gene/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "Ensembl_v110",
     "description": "Comprehensive gene annotations from the Ensembl project including gene models, transcript isoforms, protein sequences, regulatory features, and comparative genomics data across species.",
     "pubmedid": "31691826",
-    "data_source": "Custom",
+    "data_source": "Ensembl",
     "last_updated": "2025-09-23T16:30:00.000000",
     "update_frequency": "quarterly",
     "organism": "Homo sapiens",
@@ -35,7 +35,7 @@
       },
       {
         "path": "Homo_sapiens.GRCh38.110.gff3.gz",
-        "format": "gff",
+        "format": "gff3",
         "size_bytes": 900000000,
         "compression": "gzip",
         "description": "Complete gene annotations in GFF3 format"

--- a/hvantk/skills/ensembl_gene/drift_probe.py
+++ b/hvantk/skills/ensembl_gene/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for ensembl-gene.
+"""Drift probe for ensembl-gene — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+Ensembl gene annotations are acquired manually here and ship no committed
+baseline fingerprint. A release-endpoint version probe (Ensembl REST) is
+marginally feasible but deferred (see issue #177, Option 2). For now this probe
+returns a structured stub sentinel so ``hvantk drift`` reports a visible WARNING
+(status="stub") rather than a silent false-green.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "Ensembl gene annotations acquired manually; no committed baseline "
+    "(a release-endpoint version probe is feasible but deferred — issue #177)"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/gevir/catalog/datasets.json
+++ b/hvantk/skills/gevir/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "GeVIR_v1.0",
     "description": "Genome-wide scores for ranking the pathogenicity potential of human genetic variants. GeVIR integrates multiple genomic features to provide pathogenicity predictions for both coding and non-coding variants.",
     "pubmedid": "31873297",
-    "data_source": "Custom",
+    "data_source": "GeVIR",
     "last_updated": "2025-09-23T16:30:00.000000",
     "update_frequency": "irregular",
     "organism": "Homo sapiens",

--- a/hvantk/skills/gevir/drift_probe.py
+++ b/hvantk/skills/gevir/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for gevir.
+"""Drift probe for gevir — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+GeVIR metrics are published as supplementary data (PMID 31873297); there is no
+programmatic data URL to fingerprint. This probe returns a structured stub
+sentinel so ``hvantk drift`` reports a visible WARNING (status="stub") rather
+than a silent false-green. Replace with a real probe if a direct data URL becomes
+available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "GeVIR metrics are published as supplementary data (PMID 31873297); "
+    "no programmatic data URL to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/gnomad_metrics/catalog/datasets.json
+++ b/hvantk/skills/gnomad_metrics/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "gnomAD_v4.1",
     "description": "Large-scale reference dataset of human genetic variation, aggregating exome and genome sequencing data from diverse populations worldwide. Provides allele frequencies, quality metrics, and population-specific annotations.",
     "pubmedid": "32461654",
-    "data_source": "Custom",
+    "data_source": "gnomAD",
     "last_updated": "2025-09-23T16:30:00.000000",
     "update_frequency": "annually",
     "organism": "Homo sapiens",

--- a/hvantk/skills/gnomad_metrics/drift_probe.py
+++ b/hvantk/skills/gnomad_metrics/drift_probe.py
@@ -1,16 +1,21 @@
-"""Drift probe stub for gnomad-metrics.
+"""Drift probe for gnomad-metrics — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+gnomAD constraint metrics are acquired manually here and ship no committed
+baseline fingerprint. A HEAD probe of the public v2.1.1 constraint file on GCS is
+marginally feasible but deferred (see issue #177, Option 2). For now this probe
+returns a structured stub sentinel so ``hvantk drift`` reports a visible WARNING
+(status="stub") rather than a silent false-green.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "gnomAD constraint metrics acquired manually; no committed baseline "
+    "(a GCS HEAD probe of the public v2.1.1 file is feasible but deferred — "
+    "issue #177)"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/skills/gtex_eqtl/catalog/datasets.json
+++ b/hvantk/skills/gtex_eqtl/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "GTEx_v11_eQTL_signif_pairs",
     "description": "GTEx Consortium release v11 cis-eQTL significant variant-gene pairs, one parquet file per tissue. 12 source columns: phenotype_id, variant_id (chr_pos_ref_alt_b38), start_distance, af, ma_samples, ma_count, pval_nominal, slope, slope_se, pval_nominal_threshold, min_pval_nominal, pval_beta. Built into a Hail Table keyed by (locus, alleles, gene_id) via spark.read.parquet \u2192 hl.Table.from_spark; see hvantk/skills/gtex_eqtl/SKILL.md. Used as eQTL input to hvantk/qtlcascade/ and variant annotation.",
     "pubmedid": "32913098",
-    "data_source": "Custom",
+    "data_source": "GTEx",
     "last_updated": "2024-12-01T00:00:00.000000",
     "update_frequency": "irregular",
     "organism": "Homo sapiens",

--- a/hvantk/skills/gwas_catalog/catalog/datasets.json
+++ b/hvantk/skills/gwas_catalog/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "GWAS_Catalog_v1.0_e115_r2026-04-27",
     "description": "Manually curated collection of all published genome-wide association studies. Each row is a SNP-trait association with study provenance, p-value, effect size (OR or BETA), and risk-allele frequency. v1.0 schema (34 columns, no MAPPED_TRAIT_URI). Built into a Hail Table keyed by (locus, alleles) with a sentinel ALT for variant-annotation joins; see hvantk/skills/gwas_catalog/SKILL.md.",
     "pubmedid": "30445434",
-    "data_source": "Custom",
+    "data_source": "GWAS Catalog",
     "last_updated": "2026-04-27T00:00:00.000000",
     "update_frequency": "quarterly",
     "organism": "Homo sapiens",

--- a/hvantk/skills/insider/catalog/datasets.json
+++ b/hvantk/skills/insider/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "INSIDER_v1.0",
     "description": "Interactome Insider (Wei et al., Nat Methods 2017). Predicted (ECLAIR), structural (PDB), and homology-derived (I3D) protein-protein interaction interface residues. Distributed as two complementary products: (1) Whole_Human_Interactome_Interface_hg38.bed \u2014 UCSC-style BED with 208,448 named PPI tracks projecting interface residues onto GRCh38 coordinates (this file path), and (2) H_sapiens_interfacesALL.txt \u2014 per protein-pair residue arrays with Source provenance (a separately-onboardable product, not in this catalog entry). Built by a custom track-aware BED parser plus hl.import_table into an interval-keyed Hail Table that preserves PPI IDs from track names; see hvantk/skills/insider/SKILL.md. Used for variant-interval intersection (does a variant fall in any predicted PPI interface?).",
     "pubmedid": "29036289",
-    "data_source": "Custom",
+    "data_source": "INSIDER",
     "last_updated": "2025-09-23T16:30:00.000000",
     "update_frequency": "irregular",
     "organism": "Homo sapiens",

--- a/hvantk/skills/msigdb/catalog/datasets.json
+++ b/hvantk/skills/msigdb/catalog/datasets.json
@@ -4,7 +4,7 @@
     "accession": "MSigDB_C2_CP_v2026.1.Hs.symbols",
     "description": "Broad Institute Molecular Signatures Database. Collection C2 (curated gene sets) sub-collection CP (Canonical Pathways) \u2014 pathway gene sets curated from online resources (BIOCARTA, KEGG, PID, REACTOME, WP, SA). Human gene-symbol variant. GMT format: tab-separated variable-width rows where column 1 is set_name, column 2 is a gsea-msigdb URL, and columns 3..N are gene symbols. Built into a Hail Table keyed by set_name with genes as array<str>; see hvantk/skills/msigdb/SKILL.md. Used for gene-set lookup in enrichment / burden / overlap analyses.",
     "pubmedid": "16199517",
-    "data_source": "Custom",
+    "data_source": "MSigDB",
     "last_updated": "2026-01-01T00:00:00.000000",
     "update_frequency": "annually",
     "organism": "Homo sapiens",

--- a/hvantk/skills/pqtl/drift_probe.py
+++ b/hvantk/skills/pqtl/drift_probe.py
@@ -1,16 +1,20 @@
-"""Drift probe stub for pqtl.
+"""Drift probe for pqtl — documentation-only source (stub).
 
-Phase K plugin promotion lifts this source from the legacy hardcoded
-_TABLE_BUILDERS dict. A real drift probe (which queries the upstream
-source and returns a fingerprint) is a follow-up — for now this stub
-returns a placeholder fingerprint.
+pQTL summary statistics are publication-only (Fang et al. 2025 / GTEx); there is
+no stable direct data URL to fingerprint. This probe returns a structured stub
+sentinel so ``hvantk drift`` reports a visible WARNING (status="stub") rather
+than a silent false-green. Replace with a real probe if a direct data URL becomes
+available. See issue #177.
 """
 from __future__ import annotations
 
+from hvantk.core.plugin.api import stub_fingerprint
+
+_REASON = (
+    "pQTL summary statistics are publication-only (Fang et al. 2025 / GTEx); "
+    "no stable direct data URL to fingerprint"
+)
+
 
 def fetch_fingerprint() -> dict:
-    return {
-        "fingerprint": "sha256:phase-k-stub-not-implemented",
-        "probe_status": "stub",
-        "comment": "Phase K plugin promotion stub; replace with real probe.",
-    }
+    return stub_fingerprint(_REASON)

--- a/hvantk/tests/enrichex/test_burden_hail.py
+++ b/hvantk/tests/enrichex/test_burden_hail.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from hvantk.algorithms.enrichex.burden import (
     VariantFilter,
+    _build_gene_to_sets_ht,
     _compute_test_statistic,
     _linear_t_statistic,
     _logistic_z_statistic,
@@ -181,6 +182,38 @@ class TestComputeGenesetBurdenMt:
                 gene_field="SYMBOL",
                 genotype_aggregation="invalid",
             )
+
+    def test_compute_geneset_burden_dedups_gene_set_size(self, hail_session):
+        """gene_set_size must reflect the DEDUPED gene count so it stays
+        consistent with n_genes_found / gene_coverage_pct when a caller passes
+        duplicate genes within a set (PR #187 review: Copilot)."""
+        mt = self.setup_test_mt()
+        gene_sets = {"set1": ["GENE1", "GENE1", "GENE2"]}  # GENE1 duplicated
+        mt_burden = compute_geneset_burden_mt(mt, gene_sets, gene_field="SYMBOL")
+        row = mt_burden.rows().collect()[0]
+        assert row.gene_set_size == 2  # deduped (GENE1, GENE2), not 3
+
+
+@pytest.mark.hail
+class TestBuildGeneToSetsHt:
+    """Regression tests for _build_gene_to_sets_ht (gene -> [set ids])."""
+
+    def test_dedups_repeated_gene_within_a_set(self, hail_session):
+        """A gene listed twice in one set maps to that set once, not twice —
+        otherwise it is double-counted after explode_rows (n_genes_found /
+        burden). Regression for #185."""
+        ht = _build_gene_to_sets_ht({"panel_a": ["BRCA1", "BRCA1", "TP53"]})
+        rows = {r["gene"]: list(r["gene_set_ids"]) for r in ht.collect()}
+        assert rows["BRCA1"] == ["panel_a"]  # not ["panel_a", "panel_a"]
+        assert rows["TP53"] == ["panel_a"]
+
+    def test_keeps_distinct_sets_for_a_shared_gene(self, hail_session):
+        """Within-set dedup must not collapse a gene's membership across sets."""
+        ht = _build_gene_to_sets_ht(
+            {"panel_a": ["BRCA1", "BRCA1"], "panel_b": ["BRCA1"]}
+        )
+        rows = {r["gene"]: list(r["gene_set_ids"]) for r in ht.collect()}
+        assert rows["BRCA1"] == ["panel_a", "panel_b"]
 
 
 @pytest.mark.hail

--- a/hvantk/tests/test_drift_cli.py
+++ b/hvantk/tests/test_drift_cli.py
@@ -48,6 +48,40 @@ def test_drift_json_output_is_parseable():
     assert parsed[0]["status"] == "clean"
 
 
+def test_drift_stub_emits_warning_to_stderr_in_json_mode():
+    """Regression (PR #186 review): a stub probe must surface a WARNING on
+    stderr even in --json mode, so the scheduled drift workflow — which captures
+    `drift --all --json` stdout to a file — stays visibly non-green for
+    documentation-only sources. stdout must remain clean machine-readable JSON.
+    """
+    from hvantk.core.plugin.api import stub_fingerprint
+
+    spec = plugin_loader.get_registry().get_dataset("fake:default")
+    object.__setattr__(
+        spec, "drift_probe", lambda: stub_fingerprint("doc-only; no probeable URL")
+    )
+
+    # Click >= 8.2 removed the `mix_stderr` kwarg and always captures stdout
+    # and stderr separately; Click 8.1.x needs `mix_stderr=False` to do so.
+    # Support both so the test runs on either version.
+    try:
+        runner = CliRunner(mix_stderr=False)
+    except TypeError:
+        runner = CliRunner()
+    result = runner.invoke(drift_cmd, ["--json", "fake:default"])
+
+    assert result.exit_code == 0
+    # `result.stdout` is stdout-only on both Click 8.1.x (via mix_stderr=False)
+    # and 8.2+ (always separated); `result.output` mixes stderr in on 8.2+.
+    parsed = json.loads(result.stdout)
+    assert parsed[0]["status"] == "stub"
+    assert "WARNING" not in result.stdout
+    # the WARNING is on stderr so it shows up in CI step logs
+    assert "WARNING" in result.stderr
+    assert "stub probe" in result.stderr
+    assert "doc-only; no probeable URL" in result.stderr
+
+
 def test_drift_regenerate_overwrites_fingerprint(tmp_path: Path, monkeypatch):
     # Point the fixture at a tmpdir-copy so we don't mutate the test asset.
     import shutil

--- a/hvantk/tests/test_drift_runner.py
+++ b/hvantk/tests/test_drift_runner.py
@@ -163,6 +163,23 @@ def test_drift_diff_reports_removed_keys(tmp_path: Path):
     assert result.diff["changed"] == {}
 
 
+def test_stub_probe_reported_as_stub_not_false_green(tmp_path: Path):
+    """A documentation-only stub probe must surface as status='stub' — never a
+    false-green 'clean' and never a misleading 'probe_failed' — even with no
+    committed baseline fingerprint (issue #177)."""
+    from hvantk.core.plugin.api import stub_fingerprint
+
+    # Stub plugins ship no committed baseline, so point at a nonexistent file.
+    spec = _make_spec(
+        probe_return=lambda: stub_fingerprint("doc-only; no probeable URL"),
+        fingerprint_path=tmp_path / "does-not-exist.json",
+    )
+    result = _run_with_spec(spec)
+    assert result.status == "stub"
+    assert result.status not in ("clean", "probe_failed")
+    assert result.observed["reason"] == "doc-only; no probeable URL"
+
+
 def test_probe_returning_non_mapping_surfaces_clear_error(tmp_path: Path):
     fp_path = tmp_path / "fp.json"
     _write_fingerprint(fp_path, {"probe_version": 1, "headers": {}, "checksums": {}})

--- a/hvantk/tests/test_drift_runner.py
+++ b/hvantk/tests/test_drift_runner.py
@@ -91,6 +91,24 @@ def test_probe_failed_when_probe_raises(tmp_path: Path):
     assert "network down" in str(result.probe_error)
 
 
+def test_probe_failure_with_missing_baseline_reports_both(tmp_path: Path):
+    """When the probe fails AND no baseline fingerprint is committed, the error
+    must surface both the probe failure and the missing-fingerprint path — the
+    probe-first ordering must not mask the missing-baseline config error
+    (PR #188 review: Copilot)."""
+    fp_path = tmp_path / "does-not-exist.json"  # no baseline written
+
+    def boom():
+        raise DriftProbeError("network down")
+
+    spec = _make_spec(probe_return=boom, fingerprint_path=fp_path)
+    result = _run_with_spec(spec)
+    assert result.status == "probe_failed"
+    msg = str(result.probe_error)
+    assert "network down" in msg  # underlying probe error preserved
+    assert "missing" in msg.lower() and str(fp_path) in msg  # baseline flagged
+
+
 def test_fetched_at_is_excluded_from_comparison(tmp_path: Path):
     fp_path = tmp_path / "fp.json"
     _write_fingerprint(

--- a/hvantk/tools/enrichex/burden_cli.py
+++ b/hvantk/tools/enrichex/burden_cli.py
@@ -42,7 +42,7 @@ def _render_burden_summary(result_df, alpha, phenotype_type: str) -> None:
     click.echo(f"Significant gene sets (p_adj < {alpha}): {n_significant}")
 
     if n_significant > 0:
-        click.echo(f"\nTop significant gene sets:")
+        click.echo("\nTop significant gene sets:")
         click.echo("-" * 60)
 
         # Select columns based on phenotype type
@@ -434,13 +434,13 @@ def burden_test(
         click.echo("\n" + "=" * 60)
         click.echo("ENRICHEX BURDEN ANALYSIS PLAN (Hail-Native)")
         click.echo("=" * 60)
-        click.echo(f"\nInputs:")
+        click.echo("\nInputs:")
         click.echo(f"  Cohort MT: {cohort_mt}")
         click.echo(f"  Phenotypes: {phenotypes}")
         click.echo(f"    Field: {phenotype_field}")
         click.echo(f"    Type: {phenotype_type}")
         click.echo(f"  Gene sets: {gene_sets}")
-        click.echo(f"\nVariant Filters:")
+        click.echo("\nVariant Filters:")
         if max_af is not None:
             click.echo(f"  Max AF: {max_af} (field: {af_field})")
         if min_score is not None:
@@ -450,18 +450,18 @@ def burden_test(
         if consequences:
             click.echo(f"  Consequences: {consequences} (field: {consequence_field})")
         if max_af is None and min_score is None and not consequences:
-            click.echo(f"  None (MT assumed pre-filtered)")
-        click.echo(f"\nAnalysis:")
+            click.echo("  None (MT assumed pre-filtered)")
+        click.echo("\nAnalysis:")
         click.echo(f"  Gene field: {gene_field}")
         click.echo(f"  Genotype aggregation: {genotype_aggregation}")
         if covariates:
             click.echo(f"  Covariates: {covariates}")
         if normalize_by_length:
-            click.echo(f"  Normalize by length: Yes")
+            click.echo("  Normalize by length: Yes")
             if gene_lengths:
                 click.echo(f"  Gene lengths file: {gene_lengths}")
             else:
-                click.echo(f"  Gene lengths: using variant site count proxy")
+                click.echo("  Gene lengths: using variant site count proxy")
         if min_carriers > 0:
             click.echo(f"  Min carriers: {min_carriers}")
         if variant_classes:

--- a/hvantk/tools/plugins/drift_cli.py
+++ b/hvantk/tools/plugins/drift_cli.py
@@ -62,8 +62,25 @@ def drift_cmd(dataset, all_flag, domain, as_json, regenerate, timeout):
             if r.diff:
                 click.echo(json.dumps(r.diff, indent=2, default=str))
 
+    # Emit stub WARNINGs to stderr in BOTH human-readable and --json modes.
+    # The scheduled drift workflow captures `drift --all --json` stdout to a
+    # file (.github/workflows/drift.yml), so a WARNING confined to the
+    # human-readable path would never surface in CI logs — re-hiding doc-only
+    # stubs. stderr keeps machine-readable stdout clean while CI logs stay
+    # visibly non-green.
+    for r in results:
+        if r.status == "stub":
+            reason = (r.observed or {}).get("reason", "no programmatic source")
+            click.echo(
+                f"WARNING: {r.dataset_name}: stub probe — {reason}; "
+                "no real drift detection (documentation-only source).",
+                err=True,
+            )
+
     # Priority: probe_failed(2) > drifted(1) > clean(0). Infra failure trumps
     # drift because drifted output is only meaningful if the probe actually ran.
+    # status="stub" is intentional (doc-only source) → exit clean, but the
+    # WARNING above keeps it from being a silent false-green.
     exit_codes = {EXIT_CLEAN}
     for r in results:
         if r.status == "drifted":

--- a/hvantk/tools/plugins/plugins_cli.py
+++ b/hvantk/tools/plugins/plugins_cli.py
@@ -82,9 +82,16 @@ def validate_cmd(manifest_path: str):
             catalog_schema = json.loads(
                 (Path(plugin_loader.__file__).parent / "catalog_entry.schema.json").read_text()
             )
+        except (OSError, json.JSONDecodeError) as exc:
+            raise click.ClickException(
+                f"failed to read bundled catalog schema: {exc}"
+            ) from exc
+        try:
             entries = json.loads(catalog_path.read_text())
         except (OSError, json.JSONDecodeError) as exc:
-            raise click.ClickException(f"failed to read catalog {catalog_path}: {exc}")
+            raise click.ClickException(
+                f"failed to read catalog {catalog_path}: {exc}"
+            ) from exc
         if not isinstance(entries, list):
             raise click.ClickException(f"catalog must be a JSON array: {catalog_path}")
         errors: list[str] = []


### PR DESCRIPTION
This pull request introduces robust support for documentation-only ("stub") datasets in the drift detection pipeline. It standardizes the handling and reporting of sources that lack programmatically accessible data, ensuring they are surfaced as visible warnings rather than producing misleading results. Additionally, the pull request improves deduplication logic in gene set burden calculations and makes minor catalog corrections.

**Drift detection improvements:**

* Added a new `status="stub"` for datasets with no programmatic probe, updating the drift pipeline and reporting to handle these as surfaced warnings rather than silent successes or failures. This includes a new `handle_stub` function, updates to CLI summary output, and changes to the drift runner logic to recognize and propagate stub status. (`.github/scripts/drift_to_pr.py`, `hvantk/core/plugin/drift_runner.py`) [[1]](diffhunk://#diff-13fbd137e9abdbc60cfdf693b138638f3fad47e91703da3f8400dbe051c8dd06L14-R14) [[2]](diffhunk://#diff-13fbd137e9abdbc60cfdf693b138638f3fad47e91703da3f8400dbe051c8dd06L35-R38) [[3]](diffhunk://#diff-13fbd137e9abdbc60cfdf693b138638f3fad47e91703da3f8400dbe051c8dd06R372-R391) [[4]](diffhunk://#diff-13fbd137e9abdbc60cfdf693b138638f3fad47e91703da3f8400dbe051c8dd06R453-R457) [[5]](diffhunk://#diff-13fbd137e9abdbc60cfdf693b138638f3fad47e91703da3f8400dbe051c8dd06R485-R487) [[6]](diffhunk://#diff-0d2e80da2078d9556b9a559cc30b82309491d9fd276eb6b5d5d47e002386b9eaL13-R24) [[7]](diffhunk://#diff-0d2e80da2078d9556b9a559cc30b82309491d9fd276eb6b5d5d47e002386b9eaL38-R81)
* Introduced a standardized API for stub fingerprints (`stub_fingerprint`, `PROBE_STATUS_STUB`, `STUB_FINGERPRINT_TOKEN`) to be used by drift probes that cannot programmatically fingerprint their source. (`hvantk/core/plugin/api.py`)
* Updated all stub drift probes (e.g., `alphagenome`, `cosmic_cgc`, `dbnsfp`, `ensembl_gene`, `gevir`) to use the new `stub_fingerprint` helper and provide clear reasons for stub status. (`hvantk/skills/alphagenome/drift_probe.py`, `hvantk/skills/cosmic_cgc/drift_probe.py`, `hvantk/skills/dbnsfp/drift_probe.py`, `hvantk/skills/ensembl_gene/drift_probe.py`, `hvantk/skills/gevir/drift_probe.py`) [[1]](diffhunk://#diff-801ffdcb8cfbe9d8064f2de7dcddf72fe1e60a6417e86ea1560d56e808ead3acL1-R20) [[2]](diffhunk://#diff-dc28f2135516712e7920fee91ac5643ec181e9b7c0332fecabc09f3a07b3054dL1-R20) [[3]](diffhunk://#diff-400d78063c47814dc6c07ae68d65360eb5d1c4debbf34b17cdc4936cc37765a6L1-R20) [[4]](diffhunk://#diff-807360dbe8cc3b29915bb8ae688fc08c0c1effc69d134c7a5ac8ba4b1b5222f3L1-R20) [[5]](diffhunk://#diff-415317cc7f3107ce29c72c71f1d48435e0e2892201a4d73e95d59003515f88f8L1-R20)

**Gene set burden calculation improvements:**

* Improved deduplication of gene lists within gene sets to ensure accurate burden calculations and consistent reporting, regardless of input order or duplicates. (`hvantk/algorithms/enrichex/burden.py`) [[1]](diffhunk://#diff-cf3b77c988ae9d37b64890469e6a322ea60d69a89a1eb939fe81e45468d084f5L284-R288) [[2]](diffhunk://#diff-cf3b77c988ae9d37b64890469e6a322ea60d69a89a1eb939fe81e45468d084f5R401-R410)

**Data catalog corrections:**

* Updated the `data_source` field in several dataset catalogs to reflect the actual upstream source instead of "Custom" and fixed a file format typo from `"gff"` to `"gff3"`. (`hvantk/skills/clingen/catalog/datasets.json`, `hvantk/skills/clinvar/catalog/datasets.json`, `hvantk/skills/dbnsfp/catalog/datasets.json`, `hvantk/skills/ensembl_gene/catalog/datasets.json`, `hvantk/skills/gevir/catalog/datasets.json`) [[1]](diffhunk://#diff-6bd6c7e79286df58cfb69b8ce0bb2def147a590f1ecd86c1cede17cf347da471L7-R7) [[2]](diffhunk://#diff-647bade04185c09b3cf7b337614a538a2325a3e198e595a3b6d036121e70c5b3L7-R7) [[3]](diffhunk://#diff-ee7159cfba74aeff0d0f9f47aee30a26d10c7fc7e29c3a6254f93ba291bf2266L7-R7) [[4]](diffhunk://#diff-1dfe7bc29a247c92e7ee468a524e9a5e1c2f57272c225147589df369ecc9c0feL7-R7) [[5]](diffhunk://#diff-e9f6d459a259589d8053e70fe785ef15125046231f93a307b0cd2bd417cd8e85L7-R7) [[6]](diffhunk://#diff-1dfe7bc29a247c92e7ee468a524e9a5e1c2f57272c225147589df369ecc9c0feL38-R38)

**Reporting improvements:**

* Improved summary markdown rendering for QC reports to use scientific notation for very small values, preventing them from being displayed as "0.000". (`hvantk/algorithms/hgc/qc_report.py`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a formal "stub" status for documentation-only datasets and CLI warnings for stub results; drift results now include richer context (observed/expected/diff/errors).

* **Bug Fixes**
  * Deduplicated genes within gene-sets to prevent double-counting.
  * Improved numeric formatting in QC reports.
  * Clearer catalog validation error messages.

* **Documentation**
  * Updated dataset source metadata across multiple catalogs.

* **Tests**
  * Added tests for gene-set deduplication and stub probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->