### PR TITLE
docs(qtlcascade): document gwas-coloc + AF→MYOZ1 worked example

### DIFF
--- a/docs_site/examples/qtlcascade.md
+++ b/docs_site/examples/qtlcascade.md
@@ -184,6 +184,106 @@ hvantk qtlcascade coloc \
   -o coloc_results.tsv
 ```
 
+## GWAS → Effector Colocalization (`gwas-coloc`)
+
+`hvantk qtlcascade gwas-coloc` colocalizes a **GWAS** locus against cis-**eQTL** to rank the likely
+effector gene(s), then (by default) confirms the lead effector with **SuSiE-RSS + `coloc.susie`**
+fine-mapping. All summary statistics stream via **remote tabix** — no bulk downloads.
+
+The fine-mapping step is what separates a genuine colocalization (`CONFIRMED`) from a
+single-variant-ABF artifact (`REFUTED`). The example below shows both, anchored on a
+literature-supported positive control.
+
+### Positive control — atrial fibrillation → MYOZ1 (CONFIRMED)
+
+`MYOZ1` (10q22) is a known cardiac effector for atrial fibrillation. Confirm it end-to-end
+(FinnGen `I9_AF` × GTEx heart atrial-appendage eQTL `QTD000251`):
+
+```bash
+hvantk qtlcascade gwas-coloc \
+  --endpoint I9_AF --chrom 10 --lead 73600000 \
+  --eqtl QTD000251 \
+  --gene ENSG00000177791 \
+  --gwas-n 261395 --eqtl-n 372 \
+  -o results/myoz1
+```
+
+Expected output (values are illustrative; remote data may shift slightly between releases):
+
+```text
+Region chr10:73100000-74100000  |  GWAS min-p 2.7e-14  |  51 genes tested
+Top effector: ENSG00000177791 (PP4=0.812)
+Fine-map: credible sets GWAS=1 eQTL=1; coloc.susie PP4=0.712
+VERDICT: CONFIRMED (ABF + fine-mapping agree)
+Report: results/myoz1/report_I9_AF_10_73600000.json
+```
+
+> `ENSG00000177791` is `MYOZ1`. The tool reports Ensembl gene IDs; HGNC symbol mapping is a planned
+> enhancement.
+
+### Fast tier — ABF only (no external tools)
+
+The ABF ranking is pure-Python (only the core deps). Skip fine-mapping with `--no-fine-map`
+(then `--gwas-n`/`--eqtl-n` are not required):
+
+```bash
+hvantk qtlcascade gwas-coloc \
+  --endpoint I9_AF --chrom 10 --lead 73600000 \
+  --eqtl QTD000251 --no-fine-map \
+  -o results/myoz1_abf
+# Top effector: ENSG00000177791 (PP4=0.812)
+# VERDICT: SUGGESTIVE (ABF only; fine-mapping not run)
+```
+
+### Contrast — a CHD locus that does NOT survive fine-mapping (REFUTED)
+
+The septal-defect 17q21 locus has an *identical-looking* ABF signal (PP4 ≈ 0.81 for `NSF`) that
+**fails** fine-mapping — neither trait yields a credible set, so the ABF hit is a single-variant
+artifact:
+
+```bash
+hvantk qtlcascade gwas-coloc \
+  --endpoint Q17_SEPTA_DEFEC --chrom 17 --lead 46890164 \
+  --eqtl QTD000136 \
+  --gene ENSG00000073969 \
+  --gwas-n 412181 --eqtl-n 213 \
+  -o results/nsf_17q21
+# Top effector: ENSG00000073969 (PP4=0.81)
+# Fine-map: credible sets GWAS=0 eQTL=0; coloc.susie PP4=0.0
+# VERDICT: REFUTED (no fine-mappable signal — single-variant-ABF artifact)
+```
+
+This `CONFIRMED`-vs-`REFUTED` contrast is why the fine-mapping layer matters: single-variant ABF
+over-calls when a strong GWAS meets a weak eQTL.
+
+### Prerequisites
+
+| Tier | Requirements |
+|------|--------------|
+| ABF only (`--no-fine-map`) | core hvantk deps (pysam, numpy, pandas) + network |
+| Fine-mapping (default) | additionally `R` with `susieR` + `coloc`, plus `bcftools` and `curl`; downloads a 1000G GRCh38 EUR LD reference (cached under `--ld-cache-dir`) |
+
+Data sources (all remote, no downloads): FinnGen R10 GWAS, eQTL Catalogue (GTEx) cis-eQTL, and
+1000 Genomes high-coverage GRCh38 for the LD reference.
+
+### Python API
+
+```python
+from hvantk.algorithms.qtlcascade.gwas_pipeline import (
+    GwasColocConfig, run_gwas_coloc_pipeline,
+)
+
+config = GwasColocConfig(
+    endpoint="I9_AF", chrom="10", lead=73600000,
+    eqtl_dataset="QTD000251", gene_of_interest="ENSG00000177791",
+    gwas_N=261395, eqtl_N=372, fine_map=True,
+    output_dir="results/myoz1",
+)
+report = run_gwas_coloc_pipeline(config)
+print(report["verdict"])             # CONFIRMED (ABF + fine-mapping agree)
+print(report["results"]["top_PP4"])  # ~0.81
+```
+
 ## Data Sources
 
 | Source | Type | Format | Reference |
@@ -192,6 +292,9 @@ hvantk qtlcascade coloc \
 | GTEx v8 | eQTL | TSV | GTEx Consortium |
 | eQTLGen | eQTL | TSV | Vosa et al. (2021) |
 | Fang et al. 2025 | pQTL | Space-delimited TSV | Fang et al. (2025) |
+| FinnGen R10 | GWAS | Remote-tabix (bgzip+tbi) | FinnGen (2023) |
+| eQTL Catalogue (GTEx) | cis-eQTL | Remote-tabix (bgzip+tbi) | Kerimov et al. (2021) |
+| 1000 Genomes (GRCh38) | LD reference | VCF (remote-tabix) | 1000G / NYGC (2020) |
 
 See [Data Sources](../guide/data-sources.md#qtl-data) for download instructions.
 

--- a/docs_site/examples/qtlcascade.md
+++ b/docs_site/examples/qtlcascade.md
@@ -261,7 +261,7 @@ over-calls when a strong GWAS meets a weak eQTL.
 | Tier | Requirements |
 |------|--------------|
 | ABF only (`--no-fine-map`) | core hvantk deps (pysam, numpy, pandas) + network |
-| Fine-mapping (default) | additionally `R` with `susieR` + `coloc`, plus `bcftools` and `curl`; downloads a 1000G GRCh38 EUR LD reference (cached under `--ld-cache-dir`) |
+| Fine-mapping (default) | additionally `R` with `susieR` + `coloc`, plus `bcftools` and `curl`; downloads a 1000G GRCh38 LD reference for the chosen `--superpop` (default `EUR`), cached under `--ld-cache-dir` (default: `$HVANTK_LD_CACHE`, else `~/.cache/hvantk/1kg`) |
 
 Data sources (all remote, no downloads): FinnGen R10 GWAS, eQTL Catalogue (GTEx) cis-eQTL, and
 1000 Genomes high-coverage GRCh38 for the LD reference.

--- a/docs_site/tools/qtlcascade.md
+++ b/docs_site/tools/qtlcascade.md
@@ -186,7 +186,7 @@ A complementary workflow to the eQTL × pQTL cascade above. Instead of joining t
 - **GWAS source** — a FinnGen R10 endpoint (remote-tabix; no download).
 - **eQTL source** — an eQTL Catalogue dataset, e.g. GTEx `QTD000251` (remote-tabix).
 - **Screen** — ABF with trait-specific priors (W₁ = 0.04 for the case-control GWAS, W₂ = 0.0225 for the quantitative eQTL) ranks every overlapping cis gene by P(H4). Reuses the same validated `compute_log_abf` kernel as the cascade coloc.
-- **Confirmation** (optional, on by default) — SuSiE-RSS fine-maps both traits against a 1000G EUR reference-LD matrix; `coloc.susie` tests for a *shared credible set*. This separates a genuine colocalization from a single-variant-ABF artifact (a strong GWAS leaning on a weak eQTL).
+- **Confirmation** (optional, on by default) — SuSiE-RSS fine-maps both traits against a 1000G reference-LD matrix for a configurable super-population (default `EUR`, via `--superpop`); `coloc.susie` tests for a *shared credible set*. This separates a genuine colocalization from a single-variant-ABF artifact (a strong GWAS leaning on a weak eQTL).
 - **Output** — a provenance-stamped JSON report + a per-gene TSV + a verdict.
 
 ### Verdicts
@@ -195,10 +195,11 @@ A complementary workflow to the eQTL × pQTL cascade above. Instead of joining t
 |---------|---------|
 | `CONFIRMED` | ABF PP4 ≥ threshold **and** `coloc.susie` PP4 ≥ threshold |
 | `REFUTED` | ABF says coloc, but fine-mapping finds no shared credible set (single-variant-ABF artifact) |
-| `SUGGESTIVE` | ABF coloc only (fine-mapping not run, e.g. `--no-fine-map`) |
+| `SUGGESTIVE` | ABF coloc only — fine-mapping skipped (`--no-fine-map`) **or** unavailable (missing `R` / `bcftools` / `curl`) |
+| `INCONCLUSIVE` | Fine-mapping ran but produced no `coloc.susie` PP4 (e.g. too few overlapping variants, or the R step did not complete) |
 | `NO COLOC` | ABF PP4 below threshold, or the gene of interest is absent from the results |
 
-> **Fine-mapping is optional.** It requires `R` (with `susieR` + `coloc`), `bcftools`, and `curl`, plus a 1000G GRCh38 LD reference (auto-downloaded and cached under `--ld-cache-dir`). Without those tools, run `--no-fine-map` for the ABF screen alone. The default verdict threshold is PP4 ≥ 0.5 — `coloc.susie` is more conservative than single-variant ABF.
+> **Fine-mapping is optional.** It requires `R` (with `susieR` + `coloc`), `bcftools`, and `curl`, plus a 1000G GRCh38 LD reference that is auto-downloaded and cached under `--ld-cache-dir` (default: `$HVANTK_LD_CACHE`, else `~/.cache/hvantk/1kg`). Without those tools, run `--no-fine-map` for the ABF screen alone. The default verdict threshold is PP4 ≥ 0.5 — `coloc.susie` is more conservative than single-variant ABF.
 
 See the [worked example](../examples/qtlcascade.md#gwas-effector-colocalization-gwas-coloc) — AF → MYOZ1 (CONFIRMED) versus a CHD 17q21/NSF look-alike (REFUTED).
 

--- a/docs_site/tools/qtlcascade.md
+++ b/docs_site/tools/qtlcascade.md
@@ -179,6 +179,29 @@ From Giambartolomei et al. (2014), Table 1:
 | `p12` | 1×10⁻⁵ | P(variant causal for both traits) |
 | `W` | 0.04 | Prior variance on effect size |
 
+## GWAS → Effector Colocalization (`gwas-coloc`)
+
+A complementary workflow to the eQTL × pQTL cascade above. Instead of joining two molecular QTLs, it colocalizes a **GWAS** locus against cis-**eQTL** to nominate the effector gene, then optionally confirms it with **SuSiE-RSS + `coloc.susie`** fine-mapping.
+
+- **GWAS source** — a FinnGen R10 endpoint (remote-tabix; no download).
+- **eQTL source** — an eQTL Catalogue dataset, e.g. GTEx `QTD000251` (remote-tabix).
+- **Screen** — ABF with trait-specific priors (W₁ = 0.04 for the case-control GWAS, W₂ = 0.0225 for the quantitative eQTL) ranks every overlapping cis gene by P(H4). Reuses the same validated `compute_log_abf` kernel as the cascade coloc.
+- **Confirmation** (optional, on by default) — SuSiE-RSS fine-maps both traits against a 1000G EUR reference-LD matrix; `coloc.susie` tests for a *shared credible set*. This separates a genuine colocalization from a single-variant-ABF artifact (a strong GWAS leaning on a weak eQTL).
+- **Output** — a provenance-stamped JSON report + a per-gene TSV + a verdict.
+
+### Verdicts
+
+| Verdict | Meaning |
+|---------|---------|
+| `CONFIRMED` | ABF PP4 ≥ threshold **and** `coloc.susie` PP4 ≥ threshold |
+| `REFUTED` | ABF says coloc, but fine-mapping finds no shared credible set (single-variant-ABF artifact) |
+| `SUGGESTIVE` | ABF coloc only (fine-mapping not run, e.g. `--no-fine-map`) |
+| `NO COLOC` | ABF PP4 below threshold, or the gene of interest is absent from the results |
+
+> **Fine-mapping is optional.** It requires `R` (with `susieR` + `coloc`), `bcftools`, and `curl`, plus a 1000G GRCh38 LD reference (auto-downloaded and cached under `--ld-cache-dir`). Without those tools, run `--no-fine-map` for the ABF screen alone. The default verdict threshold is PP4 ≥ 0.5 — `coloc.susie` is more conservative than single-variant ABF.
+
+See the [worked example](../examples/qtlcascade.md#gwas-effector-colocalization-gwas-coloc) — AF → MYOZ1 (CONFIRMED) versus a CHD 17q21/NSF look-alike (REFUTED).
+
 ## Multi-Tissue Mode
 
 When `--tissues` is provided, the pipeline runs independently per tissue via `run_collection()`, then generates:
@@ -313,6 +336,31 @@ Required:
 Optional:
   --tissue TEXT           Filter allpairs to this tissue
   --window-kb INTEGER     Regional window ±kb [default: 500]
+```
+
+### `hvantk qtlcascade gwas-coloc`
+
+GWAS → effector colocalization (FinnGen × eQTL Catalogue) with optional SuSiE fine-map confirmation.
+
+```text
+hvantk qtlcascade gwas-coloc [OPTIONS]
+
+Required:
+  --endpoint TEXT           FinnGen R10 endpoint code (e.g. I9_AF)
+  --chrom TEXT              Chromosome (GRCh38, no 'chr')
+  --lead INTEGER            Lead variant position (GRCh38)
+  --eqtl TEXT               eQTL Catalogue dataset id / URL / local tabix (e.g. QTD000251)
+  -o, --output-dir TEXT     Output directory
+
+Optional:
+  --eqtl-study TEXT         eQTL Catalogue study id [default: QTS000015]
+  --window-kb INTEGER       Regional window ±kb around the lead [default: 500]
+  --gene TEXT               ENSG to confirm [default: the ABF-top gene]
+  --fine-map/--no-fine-map  Run SuSiE/coloc.susie confirmation [default: fine-map]
+  --gwas-n INTEGER          GWAS sample size (required for fine-mapping)
+  --eqtl-n INTEGER          eQTL sample size (required for fine-mapping)
+  --superpop TEXT           1000G super-population for the LD reference [default: EUR]
+  --ld-cache-dir TEXT       Cache directory for the 1000G LD reference
 ```
 
 ### `hvantk qtlcascade run`
@@ -629,7 +677,12 @@ hvantk/algorithms/qtlcascade/
 ├── gene_summary.py  # Gene-level aggregation + overlays
 ├── pipeline.py      # CascadeConfig, CascadePipeline, CascadeResult
 ├── plot.py          # Visualisations (cascade classes, attenuation, coloc, heatmap)
-└── report.py        # HTML report generation
+├── report.py        # HTML report generation
+├── gwas_coloc.py    # GWAS × eQTL ABF coloc (FinnGen × eQTL Catalogue, remote-tabix)
+├── finemap.py       # Optional SuSiE-RSS + coloc.susie confirmation (1000G EUR LD)
+├── gwas_pipeline.py # GwasColocConfig, run_gwas_coloc_pipeline (+ provenance report)
+└── resources/
+    └── susie_coloc.R  # R worker for SuSiE-RSS + coloc.susie
 ```
 
 ## References


### PR DESCRIPTION
## What

Documents the new `hvantk qtlcascade gwas-coloc` command (merged in #190) and ships the **AF→MYOZ1 positive control** as a reproducible worked example — turning the "evidence it works" from an internal regression test into a public, citable artifact.

## Changes

- **`docs_site/examples/qtlcascade.md`** — new "GWAS → Effector Colocalization" section:
  - **AF → MYOZ1 (CONFIRMED)** — full command + expected output (ABF PP4 ≈ 0.81, coloc.susie PP4 ≈ 0.71).
  - **Fast tier** — ABF-only (`--no-fine-map`, pure-Python, no R/bcftools).
  - **Contrast — CHD 17q21/NSF (REFUTED)** — identical-looking ABF (≈0.81) that fails fine-mapping (single-variant artifact), illustrating *why* the SuSiE layer matters.
  - Prerequisites table (two tiers) + Python API + data-source rows (FinnGen R10 / eQTL Catalogue / 1000G).
- **`docs_site/tools/qtlcascade.md`** — `gwas-coloc` reference: overview, verdict semantics (CONFIRMED / REFUTED / SUGGESTIVE / NO COLOC), optional fine-mapping deps, full CLI reference, and module-structure update (`gwas_coloc` / `finemap` / `gwas_pipeline` + `resources/susie_coloc.R`).

## Validation

- `mkdocs build --strict` passes; the cross-page deep link to the worked example resolves (anchor id verified in the built HTML).
- Commands/options/outputs match the merged CLI and the validated AF→MYOZ1 / 17q21 runs.

Docs-only; no code changes. Opened as a draft for review.
