### PR TITLE
release: dev → main (gwas-coloc, PTM constraint robustness, docs)

### DIFF
--- a/docs_site/examples/qtlcascade.md
+++ b/docs_site/examples/qtlcascade.md
@@ -184,6 +184,106 @@ hvantk qtlcascade coloc \
   -o coloc_results.tsv
 ```
 
+## GWAS → Effector Colocalization (`gwas-coloc`)
+
+`hvantk qtlcascade gwas-coloc` colocalizes a **GWAS** locus against cis-**eQTL** to rank the likely
+effector gene(s), then (by default) confirms the lead effector with **SuSiE-RSS + `coloc.susie`**
+fine-mapping. All summary statistics stream via **remote tabix** — no bulk downloads.
+
+The fine-mapping step is what separates a genuine colocalization (`CONFIRMED`) from a
+single-variant-ABF artifact (`REFUTED`). The example below shows both, anchored on a
+literature-supported positive control.
+
+### Positive control — atrial fibrillation → MYOZ1 (CONFIRMED)
+
+`MYOZ1` (10q22) is a known cardiac effector for atrial fibrillation. Confirm it end-to-end
+(FinnGen `I9_AF` × GTEx heart atrial-appendage eQTL `QTD000251`):
+
+```bash
+hvantk qtlcascade gwas-coloc \
+  --endpoint I9_AF --chrom 10 --lead 73600000 \
+  --eqtl QTD000251 \
+  --gene ENSG00000177791 \
+  --gwas-n 261395 --eqtl-n 372 \
+  -o results/myoz1
+```
+
+Expected output (values are illustrative; remote data may shift slightly between releases):
+
+```text
+Region chr10:73100000-74100000  |  GWAS min-p 2.7e-14  |  51 genes tested
+Top effector: ENSG00000177791 (PP4=0.812)
+Fine-map: credible sets GWAS=1 eQTL=1; coloc.susie PP4=0.712
+VERDICT: CONFIRMED (ABF + fine-mapping agree)
+Report: results/myoz1/report_I9_AF_10_73600000.json
+```
+
+> `ENSG00000177791` is `MYOZ1`. The tool reports Ensembl gene IDs; HGNC symbol mapping is a planned
+> enhancement.
+
+### Fast tier — ABF only (no external tools)
+
+The ABF ranking is pure-Python (only the core deps). Skip fine-mapping with `--no-fine-map`
+(then `--gwas-n`/`--eqtl-n` are not required):
+
+```bash
+hvantk qtlcascade gwas-coloc \
+  --endpoint I9_AF --chrom 10 --lead 73600000 \
+  --eqtl QTD000251 --no-fine-map \
+  -o results/myoz1_abf
+# Top effector: ENSG00000177791 (PP4=0.812)
+# VERDICT: SUGGESTIVE (ABF only; fine-mapping not run)
+```
+
+### Contrast — a CHD locus that does NOT survive fine-mapping (REFUTED)
+
+The septal-defect 17q21 locus has an *identical-looking* ABF signal (PP4 ≈ 0.81 for `NSF`) that
+**fails** fine-mapping — neither trait yields a credible set, so the ABF hit is a single-variant
+artifact:
+
+```bash
+hvantk qtlcascade gwas-coloc \
+  --endpoint Q17_SEPTA_DEFEC --chrom 17 --lead 46890164 \
+  --eqtl QTD000136 \
+  --gene ENSG00000073969 \
+  --gwas-n 412181 --eqtl-n 213 \
+  -o results/nsf_17q21
+# Top effector: ENSG00000073969 (PP4=0.81)
+# Fine-map: credible sets GWAS=0 eQTL=0; coloc.susie PP4=0.0
+# VERDICT: REFUTED (no fine-mappable signal — single-variant-ABF artifact)
+```
+
+This `CONFIRMED`-vs-`REFUTED` contrast is why the fine-mapping layer matters: single-variant ABF
+over-calls when a strong GWAS meets a weak eQTL.
+
+### Prerequisites
+
+| Tier | Requirements |
+|------|--------------|
+| ABF only (`--no-fine-map`) | core hvantk deps (pysam, numpy, pandas) + network |
+| Fine-mapping (default) | additionally `R` with `susieR` + `coloc`, plus `bcftools` and `curl`; downloads a 1000G GRCh38 LD reference for the chosen `--superpop` (default `EUR`), cached under `--ld-cache-dir` (default: `$HVANTK_LD_CACHE`, else `~/.cache/hvantk/1kg`) |
+
+Data sources (all remote, no downloads): FinnGen R10 GWAS, eQTL Catalogue (GTEx) cis-eQTL, and
+1000 Genomes high-coverage GRCh38 for the LD reference.
+
+### Python API
+
+```python
+from hvantk.algorithms.qtlcascade.gwas_pipeline import (
+    GwasColocConfig, run_gwas_coloc_pipeline,
+)
+
+config = GwasColocConfig(
+    endpoint="I9_AF", chrom="10", lead=73600000,
+    eqtl_dataset="QTD000251", gene_of_interest="ENSG00000177791",
+    gwas_N=261395, eqtl_N=372, fine_map=True,
+    output_dir="results/myoz1",
+)
+report = run_gwas_coloc_pipeline(config)
+print(report["verdict"])             # CONFIRMED (ABF + fine-mapping agree)
+print(report["results"]["top_PP4"])  # ~0.81
+```
+
 ## Data Sources
 
 | Source | Type | Format | Reference |
@@ -192,6 +292,9 @@ hvantk qtlcascade coloc \
 | GTEx v8 | eQTL | TSV | GTEx Consortium |
 | eQTLGen | eQTL | TSV | Vosa et al. (2021) |
 | Fang et al. 2025 | pQTL | Space-delimited TSV | Fang et al. (2025) |
+| FinnGen R10 | GWAS | Remote-tabix (bgzip+tbi) | FinnGen (2023) |
+| eQTL Catalogue (GTEx) | cis-eQTL | Remote-tabix (bgzip+tbi) | Kerimov et al. (2021) |
+| 1000 Genomes (GRCh38) | LD reference | VCF (remote-tabix) | 1000G / NYGC (2020) |
 
 See [Data Sources](../guide/data-sources.md#qtl-data) for download instructions.
 

--- a/docs_site/tools/qtlcascade.md
+++ b/docs_site/tools/qtlcascade.md
@@ -179,6 +179,30 @@ From Giambartolomei et al. (2014), Table 1:
 | `p12` | 1×10⁻⁵ | P(variant causal for both traits) |
 | `W` | 0.04 | Prior variance on effect size |
 
+## GWAS → Effector Colocalization (`gwas-coloc`)
+
+A complementary workflow to the eQTL × pQTL cascade above. Instead of joining two molecular QTLs, it colocalizes a **GWAS** locus against cis-**eQTL** to nominate the effector gene, then optionally confirms it with **SuSiE-RSS + `coloc.susie`** fine-mapping.
+
+- **GWAS source** — a FinnGen R10 endpoint (remote-tabix; no download).
+- **eQTL source** — an eQTL Catalogue dataset, e.g. GTEx `QTD000251` (remote-tabix).
+- **Screen** — ABF with trait-specific priors (W₁ = 0.04 for the case-control GWAS, W₂ = 0.0225 for the quantitative eQTL) ranks every overlapping cis gene by P(H4). Reuses the same validated `compute_log_abf` kernel as the cascade coloc.
+- **Confirmation** (optional, on by default) — SuSiE-RSS fine-maps both traits against a 1000G reference-LD matrix for a configurable super-population (default `EUR`, via `--superpop`); `coloc.susie` tests for a *shared credible set*. This separates a genuine colocalization from a single-variant-ABF artifact (a strong GWAS leaning on a weak eQTL).
+- **Output** — a provenance-stamped JSON report + a per-gene TSV + a verdict.
+
+### Verdicts
+
+| Verdict | Meaning |
+|---------|---------|
+| `CONFIRMED` | ABF PP4 ≥ threshold **and** `coloc.susie` PP4 ≥ threshold |
+| `REFUTED` | ABF says coloc, but fine-mapping finds no shared credible set (single-variant-ABF artifact) |
+| `SUGGESTIVE` | ABF coloc only — fine-mapping skipped (`--no-fine-map`) **or** unavailable (missing `R` / `bcftools` / `curl`) |
+| `INCONCLUSIVE` | Fine-mapping ran but produced no `coloc.susie` PP4 (e.g. too few overlapping variants, or the R step did not complete) |
+| `NO COLOC` | ABF PP4 below threshold, or the gene of interest is absent from the results |
+
+> **Fine-mapping is optional.** It requires `R` (with `susieR` + `coloc`), `bcftools`, and `curl`, plus a 1000G GRCh38 LD reference that is auto-downloaded and cached under `--ld-cache-dir` (default: `$HVANTK_LD_CACHE`, else `~/.cache/hvantk/1kg`). Without those tools, run `--no-fine-map` for the ABF screen alone. The default verdict threshold is PP4 ≥ 0.5 — `coloc.susie` is more conservative than single-variant ABF.
+
+See the [worked example](../examples/qtlcascade.md#gwas-effector-colocalization-gwas-coloc) — AF → MYOZ1 (CONFIRMED) versus a CHD 17q21/NSF look-alike (REFUTED).
+
 ## Multi-Tissue Mode
 
 When `--tissues` is provided, the pipeline runs independently per tissue via `run_collection()`, then generates:
@@ -313,6 +337,31 @@ Required:
 Optional:
   --tissue TEXT           Filter allpairs to this tissue
   --window-kb INTEGER     Regional window ±kb [default: 500]
+```
+
+### `hvantk qtlcascade gwas-coloc`
+
+GWAS → effector colocalization (FinnGen × eQTL Catalogue) with optional SuSiE fine-map confirmation.
+
+```text
+hvantk qtlcascade gwas-coloc [OPTIONS]
+
+Required:
+  --endpoint TEXT           FinnGen R10 endpoint code (e.g. I9_AF)
+  --chrom TEXT              Chromosome (GRCh38, no 'chr')
+  --lead INTEGER            Lead variant position (GRCh38)
+  --eqtl TEXT               eQTL Catalogue dataset id / URL / local tabix (e.g. QTD000251)
+  -o, --output-dir TEXT     Output directory
+
+Optional:
+  --eqtl-study TEXT         eQTL Catalogue study id [default: QTS000015]
+  --window-kb INTEGER       Regional window ±kb around the lead [default: 500]
+  --gene TEXT               ENSG to confirm [default: the ABF-top gene]
+  --fine-map/--no-fine-map  Run SuSiE/coloc.susie confirmation [default: fine-map]
+  --gwas-n INTEGER          GWAS sample size (required for fine-mapping)
+  --eqtl-n INTEGER          eQTL sample size (required for fine-mapping)
+  --superpop TEXT           1000G super-population for the LD reference [default: EUR]
+  --ld-cache-dir TEXT       Cache directory for the 1000G LD reference
 ```
 
 ### `hvantk qtlcascade run`
@@ -629,7 +678,12 @@ hvantk/algorithms/qtlcascade/
 ├── gene_summary.py  # Gene-level aggregation + overlays
 ├── pipeline.py      # CascadeConfig, CascadePipeline, CascadeResult
 ├── plot.py          # Visualisations (cascade classes, attenuation, coloc, heatmap)
-└── report.py        # HTML report generation
+├── report.py        # HTML report generation
+├── gwas_coloc.py    # GWAS × eQTL ABF coloc (FinnGen × eQTL Catalogue, remote-tabix)
+├── finemap.py       # Optional SuSiE-RSS + coloc.susie confirmation (1000G EUR LD)
+├── gwas_pipeline.py # GwasColocConfig, run_gwas_coloc_pipeline (+ provenance report)
+└── resources/
+    └── susie_coloc.R  # R worker for SuSiE-RSS + coloc.susie
 ```
 
 ## References

--- a/docs_site/tools/qtlcascade.md
+++ b/docs_site/tools/qtlcascade.md
@@ -680,7 +680,7 @@ hvantk/algorithms/qtlcascade/
 ├── plot.py          # Visualisations (cascade classes, attenuation, coloc, heatmap)
 ├── report.py        # HTML report generation
 ├── gwas_coloc.py    # GWAS × eQTL ABF coloc (FinnGen × eQTL Catalogue, remote-tabix)
-├── finemap.py       # Optional SuSiE-RSS + coloc.susie confirmation (1000G EUR LD)
+├── finemap.py       # Optional SuSiE-RSS + coloc.susie confirmation (1000G LD; configurable --superpop)
 ├── gwas_pipeline.py # GwasColocConfig, run_gwas_coloc_pipeline (+ provenance report)
 └── resources/
     └── susie_coloc.R  # R worker for SuSiE-RSS + coloc.susie

--- a/hvantk/algorithms/ptm/constraint.py
+++ b/hvantk/algorithms/ptm/constraint.py
@@ -59,11 +59,13 @@ class PTMConstraintConfig:
     loeuf_field: str = "loeuf"
     ptm_category_field: str = "ptm_types"
     gene_id_mapping: Optional[str] = None
+    group_mapping: Optional[str] = None
     expression_metric: str = "median"
     min_cells_per_group: int = 50
     min_variants_per_group: int = 20
     flanking_codons: int = 7
     expressed_threshold: float = 1.0
+    af_observed_only: bool = True
     overwrite: bool = False
 
     def validate(self) -> List[str]:
@@ -87,6 +89,10 @@ class PTMConstraintConfig:
         if self.gene_id_mapping and not os.path.exists(self.gene_id_mapping):
             errors.append(
                 f"--gene-id-mapping does not exist: {self.gene_id_mapping}"
+            )
+        if self.group_mapping and not os.path.exists(self.group_mapping):
+            errors.append(
+                f"--group-mapping does not exist: {self.group_mapping}"
             )
         if self.min_cells_per_group < 0:
             errors.append("--min-cells-per-group must be >= 0.")
@@ -162,10 +168,12 @@ def run_ptm_constraint(config: PTMConstraintConfig) -> PTMConstraintResult:
     )
 
     gene_id_map = _load_gene_id_map(config.gene_id_mapping)
+    group_map = _load_group_map(config.group_mapping)
     gene_features = _compute_gene_features(
         expr_wide,
         expressed_threshold=config.expressed_threshold,
         gene_id_map=gene_id_map,
+        group_map=group_map,
     )
 
     merged = _join_and_filter(variants_df, gene_features, config)
@@ -237,7 +245,28 @@ def _json_default(obj: Any) -> Any:
 
 
 def _load_variants(config: PTMConstraintConfig) -> pd.DataFrame:
-    """Load the PTM-annotated variant HT into pandas, keeping the needed columns."""
+    """Load the PTM-annotated variant table into pandas, keeping needed columns.
+
+    Accepts either a Hail Table (a directory path, e.g. produced by
+    ``hvantk ptm annotate``) or a tabular file (.pkl/.parquet/.csv/.tsv, each
+    optionally gzip/bgz-compressed). Both routes yield the same normalised
+    columns: is_ptm_site, is_ptm_proximal, ptm_any, gene_key, af, loeuf, label,
+    ptm_categories.
+    """
+    if _is_hail_table_path(config.variants_ht_path):
+        df = _load_variants_hail(config)
+    else:
+        df = _load_variants_tabular(config)
+    return _finalize_variants_df(df)
+
+
+def _is_hail_table_path(path: str) -> bool:
+    """A Hail Table is a directory on disk; tabular inputs are files."""
+    return os.path.isdir(path) or str(path).rstrip("/").endswith(".ht")
+
+
+def _load_variants_hail(config: PTMConstraintConfig) -> pd.DataFrame:
+    """Load + label-filter a PTM-annotated variant Hail Table into pandas."""
     from hvantk.core.utils.hail_context import hl, init_hail
 
     init_hail()
@@ -266,6 +295,13 @@ def _load_variants(config: PTMConstraintConfig) -> pd.DataFrame:
 
     if config.af_field in row_fields:
         select["af"] = ht[config.af_field]
+    elif config.af_observed_only:
+        raise ValueError(
+            f"AF field '{config.af_field}' is absent from the variants HT, but "
+            "--af-observed-only (default) restricts to gnomAD AF > 0 and would "
+            "drop every variant. Pass --include-zero-af to disable the filter or "
+            "supply the correct --af-field."
+        )
     else:
         logger.warning(
             "AF field '%s' not found; filling with zeros.", config.af_field
@@ -300,15 +336,107 @@ def _load_variants(config: PTMConstraintConfig) -> pd.DataFrame:
                 "correct --label-field."
             )
 
-    df = ht.to_pandas()
+    return ht.to_pandas()
 
+
+def _load_variants_tabular(config: PTMConstraintConfig) -> pd.DataFrame:
+    """Load + label-filter a PTM-annotated variant table from a tabular file.
+
+    Recognised extensions: .pkl/.pickle, .parquet, .csv, .tsv/.tab (each
+    optionally .gz/.bgz). ``is_ptm_proximal`` is required; ``is_ptm_site``
+    defaults to False when absent. Gene/AF/LOEUF/label/category columns are read
+    from the configured field names, with safe fallbacks.
+    """
+    raw = _read_variants_tabular_file(config.variants_ht_path)
+    cols = set(raw.columns)
+
+    if "is_ptm_proximal" not in cols:
+        raise KeyError(
+            "Variant table missing required 'is_ptm_proximal' column. "
+            f"Available columns: {sorted(cols)[:30]}"
+        )
+    if config.gene_field not in cols:
+        raise KeyError(
+            f"Gene field '{config.gene_field}' not in variant table. "
+            f"Available columns: {sorted(cols)[:30]}"
+        )
+
+    out = pd.DataFrame(index=raw.index)
+    out["is_ptm_proximal"] = raw["is_ptm_proximal"]
+    out["is_ptm_site"] = raw["is_ptm_site"] if "is_ptm_site" in cols else False
+    out["gene_key"] = raw[config.gene_field]
+
+    if config.af_field in cols:
+        out["af"] = raw[config.af_field]
+    elif config.af_observed_only:
+        raise ValueError(
+            f"AF field '{config.af_field}' is absent from the variant table, but "
+            "--af-observed-only (default) restricts to gnomAD AF > 0 and would "
+            "drop every variant. Pass --include-zero-af to disable the filter or "
+            "supply the correct --af-field."
+        )
+    else:
+        logger.warning("AF field '%s' not found; filling with zeros.", config.af_field)
+        out["af"] = 0.0
+
+    out["loeuf"] = raw[config.loeuf_field] if config.loeuf_field in cols else np.nan
+    out["label"] = raw[config.label_field] if config.label_field in cols else None
+    out["ptm_categories"] = (
+        raw[config.ptm_category_field] if config.ptm_category_field in cols else None
+    )
+
+    if config.label_filter != "all":
+        if config.label_field in cols:
+            out = out[out["label"] == config.label_filter].copy()
+        else:
+            raise ValueError(
+                f"--label-filter '{config.label_filter}' requested but label "
+                f"field '{config.label_field}' is absent from the variant table. "
+                "Pass --label-filter all to disable filtering or supply the "
+                "correct --label-field."
+            )
+
+    return out
+
+
+def _read_variants_tabular_file(path: str) -> pd.DataFrame:
+    """Read a variant table from pickle/parquet/CSV/TSV (gzip/bgz transparent)."""
+    from pathlib import Path
+
+    suffixes = [s.lower() for s in Path(path).suffixes]
+    if ".pkl" in suffixes or ".pickle" in suffixes:
+        return pd.read_pickle(path)
+    if ".parquet" in suffixes:
+        return pd.read_parquet(path)
+    # pandas does not infer ".bgz"; map it (and .gz) to gzip explicitly. BGZF is a
+    # valid multi-member gzip stream, so the gzip codec reads it transparently.
+    comp_map = {".gz": "gzip", ".bgz": "gzip", ".bz2": "bz2"}
+    compression = next(
+        (comp_map[s] for s in reversed(suffixes) if s in comp_map), "infer"
+    )
+    base = next((s for s in reversed(suffixes) if s not in comp_map), "")
+    sep = "," if base == ".csv" else "\t"
+    return pd.read_csv(path, sep=sep, low_memory=False, compression=compression)
+
+
+def _finalize_variants_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise dtypes shared by the Hail and tabular variant loaders."""
+    df = df.copy()
     df["is_ptm_site"] = df["is_ptm_site"].fillna(False).astype(bool)
     df["is_ptm_proximal"] = df["is_ptm_proximal"].fillna(False).astype(bool)
     df["ptm_any"] = df["is_ptm_site"] | df["is_ptm_proximal"]
-    df["af"] = pd.to_numeric(df["af"], errors="coerce").fillna(0.0)
+    af_numeric = pd.to_numeric(df["af"], errors="coerce")
+    n_missing_af = int(af_numeric.isna().sum())
+    if n_missing_af:
+        logger.warning(
+            "%d variant(s) have missing/non-numeric AF coerced to 0.0; under "
+            "--af-observed-only these are dropped and become indistinguishable "
+            "from gnomAD-absent variants. Check the AF field if unexpected.",
+            n_missing_af,
+        )
+    df["af"] = af_numeric.fillna(0.0)
     df["loeuf"] = pd.to_numeric(df["loeuf"], errors="coerce")
     df["gene_key"] = df["gene_key"].astype(str).str.replace(r"\.\d+$", "", regex=True)
-
     return df
 
 
@@ -324,10 +452,31 @@ def _load_gene_id_map(path: Optional[str]) -> Optional[Dict[str, str]]:
     return dict(zip(df[src].astype(str), df[dst].astype(str)))
 
 
+def _load_group_map(path: Optional[str]) -> Optional[Dict[str, str]]:
+    """Load a two-column TSV mapping raw expression-group labels to analysis groups.
+
+    Used to collapse fine-grained expression columns (e.g. 53 GTEx tissues) into
+    broader analysis categories (e.g. 12 organ systems) for the per-group ranking.
+    The mapping is applied to each gene's primary (argmax) group, so τ and the
+    expressed flag remain computed on the full-resolution expression profile. The
+    first column is the raw label, the second the analysis group.
+    """
+    if path is None:
+        return None
+    df = pd.read_csv(path, sep="\t")
+    if df.shape[1] < 2:
+        raise ValueError(
+            "Group mapping TSV needs at least two columns (raw_label, analysis_group)."
+        )
+    src, dst = df.columns[0], df.columns[1]
+    return dict(zip(df[src].astype(str), df[dst].astype(str)))
+
+
 def _compute_gene_features(
     expr_wide: pd.DataFrame,
     expressed_threshold: float,
     gene_id_map: Optional[Dict[str, str]],
+    group_map: Optional[Dict[str, str]] = None,
 ) -> pd.DataFrame:
     """Produce per-gene τ, primary_group, and max-expression flag."""
     index = expr_wide.index.astype(str).str.replace(r"\.\d+$", "", regex=True)
@@ -343,6 +492,8 @@ def _compute_gene_features(
     tau = compute_specificity(expr_wide, method="tau")
 
     primary_group = expr_wide.idxmax(axis=1)
+    if group_map is not None:
+        primary_group = primary_group.map(lambda g: group_map.get(str(g), str(g)))
     max_expr = expr_wide.max(axis=1)
 
     features = pd.DataFrame(
@@ -380,6 +531,20 @@ def _join_and_filter(
             f"(threshold={config.expressed_threshold})."
         )
 
+    if config.af_observed_only:
+        n_before = len(merged)
+        merged = merged[merged["af"] > 0].copy()
+        logger.info(
+            "AF-observed-only: kept %d/%d variants with gnomAD AF > 0.",
+            len(merged),
+            n_before,
+        )
+        if len(merged) == 0:
+            raise ValueError(
+                "No variants remain after restricting to gnomAD AF > 0. "
+                "Pass --include-zero-af to keep unobserved variants."
+            )
+
     return merged
 
 
@@ -397,12 +562,28 @@ def _mw_log2_ratio(
     mean_ptm = float(np.mean(afs_ptm)) if n_ptm else np.nan
     mean_non = float(np.mean(afs_non)) if n_non else np.nan
 
-    ratio = (
-        (mean_non + pseudocount) / (mean_ptm + pseudocount)
-        if n_ptm and n_non
+    # Effect size is reported on MEDIANS, consistent with the rank-based
+    # Mann-Whitney U test below. Mean AF ratios are dominated by heavy-tailed
+    # outliers and can invert the ranking at small n (e.g. a 14-variant group
+    # outranking heart), so the median ratio is the headline and the mean ratio
+    # is retained as a secondary column for transparency.
+    have_both = bool(n_ptm and n_non)
+    median_ratio = (
+        (med_non + pseudocount) / (med_ptm + pseudocount) if have_both else np.nan
+    )
+    mean_ratio = (
+        (mean_non + pseudocount) / (mean_ptm + pseudocount) if have_both else np.nan
+    )
+    log2_ratio = (
+        float(np.log2(median_ratio))
+        if np.isfinite(median_ratio) and median_ratio > 0
         else np.nan
     )
-    log2_ratio = float(np.log2(ratio)) if np.isfinite(ratio) and ratio > 0 else np.nan
+    log2_mean_ratio = (
+        float(np.log2(mean_ratio))
+        if np.isfinite(mean_ratio) and mean_ratio > 0
+        else np.nan
+    )
 
     pvalue = np.nan
     if n_ptm >= 3 and n_non >= 3:
@@ -421,8 +602,10 @@ def _mw_log2_ratio(
         "med_non": med_non,
         "mean_ptm": mean_ptm,
         "mean_non": mean_non,
-        "ratio": float(ratio) if np.isfinite(ratio) else np.nan,
+        "ratio": float(median_ratio) if np.isfinite(median_ratio) else np.nan,
         "log2_ratio": log2_ratio,
+        "mean_ratio": float(mean_ratio) if np.isfinite(mean_ratio) else np.nan,
+        "log2_mean_ratio": log2_mean_ratio,
         "p_value": pvalue,
     }
 

--- a/hvantk/algorithms/ptm/constraint.py
+++ b/hvantk/algorithms/ptm/constraint.py
@@ -10,9 +10,11 @@ PTM flags use :func:`hvantk.ptm.annotate.annotate_variants_with_ptm`.
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import os
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -405,6 +407,12 @@ def _read_variants_tabular_file(path: str) -> pd.DataFrame:
 
     suffixes = [s.lower() for s in Path(path).suffixes]
     if ".pkl" in suffixes or ".pickle" in suffixes:
+        # Pickle deserialization executes arbitrary code — only load files you
+        # produced or trust. Prefer .parquet/.tsv for untrusted sources.
+        logger.warning(
+            "Loading pickle '%s'; unpickling runs arbitrary code — only use "
+            "trusted files (prefer .parquet/.csv/.tsv otherwise).", path
+        )
         return pd.read_pickle(path)
     if ".parquet" in suffixes:
         return pd.read_parquet(path)
@@ -708,13 +716,34 @@ def _test_loeuf_group_factorial(
 
 
 def _normalise_category(raw: Any) -> List[str]:
-    """Explode a set/list/string of PTM categories into lowercase tokens."""
-    if raw is None:
+    """Explode a set/list/string of PTM categories into lowercase tokens.
+
+    Hail inputs arrive as a real collection; tabular (CSV/TSV) inputs arrive as
+    a *string* rendering of one, e.g. ``"{'phospho', 'ac'}"``, ``"['phospho']"``,
+    ``"frozenset({'phospho'})"`` or a delimited list ``"phospho;ac"``. Parse
+    those so each category is counted separately rather than as one token.
+    """
+    if raw is None or (isinstance(raw, float) and pd.isna(raw)):
         return []
     if isinstance(raw, (set, frozenset, list, tuple, np.ndarray)):
         cats = [str(x).lower() for x in raw if x is not None]
     else:
-        cats = [str(raw).lower()]
+        s = str(raw).strip()
+        if not s:
+            return ["other"]
+        parsed: Optional[List[str]] = None
+        m = re.search(r"[\[\{\(].*[\]\}\)]", s)  # a collection literal anywhere in s
+        if m:
+            try:
+                val = ast.literal_eval(m.group(0))
+                if isinstance(val, (set, frozenset, list, tuple)):
+                    parsed = [str(x).lower() for x in val if x is not None]
+            except (ValueError, SyntaxError):
+                inner = m.group(0)[1:-1]
+                parsed = [t.strip().strip("'\"").lower() for t in inner.split(",")]
+        if parsed is None:
+            parsed = [t.strip().lower() for t in re.split(r"[;,|]", s)]
+        cats = [c for c in parsed if c]
     return cats or ["other"]
 
 

--- a/hvantk/algorithms/qtlcascade/constants.py
+++ b/hvantk/algorithms/qtlcascade/constants.py
@@ -54,3 +54,47 @@ DEFAULT_COLOC_H4_THRESHOLD = 0.8
 
 # Regional window for coloc (±kb from lead variant)
 DEFAULT_COLOC_WINDOW_KB = 500
+
+# ---------------------------------------------------------------------------
+# GWAS × eQTL colocalization (gwas_coloc.py)
+# ---------------------------------------------------------------------------
+# Trait-specific prior effect-size variances W (Wakefield 2009). coloc's
+# conventional defaults: case-control GWAS sd(logOR)=0.2 -> W=0.04;
+# quantitative cis-eQTL sd=0.15 -> W=0.0225.
+DEFAULT_GWAS_W_CC = 0.04
+DEFAULT_EQTL_W_QUANT = 0.0225
+
+# Minimum shared variants in a region for a gene to be coloc-tested.
+DEFAULT_COLOC_MIN_SNPS = 20
+
+# Public summary-statistic sources (remote-tabix; no bulk download).
+# FinnGen R10 GWAS: contig has no 'chr'; cols chrom pos ref alt rsids
+#   nearest_genes pval mlogp beta sebeta af*.
+FINNGEN_R10_SUMSTATS_URL = (
+    "https://storage.googleapis.com/finngen-public-data-r10/"
+    "summary_stats/finngen_R10_{endpoint}.gz"
+)
+# eQTL Catalogue cis-eQTL all-variant sumstats; cols gene_id chrom pos ref alt
+#   variant ma_samples maf pvalue beta se. Default study QTS000015 = GTEx.
+EQTL_CATALOGUE_SUMSTATS_URL = (
+    "https://ftp.ebi.ac.uk/pub/databases/spot/eQTL/sumstats/"
+    "{study}/{dataset}/{dataset}.all.tsv.gz"
+)
+EQTL_CATALOGUE_DEFAULT_STUDY = "QTS000015"
+
+# ---------------------------------------------------------------------------
+# Fine-mapping LD reference (finemap.py) — 1000 Genomes high-coverage GRCh38.
+# Used to build a EUR LD matrix for SuSiE-RSS + coloc.susie. Optional layer.
+# ---------------------------------------------------------------------------
+KG_PHASED_VCF_URL = (
+    "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/"
+    "1000G_2504_high_coverage/working/20201028_3202_phased/"
+    "CCDG_14151_B01_GRM_WGS_2020-08-05_chr{chrom}."
+    "filtered.shapeit2-duohmm-phased.vcf.gz"
+)
+KG_PANEL_URL = (
+    "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/"
+    "1000G_2504_high_coverage/20130606_g1k_3202_samples_ped_population.txt"
+)
+# Default fine-map super-population for the LD reference.
+DEFAULT_FINEMAP_SUPERPOP = "EUR"

--- a/hvantk/algorithms/qtlcascade/finemap.py
+++ b/hvantk/algorithms/qtlcascade/finemap.py
@@ -2,9 +2,9 @@
 
 The single-variant ABF in :mod:`gwas_coloc` is fast but can over-call when a
 strong GWAS meets a weak eQTL. This module fine-maps both traits with SuSiE-RSS
-(using a 1000G EUR reference-LD matrix) and runs ``coloc.susie`` to test for a
-**shared credible set** — separating genuine colocalization from single-variant
-artifacts.
+(using a 1000G reference-LD matrix for a configurable super-population, default
+EUR via ``--superpop``) and runs ``coloc.susie`` to test for a **shared credible
+set** — separating genuine colocalization from single-variant artifacts.
 
 This layer is OPTIONAL: it needs external tools (``R`` with ``susieR``+``coloc``,
 ``bcftools``) and network access to the 1000G reference. :func:`finemap_available`
@@ -71,7 +71,7 @@ def finemap_available() -> tuple[bool, list[str]]:
 
 
 # ---------------------------------------------------------------------------
-# 1000G EUR reference LD
+# 1000G reference LD (configurable super-population, default EUR)
 # ---------------------------------------------------------------------------
 
 
@@ -82,7 +82,7 @@ def _cache_dir(ld_cache_dir: Optional[str]) -> Path:
     return d
 
 
-def _eur_unrelated_samples(cache: Path, superpop: str) -> Path:
+def _unrelated_samples(cache: Path, superpop: str) -> Path:
     """Download the 1000G 3202 panel once; derive unrelated founders of ``superpop``."""
     out = cache / f"{superpop.lower()}_unrelated.txt"
     if out.exists():
@@ -101,6 +101,11 @@ def _eur_unrelated_samples(cache: Path, superpop: str) -> Path:
             f = line.split()
             if len(f) > sup and f[sup] == superpop and f[fat] == "0" and f[mot] == "0":
                 samples.append(f[sid])
+    if not samples:
+        raise ValueError(
+            f"No unrelated founders found for super-population '{superpop}' in the "
+            "1000G panel. Check --superpop (one of EUR, AFR, EAS, SAS, AMR)."
+        )
     out.write_text("\n".join(samples) + "\n")
     logger.info("derived %d unrelated %s founders", len(samples), superpop)
     return out
@@ -116,14 +121,14 @@ def _kg_index(chrom: str, cache: Path) -> str:
     return str(idx)
 
 
-def _eur_dosages(chrom: str, start: int, end: int, cache: Path, superpop: str
-                 ) -> dict[tuple[int, str, str], np.ndarray]:
+def _panel_dosages(chrom: str, start: int, end: int, cache: Path, superpop: str
+                   ) -> dict[tuple[int, str, str], np.ndarray]:
     """Region ALT-dosage matrix over unrelated `superpop` samples (biallelic SNPs).
 
     Downloads the region subset to a local VCF first (EBI streams flaky BGZF
     mid-pipe), retrying until bcftools exits cleanly, then queries locally.
     """
-    samples = _eur_unrelated_samples(cache, superpop)
+    samples = _unrelated_samples(cache, superpop)
     idx = _kg_index(chrom, cache)
     url = KG_PHASED_VCF_URL.format(chrom=chrom) + f"##idx##{idx}"
     reg = cache / f"region_chr{chrom}_{start}_{end}_{superpop.lower()}.vcf.gz"
@@ -180,12 +185,13 @@ class FineMapResult:
 
 def _build_inputs(gwas, eqtl_recs, chrom, start, end, gwas_N, eqtl_N,
                   cache: Path, work: Path, superpop: str) -> int:
-    """Harmonize GWAS ∩ eQTL ∩ 1000G-EUR → write merged.tsv, ld.tsv, meta.json.
+    """Harmonize GWAS ∩ eQTL ∩ 1000G panel → write merged.tsv, ld.tsv, meta.json.
 
     Effects oriented to the GWAS ALT allele; LD computed as ALT-dosage
-    correlation so its sign matches the betas. Returns the variant count.
+    correlation (over the chosen super-population) so its sign matches the betas.
+    Returns the variant count.
     """
-    kg = _eur_dosages(chrom, start, end, cache, superpop)
+    kg = _panel_dosages(chrom, start, end, cache, superpop)
     eqtl_by_key = {key: (b, s) for key, b, s, _p in eqtl_recs}
     rows, dosages = [], []
     for (pos, ref, alt), (bg, sg, _pg) in gwas.items():
@@ -204,14 +210,22 @@ def _build_inputs(gwas, eqtl_recs, chrom, start, end, gwas_N, eqtl_N,
             dv = 2.0 - kg[(pos, alt, ref)]
         if dv is None:
             continue
+        if np.isnan(dv).all():
+            continue  # all genotypes missing — would poison the LD correlation
         if np.isnan(dv).any():
             dv = np.where(np.isnan(dv), np.nanmean(dv), dv)
-        if np.nanstd(dv) == 0:
+        if not np.isfinite(dv).all() or np.std(dv) == 0:
             continue
         rows.append((f"{chrom}:{pos}:{ref}:{alt}", pos, bg, sg, be, se))
         dosages.append(dv)
     if len(rows) < 2:
         return len(rows)
+    if len(rows) > 5000:
+        logger.warning(
+            "%d variants in the LD region; the %dx%d correlation matrix is large "
+            "and SuSiE may be slow/memory-heavy. Consider a smaller --window-kb.",
+            len(rows), len(rows), len(rows),
+        )
     order = np.argsort([r[1] for r in rows])
     rows = [rows[i] for i in order]
     R = np.corrcoef(np.array([dosages[i] for i in order]))
@@ -289,6 +303,10 @@ def run_finemap(
             ld_s_gwas=_f("LD_S_GWAS"), ld_s_eqtl=_f("LD_S_EQTL"),
             note="ok",
         )
+    except Exception as exc:  # fine-mapping is optional: degrade, don't abort the run
+        logger.warning("fine-mapping failed, continuing without it: %s", exc)
+        return FineMapResult(available=True, n_variants=0,
+                             note=f"fine-map error: {exc}")
     finally:
         if work_dir is None:
             shutil.rmtree(work, ignore_errors=True)

--- a/hvantk/algorithms/qtlcascade/finemap.py
+++ b/hvantk/algorithms/qtlcascade/finemap.py
@@ -1,0 +1,294 @@
+"""Optional SuSiE-RSS + coloc.susie fine-mapping confirmation for a GWAS×eQTL locus.
+
+The single-variant ABF in :mod:`gwas_coloc` is fast but can over-call when a
+strong GWAS meets a weak eQTL. This module fine-maps both traits with SuSiE-RSS
+(using a 1000G EUR reference-LD matrix) and runs ``coloc.susie`` to test for a
+**shared credible set** — separating genuine colocalization from single-variant
+artifacts.
+
+This layer is OPTIONAL: it needs external tools (``R`` with ``susieR``+``coloc``,
+``bcftools``) and network access to the 1000G reference. :func:`finemap_available`
+reports what's missing so callers can skip it gracefully.
+
+Caveat: reference (not in-sample) LD is the documented SuSiE-RSS limitation —
+for weak/underpowered eQTLs the credible sets may be unreliable; the LD-mismatch
+diagnostics (``estimate_s_rss``) are reported alongside the result.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from hvantk.algorithms.qtlcascade.constants import (
+    KG_PHASED_VCF_URL,
+    KG_PANEL_URL,
+    DEFAULT_FINEMAP_SUPERPOP,
+)
+
+logger = logging.getLogger(__name__)
+
+_R_SCRIPT = Path(__file__).resolve().parent / "resources" / "susie_coloc.R"
+_R_LIB_PREFIX = (
+    'ul<-Sys.getenv("R_LIBS_USER"); if(nzchar(ul)) .libPaths(c(ul,.libPaths())); '
+)
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+def finemap_available() -> tuple[bool, list[str]]:
+    """Return ``(ok, missing)`` — whether R+packages and bcftools are present."""
+    missing: list[str] = []
+    if shutil.which("bcftools") is None:
+        missing.append("bcftools")
+    if shutil.which("curl") is None:
+        missing.append("curl")
+    if shutil.which("Rscript") is None:
+        missing.append("Rscript (R)")
+        return False, missing
+    try:
+        r = subprocess.run(
+            ["Rscript", "-e", _R_LIB_PREFIX
+             + 'cat(all(sapply(c("susieR","coloc","jsonlite"),requireNamespace,quietly=TRUE)))'],
+            capture_output=True, text=True, timeout=120,
+        )
+        if "TRUE" not in r.stdout:
+            missing.append("R packages: susieR, coloc, jsonlite")
+    except Exception as exc:  # pragma: no cover
+        missing.append(f"R check failed: {exc}")
+    return (len(missing) == 0), missing
+
+
+# ---------------------------------------------------------------------------
+# 1000G EUR reference LD
+# ---------------------------------------------------------------------------
+
+
+def _cache_dir(ld_cache_dir: Optional[str]) -> Path:
+    d = Path(ld_cache_dir) if ld_cache_dir else Path(
+        os.environ.get("HVANTK_LD_CACHE", Path.home() / ".cache" / "hvantk" / "1kg"))
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _eur_unrelated_samples(cache: Path, superpop: str) -> Path:
+    """Download the 1000G 3202 panel once; derive unrelated founders of ``superpop``."""
+    out = cache / f"{superpop.lower()}_unrelated.txt"
+    if out.exists():
+        return out
+    panel = cache / "g1k_3202.panel"
+    if not panel.exists():
+        subprocess.run(["curl", "-sSL", "--retry", "3", "--max-time", "120",
+                        "-o", str(panel), KG_PANEL_URL], check=True)
+    samples = []
+    with open(panel) as fh:
+        header = fh.readline().split()
+        idx = {name: i for i, name in enumerate(header)}
+        sid, fat, mot, sup = (idx["SampleID"], idx["FatherID"],
+                              idx["MotherID"], idx["Superpopulation"])
+        for line in fh:
+            f = line.split()
+            if len(f) > sup and f[sup] == superpop and f[fat] == "0" and f[mot] == "0":
+                samples.append(f[sid])
+    out.write_text("\n".join(samples) + "\n")
+    logger.info("derived %d unrelated %s founders", len(samples), superpop)
+    return out
+
+
+def _kg_index(chrom: str, cache: Path) -> str:
+    """Download the per-chrom 1000G tabix index locally (remote index is flaky)."""
+    idx = cache / f"kg_chr{chrom}.tbi"
+    if not idx.exists():
+        url = KG_PHASED_VCF_URL.format(chrom=chrom) + ".tbi"
+        subprocess.run(["curl", "-sSL", "--retry", "3", "--max-time", "300",
+                        "-o", str(idx), url], check=True)
+    return str(idx)
+
+
+def _eur_dosages(chrom: str, start: int, end: int, cache: Path, superpop: str
+                 ) -> dict[tuple[int, str, str], np.ndarray]:
+    """Region ALT-dosage matrix over unrelated `superpop` samples (biallelic SNPs).
+
+    Downloads the region subset to a local VCF first (EBI streams flaky BGZF
+    mid-pipe), retrying until bcftools exits cleanly, then queries locally.
+    """
+    samples = _eur_unrelated_samples(cache, superpop)
+    idx = _kg_index(chrom, cache)
+    url = KG_PHASED_VCF_URL.format(chrom=chrom) + f"##idx##{idx}"
+    reg = cache / f"region_chr{chrom}_{start}_{end}_{superpop.lower()}.vcf.gz"
+    if not reg.exists():
+        ok = False
+        for attempt in range(8):
+            p = subprocess.run(
+                ["bcftools", "view", "-r", f"chr{chrom}:{start}-{end}",
+                 "-S", str(samples), "--force-samples", "-m2", "-M2", "-v", "snps",
+                 url, "-Oz", "-o", str(reg)],
+                capture_output=True, text=True,
+            )
+            if p.returncode == 0 and reg.exists() and reg.stat().st_size > 1000:
+                ok = True
+                break
+            logger.warning("1000G region fetch attempt %d failed (rc=%d)",
+                           attempt + 1, p.returncode)
+            reg.unlink(missing_ok=True)
+        if not ok:
+            raise RuntimeError("1000G region fetch failed after retries")
+    out: dict[tuple[int, str, str], np.ndarray] = {}
+    q = subprocess.run(["bcftools", "query", "-f", "%POS\t%REF\t%ALT[\t%GT]\n", str(reg)],
+                       capture_output=True, text=True)
+    if q.returncode != 0:
+        raise RuntimeError(f"bcftools query failed: {q.stderr.strip()[-200:]}")
+    for line in q.stdout.splitlines():
+        f = line.split("\t")
+        if len(f) < 4:
+            continue
+        dos = []
+        for gt in f[3:]:
+            gt = gt.replace("|", "/")
+            dos.append(np.nan if "." in gt else sum(1 for a in gt.split("/") if a == "1"))
+        out[(int(f[0]), f[1], f[2])] = np.array(dos, dtype=float)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fine-map driver
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FineMapResult:
+    available: bool
+    n_variants: int = 0
+    cs_gwas: Optional[int] = None
+    cs_eqtl: Optional[int] = None
+    coloc_susie_pp4: Optional[float] = None
+    ld_s_gwas: Optional[float] = None
+    ld_s_eqtl: Optional[float] = None
+    note: str = ""
+
+
+def _build_inputs(gwas, eqtl_recs, chrom, start, end, gwas_N, eqtl_N,
+                  cache: Path, work: Path, superpop: str) -> int:
+    """Harmonize GWAS ∩ eQTL ∩ 1000G-EUR → write merged.tsv, ld.tsv, meta.json.
+
+    Effects oriented to the GWAS ALT allele; LD computed as ALT-dosage
+    correlation so its sign matches the betas. Returns the variant count.
+    """
+    kg = _eur_dosages(chrom, start, end, cache, superpop)
+    eqtl_by_key = {key: (b, s) for key, b, s, _p in eqtl_recs}
+    rows, dosages = [], []
+    for (pos, ref, alt), (bg, sg, _pg) in gwas.items():
+        be = se = None
+        if (pos, ref, alt) in eqtl_by_key:
+            be, se = eqtl_by_key[(pos, ref, alt)]
+        elif (pos, alt, ref) in eqtl_by_key:
+            be, se = eqtl_by_key[(pos, alt, ref)]
+            be = -be
+        if be is None:
+            continue
+        dv = None
+        if (pos, ref, alt) in kg:
+            dv = kg[(pos, ref, alt)]
+        elif (pos, alt, ref) in kg:
+            dv = 2.0 - kg[(pos, alt, ref)]
+        if dv is None:
+            continue
+        if np.isnan(dv).any():
+            dv = np.where(np.isnan(dv), np.nanmean(dv), dv)
+        if np.nanstd(dv) == 0:
+            continue
+        rows.append((f"{chrom}:{pos}:{ref}:{alt}", pos, bg, sg, be, se))
+        dosages.append(dv)
+    if len(rows) < 2:
+        return len(rows)
+    order = np.argsort([r[1] for r in rows])
+    rows = [rows[i] for i in order]
+    R = np.corrcoef(np.array([dosages[i] for i in order]))
+    with open(work / "merged.tsv", "w") as fh:
+        fh.write("snp\tpos\tbeta_gwas\tse_gwas\tbeta_eqtl\tse_eqtl\n")
+        for snp, pos, bg, sg, be, se in rows:
+            fh.write(f"{snp}\t{pos}\t{bg}\t{sg}\t{be}\t{se}\n")
+    np.savetxt(work / "ld.tsv", R, fmt="%.6f", delimiter="\t")
+    with open(work / "meta.json", "w") as fh:
+        json.dump({"gwas_N": gwas_N, "eqtl_N": eqtl_N}, fh)
+    return len(rows)
+
+
+def run_finemap(
+    *,
+    gwas: dict[tuple[int, str, str], tuple[float, float, float]],
+    eqtl_recs: list[tuple[tuple[int, str, str], float, float, float]],
+    chrom: str,
+    start: int,
+    end: int,
+    gwas_N: int,
+    eqtl_N: int,
+    ld_cache_dir: Optional[str] = None,
+    superpop: str = DEFAULT_FINEMAP_SUPERPOP,
+    work_dir: Optional[str] = None,
+) -> FineMapResult:
+    """Fine-map a single GWAS×eQTL locus and run coloc.susie.
+
+    ``eqtl_recs`` is the per-gene record list from
+    :func:`gwas_coloc.fetch_eqtl_region` for the gene of interest.
+    """
+    ok, missing = finemap_available()
+    if not ok:
+        return FineMapResult(available=False,
+                             note="fine-map skipped; missing: " + ", ".join(missing))
+    cache = _cache_dir(ld_cache_dir)
+    import tempfile
+    work = Path(work_dir) if work_dir else Path(tempfile.mkdtemp(prefix="hvantk_finemap_"))
+    work.mkdir(parents=True, exist_ok=True)
+    try:
+        n = _build_inputs(gwas, eqtl_recs, chrom, start, end, gwas_N, eqtl_N,
+                          cache, work, superpop)
+        if n < 2:
+            return FineMapResult(available=True, n_variants=n,
+                                 note="too few overlapping variants for fine-mapping")
+        p = subprocess.run(["Rscript", str(_R_SCRIPT), str(work)],
+                           capture_output=True, text=True, timeout=1800)
+        vals: dict[str, str] = {}
+        for line in p.stdout.splitlines():
+            parts = line.split()
+            if len(parts) == 2:
+                vals[parts[0]] = parts[1]
+        if "DONE" not in p.stdout:
+            return FineMapResult(available=True, n_variants=n,
+                                 note=f"R fine-map did not complete: {p.stderr.strip()[-200:]}")
+
+        def _f(k):
+            v = vals.get(k)
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return None
+
+        def _i(k):
+            v = vals.get(k)
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return None
+
+        return FineMapResult(
+            available=True, n_variants=n,
+            cs_gwas=_i("CS_GWAS"), cs_eqtl=_i("CS_EQTL"),
+            coloc_susie_pp4=_f("COLOC_SUSIE_PP4"),
+            ld_s_gwas=_f("LD_S_GWAS"), ld_s_eqtl=_f("LD_S_EQTL"),
+            note="ok",
+        )
+    finally:
+        if work_dir is None:
+            shutil.rmtree(work, ignore_errors=True)

--- a/hvantk/algorithms/qtlcascade/gwas_coloc.py
+++ b/hvantk/algorithms/qtlcascade/gwas_coloc.py
@@ -225,8 +225,11 @@ def run_locus_coloc(
             g = gwas.get((pos, eref, ealt)) or gwas.get((pos, ealt, eref))
             if g is None:
                 continue
-            b1.append(g[0]); s1.append(g[1])
-            b2.append(ebeta); s2.append(ese); eqtl_ps.append(epval)
+            b1.append(g[0])
+            s1.append(g[1])
+            b2.append(ebeta)
+            s2.append(ese)
+            eqtl_ps.append(epval)
         if len(b1) < min_snps:
             continue
         res = coloc_abf_two_traits(
@@ -266,7 +269,7 @@ def run_finngen_eqtl_coloc(
 ) -> GwasColocResult:
     """End-to-end ABF coloc: fetch FinnGen × eQTL Catalogue region, rank effectors."""
     half = window_kb * 1000
-    start, end = max(0, lead - half), lead + half  # clamp left edge near contig start
+    start, end = max(1, lead - half), lead + half  # 1-based; clamp left edge near contig start
     region = f"chr{chrom}:{start}-{end}"
     logger.info("coloc %s × %s @ %s", endpoint, eqtl_dataset, region)
     gwas = fetch_finngen_region(endpoint, chrom, start, end)

--- a/hvantk/algorithms/qtlcascade/gwas_coloc.py
+++ b/hvantk/algorithms/qtlcascade/gwas_coloc.py
@@ -1,0 +1,278 @@
+"""GWAS → effector colocalization (FinnGen GWAS × eQTL Catalogue cis-eQTL).
+
+ABF colocalization that ranks the cis genes at a GWAS locus by the posterior
+probability that the GWAS signal and the gene's cis-eQTL share a causal variant
+(H4). All summary statistics are streamed via **remote tabix** — no bulk
+downloads. The single-variant ABF here is the fast screen; for rigour it should
+be confirmed by fine-mapping (see :mod:`hvantk.algorithms.qtlcascade.finemap`),
+which separates genuine colocalization from single-variant-ABF artifacts.
+
+Reuses the validated Wakefield kernel (:func:`coloc.compute_log_abf`) with
+trait-specific prior variances (case-control GWAS vs quantitative eQTL).
+
+References
+----------
+- Giambartolomei et al. (2014) PLoS Genet — coloc
+- Wakefield (2009) Am J Hum Genet — ABF
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import pysam
+
+from hvantk.algorithms.qtlcascade.coloc import (
+    compute_log_abf,
+    _logsumexp,
+    _logdiff,
+)
+from hvantk.algorithms.qtlcascade.constants import (
+    DEFAULT_COLOC_P1,
+    DEFAULT_COLOC_P2,
+    DEFAULT_COLOC_P12,
+    DEFAULT_GWAS_W_CC,
+    DEFAULT_EQTL_W_QUANT,
+    DEFAULT_COLOC_MIN_SNPS,
+    DEFAULT_COLOC_WINDOW_KB,
+    FINNGEN_R10_SUMSTATS_URL,
+    EQTL_CATALOGUE_SUMSTATS_URL,
+    EQTL_CATALOGUE_DEFAULT_STUDY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Remote-tabix helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_ca_bundle() -> None:
+    """htslib remote-TLS needs a CA bundle; point it at certifi if unset."""
+    if not os.environ.get("CURL_CA_BUNDLE"):
+        try:
+            import certifi
+
+            os.environ["CURL_CA_BUNDLE"] = certifi.where()
+        except Exception as exc:  # pragma: no cover - certifi is a hard dep
+            logger.debug("certifi unavailable for CA bundle: %s", exc)
+
+
+def _contig(tb: "pysam.TabixFile", chrom: str) -> str:
+    """Resolve a contig name against a tabix file's naming (with/without 'chr')."""
+    if chrom in tb.contigs:
+        return chrom
+    alt = f"chr{chrom}" if not chrom.startswith("chr") else chrom[3:]
+    return alt if alt in tb.contigs else chrom
+
+
+def finngen_url(endpoint: str) -> str:
+    return FINNGEN_R10_SUMSTATS_URL.format(endpoint=endpoint)
+
+
+def eqtl_catalogue_url(dataset: str, study: str = EQTL_CATALOGUE_DEFAULT_STUDY) -> str:
+    """Build an eQTL Catalogue URL from a dataset id (e.g. ``QTD000251``).
+
+    If ``dataset`` already looks like a URL/path it is returned unchanged.
+    """
+    if "://" in dataset or dataset.endswith(".tsv.gz") or os.path.exists(dataset):
+        return dataset
+    return EQTL_CATALOGUE_SUMSTATS_URL.format(study=study, dataset=dataset)
+
+
+def fetch_finngen_region(
+    endpoint: str, chrom: str, start: int, end: int
+) -> dict[tuple[int, str, str], tuple[float, float, float]]:
+    """FinnGen R10 GWAS over a region → ``{(pos, ref, alt): (beta, se, pval)}``.
+
+    Effects are ALT-referenced. Cols: chrom pos ref alt rsids nearest_genes
+    pval mlogp beta sebeta af*.
+    """
+    _ensure_ca_bundle()
+    out: dict[tuple[int, str, str], tuple[float, float, float]] = {}
+    with pysam.TabixFile(finngen_url(endpoint)) as tb:
+        for rec in tb.fetch(_contig(tb, chrom), start, end):
+            f = rec.split("\t")
+            try:
+                se = float(f[9])
+                if se > 0:
+                    out[(int(f[1]), f[2], f[3])] = (float(f[8]), se, float(f[6]))
+            except (ValueError, IndexError):
+                continue
+    return out
+
+
+def fetch_eqtl_region(
+    dataset: str, chrom: str, start: int, end: int, study: str = EQTL_CATALOGUE_DEFAULT_STUDY
+) -> dict[str, list[tuple[tuple[int, str, str], float, float, float]]]:
+    """eQTL Catalogue cis-eQTL over a region → ``{gene_id: [(key, beta, se, pval), ...]}``.
+
+    Effects are ALT-referenced. Cols: gene_id chrom pos ref alt variant
+    ma_samples maf pvalue beta se. ``dataset`` may be a QTD id, a full URL, or a
+    local tabix path.
+    """
+    _ensure_ca_bundle()
+    out: dict[str, list[tuple[tuple[int, str, str], float, float, float]]] = {}
+    with pysam.TabixFile(eqtl_catalogue_url(dataset, study)) as tb:
+        for rec in tb.fetch(_contig(tb, chrom), start, end):
+            f = rec.split("\t")
+            try:
+                se = float(f[10])
+                if se <= 0:  # guard against div-by-zero in the ABF kernel
+                    continue
+                key = (int(f[2]), f[3], f[4])
+                out.setdefault(f[0].split(".")[0], []).append(
+                    (key, float(f[9]), se, float(f[8]))
+                )
+            except (ValueError, IndexError):
+                continue
+    return out
+
+
+# ---------------------------------------------------------------------------
+# ABF coloc (two traits, trait-specific W) — reuses the validated kernel
+# ---------------------------------------------------------------------------
+
+
+def coloc_abf_two_traits(
+    beta1: np.ndarray,
+    se1: np.ndarray,
+    beta2: np.ndarray,
+    se2: np.ndarray,
+    W1: float = DEFAULT_GWAS_W_CC,
+    W2: float = DEFAULT_EQTL_W_QUANT,
+    p1: float = DEFAULT_COLOC_P1,
+    p2: float = DEFAULT_COLOC_P2,
+    p12: float = DEFAULT_COLOC_P12,
+) -> dict:
+    """Wakefield/Giambartolomei ABF coloc with **trait-specific** prior variances.
+
+    Identical hypothesis algebra to :func:`coloc.coloc_abf`, but uses W1 for
+    trait 1 (e.g. case-control GWAS) and W2 for trait 2 (e.g. quantitative
+    eQTL). Returns H0–H4 posteriors + ``n_variants`` + ``lead_idx``.
+    """
+    n = len(beta1)
+    if n == 0:
+        return {"H0": 1.0, "H1": 0.0, "H2": 0.0, "H3": 0.0, "H4": 0.0,
+                "n_variants": 0, "lead_idx": -1}
+    la1 = compute_log_abf(np.asarray(beta1), np.asarray(se1), W1)
+    la2 = compute_log_abf(np.asarray(beta2), np.asarray(se2), W2)
+    s1, s2 = _logsumexp(la1), _logsumexp(la2)
+    la_both = la1 + la2
+    s_both = _logsumexp(la_both)
+    log_h = np.array([
+        0.0,
+        np.log(p1) + s1,
+        np.log(p2) + s2,
+        np.log(p1) + np.log(p2) + _logdiff(s1 + s2, s_both),
+        np.log(p12) + s_both,
+    ])
+    post = np.exp(log_h - np.max(log_h))
+    post /= post.sum()
+    return {"H0": float(post[0]), "H1": float(post[1]), "H2": float(post[2]),
+            "H3": float(post[3]), "H4": float(post[4]),
+            "n_variants": n, "lead_idx": int(np.argmax(la_both))}
+
+
+# ---------------------------------------------------------------------------
+# Region driver
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GwasColocResult:
+    """Ranked coloc result for one GWAS locus × one eQTL dataset."""
+
+    table: pd.DataFrame          # gene_id, n_snp, eqtl_minp, PP3, PP4 (PP4-sorted)
+    gwas_min_p: float
+    n_genes_tested: int
+    region: str
+
+
+def run_locus_coloc(
+    *,
+    gwas: dict[tuple[int, str, str], tuple[float, float, float]],
+    eqtl: dict[str, list[tuple[tuple[int, str, str], float, float, float]]],
+    region: str,
+    min_snps: int = DEFAULT_COLOC_MIN_SNPS,
+    W1: float = DEFAULT_GWAS_W_CC,
+    W2: float = DEFAULT_EQTL_W_QUANT,
+    p1: float = DEFAULT_COLOC_P1,
+    p2: float = DEFAULT_COLOC_P2,
+    p12: float = DEFAULT_COLOC_P12,
+    gene_symbols: Optional[dict[str, str]] = None,
+) -> GwasColocResult:
+    """ABF coloc of a GWAS region against every overlapping cis gene.
+
+    Variants are matched on position and allele *set* — ref/alt may be stored in
+    either order across sources (the ABF kernel uses z^2, so allele orientation
+    does not affect H4). Pure in-memory — fetch with :func:`fetch_finngen_region`
+    / :func:`fetch_eqtl_region` first.
+    """
+    gwas_min_p = min((v[2] for v in gwas.values()), default=float("nan"))
+    rows = []
+    for ensg, recs in eqtl.items():
+        b1, s1, b2, s2, eqtl_ps = [], [], [], [], []
+        for (pos, eref, ealt), ebeta, ese, epval in recs:
+            # Match order-independently: sources may store ref/alt swapped.
+            # The ABF kernel uses z^2 (sign-independent), so no beta flip needed.
+            g = gwas.get((pos, eref, ealt)) or gwas.get((pos, ealt, eref))
+            if g is None:
+                continue
+            b1.append(g[0]); s1.append(g[1])
+            b2.append(ebeta); s2.append(ese); eqtl_ps.append(epval)
+        if len(b1) < min_snps:
+            continue
+        res = coloc_abf_two_traits(
+            np.array(b1), np.array(s1), np.array(b2), np.array(s2),
+            W1=W1, W2=W2, p1=p1, p2=p2, p12=p12,
+        )
+        rows.append({
+            "gene_id": ensg,
+            "gene": (gene_symbols or {}).get(ensg, ensg),
+            "n_snp": len(b1),
+            "eqtl_min_p": min(eqtl_ps),
+            "PP3": res["H3"],
+            "PP4": res["H4"],
+        })
+    cols = ["gene_id", "gene", "n_snp", "eqtl_min_p", "PP3", "PP4"]
+    df = (pd.DataFrame(rows, columns=cols).sort_values("PP4", ascending=False)
+          .reset_index(drop=True) if rows else pd.DataFrame(columns=cols))
+    return GwasColocResult(table=df, gwas_min_p=gwas_min_p,
+                           n_genes_tested=len(df), region=region)
+
+
+def run_finngen_eqtl_coloc(
+    *,
+    endpoint: str,
+    chrom: str,
+    lead: int,
+    eqtl_dataset: str,
+    window_kb: int = DEFAULT_COLOC_WINDOW_KB,
+    eqtl_study: str = EQTL_CATALOGUE_DEFAULT_STUDY,
+    min_snps: int = DEFAULT_COLOC_MIN_SNPS,
+    W1: float = DEFAULT_GWAS_W_CC,
+    W2: float = DEFAULT_EQTL_W_QUANT,
+    p1: float = DEFAULT_COLOC_P1,
+    p2: float = DEFAULT_COLOC_P2,
+    p12: float = DEFAULT_COLOC_P12,
+    gene_symbols: Optional[dict[str, str]] = None,
+) -> GwasColocResult:
+    """End-to-end ABF coloc: fetch FinnGen × eQTL Catalogue region, rank effectors."""
+    half = window_kb * 1000
+    start, end = max(0, lead - half), lead + half  # clamp left edge near contig start
+    region = f"chr{chrom}:{start}-{end}"
+    logger.info("coloc %s × %s @ %s", endpoint, eqtl_dataset, region)
+    gwas = fetch_finngen_region(endpoint, chrom, start, end)
+    eqtl = fetch_eqtl_region(eqtl_dataset, chrom, start, end, study=eqtl_study)
+    logger.info("  GWAS variants=%d; eQTL genes=%d", len(gwas), len(eqtl))
+    return run_locus_coloc(
+        gwas=gwas, eqtl=eqtl, region=region, min_snps=min_snps,
+        W1=W1, W2=W2, p1=p1, p2=p2, p12=p12, gene_symbols=gene_symbols,
+    )

--- a/hvantk/algorithms/qtlcascade/gwas_pipeline.py
+++ b/hvantk/algorithms/qtlcascade/gwas_pipeline.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import datetime
 import json
 import logging
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -65,6 +66,14 @@ class GwasColocConfig:
             errs.append("endpoint is required")
         if not self.eqtl_dataset:
             errs.append("eqtl_dataset is required")
+        if self.lead <= 0:
+            errs.append("lead must be a positive 1-based position")
+        if self.window_kb <= 0:
+            errs.append("window_kb must be > 0")
+        if self.min_snps < 2:
+            errs.append("min_snps must be >= 2")
+        if not 0.0 <= self.pp4_threshold <= 1.0:
+            errs.append("pp4_threshold must be in [0, 1]")
         if self.fine_map and (self.gwas_N is None or self.eqtl_N is None):
             errs.append("fine-mapping requires gwas_N and eqtl_N (or pass --no-fine-map)")
         return errs
@@ -76,10 +85,12 @@ def _verdict(pp4_abf: Optional[float], fmr: Optional[fm.FineMapResult],
         return "NO COLOC (gene of interest absent from results / no eQTL genes tested)"
     if pp4_abf < pp4_threshold:
         return f"NO COLOC (ABF PP4 {pp4_abf:.2f} < {pp4_threshold})"
-    if fmr is None or not fmr.available:
+    if fmr is None:
         return "SUGGESTIVE (ABF only; fine-mapping not run)"
+    if not fmr.available:
+        return f"SUGGESTIVE (ABF only; fine-mapping unavailable — {fmr.note})"
     if fmr.coloc_susie_pp4 is None:
-        return "INCONCLUSIVE (fine-mapping incomplete)"
+        return f"INCONCLUSIVE (fine-mapping incomplete — {fmr.note})"
     if fmr.coloc_susie_pp4 >= pp4_threshold:
         return "CONFIRMED (ABF + fine-mapping agree)"
     if (fmr.cs_gwas or 0) == 0 or (fmr.cs_eqtl or 0) == 0:
@@ -87,10 +98,21 @@ def _verdict(pp4_abf: Optional[float], fmr: Optional[fm.FineMapResult],
     return "REFUTED (distinct causal variants — ABF PP4 not supported by fine-mapping)"
 
 
+def _json_safe(obj):
+    """Recursively replace non-finite floats (NaN/inf) with None for strict JSON."""
+    if isinstance(obj, dict):
+        return {k: _json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj]
+    if isinstance(obj, float) and not math.isfinite(obj):
+        return None
+    return obj
+
+
 def run_gwas_coloc_pipeline(config: GwasColocConfig) -> dict:
     """Run the pipeline and write a provenance-stamped report. Returns the report dict."""
     half = config.window_kb * 1000
-    start, end = max(0, config.lead - half), config.lead + half  # clamp left edge
+    start, end = max(1, config.lead - half), config.lead + half  # 1-based; clamp left edge
     region = f"chr{config.chrom}:{start}-{end}"
 
     gwas = gc.fetch_finngen_region(config.endpoint, config.chrom, start, end)
@@ -175,7 +197,7 @@ def run_gwas_coloc_pipeline(config: GwasColocConfig) -> dict:
     }
     report_path = out_dir / f"report_{config.endpoint}_{config.chrom}_{config.lead}.json"
     with open(report_path, "w") as fh:
-        json.dump(report, fh, indent=2)
+        json.dump(_json_safe(report), fh, indent=2)
     report["results"]["report_json"] = str(report_path)
     logger.info("verdict: %s", verdict)
     return report

--- a/hvantk/algorithms/qtlcascade/gwas_pipeline.py
+++ b/hvantk/algorithms/qtlcascade/gwas_pipeline.py
@@ -1,0 +1,181 @@
+"""End-to-end GWAS→effector colocalization pipeline.
+
+Orchestrates: FinnGen GWAS × eQTL Catalogue ABF coloc (rank cis effectors) →
+optional SuSiE/coloc.susie fine-map confirmation of the lead effector → a
+provenance-stamped report. The fine-map step is what makes a verdict
+trustworthy: it distinguishes a genuine colocalization (CONFIRMED) from a
+single-variant-ABF artifact (REFUTED). Validated on the AF→MYOZ1 positive
+control (CONFIRMED) vs the CHD 17q21/NSF look-alike (REFUTED).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from hvantk.algorithms.qtlcascade import gwas_coloc as gc
+from hvantk.algorithms.qtlcascade import finemap as fm
+from hvantk.algorithms.qtlcascade.constants import (
+    DEFAULT_COLOC_P1, DEFAULT_COLOC_P2, DEFAULT_COLOC_P12,
+    DEFAULT_GWAS_W_CC, DEFAULT_EQTL_W_QUANT, DEFAULT_COLOC_MIN_SNPS,
+    DEFAULT_COLOC_WINDOW_KB,
+    EQTL_CATALOGUE_DEFAULT_STUDY, DEFAULT_FINEMAP_SUPERPOP,
+)
+
+# PP4 cutoff for the verdict gate (ABF "colocalizes" and coloc.susie "confirms").
+# Deliberately 0.5 (not the stricter 0.8 ABF-declaration threshold): coloc.susie
+# is more conservative than single-variant ABF, and the validated positive
+# control (AF→MYOZ1) confirms at coloc.susie PP4=0.71.
+DEFAULT_VERDICT_PP4 = 0.5
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GwasColocConfig:
+    endpoint: str                       # FinnGen R10 endpoint code
+    chrom: str
+    lead: int
+    eqtl_dataset: str                   # eQTL Catalogue QTD id / URL / local tabix
+    output_dir: str
+    eqtl_study: str = EQTL_CATALOGUE_DEFAULT_STUDY
+    window_kb: int = DEFAULT_COLOC_WINDOW_KB
+    gene_of_interest: Optional[str] = None  # ENSG; default = ABF-top
+    fine_map: bool = True
+    gwas_N: Optional[int] = None        # required for fine-mapping
+    eqtl_N: Optional[int] = None        # required for fine-mapping
+    min_snps: int = DEFAULT_COLOC_MIN_SNPS
+    W1: float = DEFAULT_GWAS_W_CC
+    W2: float = DEFAULT_EQTL_W_QUANT
+    p1: float = DEFAULT_COLOC_P1
+    p2: float = DEFAULT_COLOC_P2
+    p12: float = DEFAULT_COLOC_P12
+    pp4_threshold: float = DEFAULT_VERDICT_PP4
+    superpop: str = DEFAULT_FINEMAP_SUPERPOP
+    ld_cache_dir: Optional[str] = None
+    gene_symbols: dict = field(default_factory=dict)
+
+    def validate(self) -> list[str]:
+        errs = []
+        if not self.endpoint:
+            errs.append("endpoint is required")
+        if not self.eqtl_dataset:
+            errs.append("eqtl_dataset is required")
+        if self.fine_map and (self.gwas_N is None or self.eqtl_N is None):
+            errs.append("fine-mapping requires gwas_N and eqtl_N (or pass --no-fine-map)")
+        return errs
+
+
+def _verdict(pp4_abf: Optional[float], fmr: Optional[fm.FineMapResult],
+             pp4_threshold: float) -> str:
+    if pp4_abf is None:
+        return "NO COLOC (gene of interest absent from results / no eQTL genes tested)"
+    if pp4_abf < pp4_threshold:
+        return f"NO COLOC (ABF PP4 {pp4_abf:.2f} < {pp4_threshold})"
+    if fmr is None or not fmr.available:
+        return "SUGGESTIVE (ABF only; fine-mapping not run)"
+    if fmr.coloc_susie_pp4 is None:
+        return "INCONCLUSIVE (fine-mapping incomplete)"
+    if fmr.coloc_susie_pp4 >= pp4_threshold:
+        return "CONFIRMED (ABF + fine-mapping agree)"
+    if (fmr.cs_gwas or 0) == 0 or (fmr.cs_eqtl or 0) == 0:
+        return "REFUTED (no fine-mappable signal — single-variant-ABF artifact)"
+    return "REFUTED (distinct causal variants — ABF PP4 not supported by fine-mapping)"
+
+
+def run_gwas_coloc_pipeline(config: GwasColocConfig) -> dict:
+    """Run the pipeline and write a provenance-stamped report. Returns the report dict."""
+    half = config.window_kb * 1000
+    start, end = max(0, config.lead - half), config.lead + half  # clamp left edge
+    region = f"chr{config.chrom}:{start}-{end}"
+
+    gwas = gc.fetch_finngen_region(config.endpoint, config.chrom, start, end)
+    eqtl = gc.fetch_eqtl_region(config.eqtl_dataset, config.chrom, start, end,
+                                study=config.eqtl_study)
+    logger.info("GWAS variants=%d; eQTL genes=%d", len(gwas), len(eqtl))
+
+    cres = gc.run_locus_coloc(
+        gwas=gwas, eqtl=eqtl, region=region, min_snps=config.min_snps,
+        W1=config.W1, W2=config.W2, p1=config.p1, p2=config.p2, p12=config.p12,
+        gene_symbols=config.gene_symbols,
+    )
+
+    user_gene = config.gene_of_interest
+    target = user_gene if user_gene else (
+        str(cres.table.iloc[0]["gene_id"]) if not cres.table.empty else None)
+    goi_row = None
+    if target is not None and not cres.table.empty:
+        match = cres.table[cres.table["gene_id"] == target]
+        goi_row = match.iloc[0] if len(match) else None
+    if user_gene is not None:
+        # User-specified gene: report ITS PP4 (or None if absent from results) —
+        # never another gene's — so the verdict is about the requested gene.
+        pp4_abf = float(goi_row["PP4"]) if goi_row is not None else None
+    else:
+        pp4_abf = float(cres.table.iloc[0]["PP4"]) if not cres.table.empty else None
+
+    fmr = None
+    if config.fine_map and target is not None and target in eqtl:
+        if config.gwas_N is None or config.eqtl_N is None:
+            fmr = fm.FineMapResult(available=False, note="fine-map needs gwas_N/eqtl_N")
+        else:
+            logger.info("fine-mapping %s …", target)
+            fmr = fm.run_finemap(
+                gwas=gwas, eqtl_recs=eqtl[target], chrom=config.chrom,
+                start=start, end=end, gwas_N=config.gwas_N, eqtl_N=config.eqtl_N,
+                ld_cache_dir=config.ld_cache_dir, superpop=config.superpop,
+            )
+
+    verdict = _verdict(pp4_abf, fmr, config.pp4_threshold)
+
+    out_dir = Path(config.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tsv_path = out_dir / f"coloc_{config.endpoint}_{config.chrom}_{config.lead}.tsv"
+    cres.table.to_csv(tsv_path, sep="\t", index=False)
+
+    top = cres.table.iloc[0] if not cres.table.empty else None
+    report = {
+        "endpoint": config.endpoint,
+        "region": region,
+        "genome_build": "GRCh38",
+        "run_date": datetime.date.today().isoformat(),
+        "gwas": {"source": f"FinnGen R10 {config.endpoint}", "N": config.gwas_N,
+                 "min_p_in_region": cres.gwas_min_p},
+        "eqtl": {"source": f"eQTL Catalogue {config.eqtl_dataset} (study {config.eqtl_study})",
+                 "N": config.eqtl_N},
+        "coloc_params": {"W1": config.W1, "W2": config.W2, "p1": config.p1,
+                         "p2": config.p2, "p12": config.p12,
+                         "window_kb": config.window_kb, "min_snps": config.min_snps},
+        "results": {
+            "n_genes_tested": cres.n_genes_tested,
+            "top_effector": (None if top is None else str(top["gene_id"])),
+            "top_PP4": (None if top is None else float(top["PP4"])),
+            "gene_of_interest": target,
+            "goi_PP4_abf": pp4_abf,
+            "coloc_table_tsv": str(tsv_path),
+        },
+        "fine_map": (None if fmr is None else {
+            "available": fmr.available, "n_variants": fmr.n_variants,
+            "credible_sets_gwas": fmr.cs_gwas, "credible_sets_eqtl": fmr.cs_eqtl,
+            "coloc_susie_PP4": fmr.coloc_susie_pp4,
+            "ld_consistency_s_gwas": fmr.ld_s_gwas, "ld_consistency_s_eqtl": fmr.ld_s_eqtl,
+            "ld_panel": f"1000G high-coverage GRCh38, {config.superpop} unrelated founders",
+            "note": fmr.note,
+        }),
+        "verdict": verdict,
+        "provenance_notes": (
+            "Summary statistics streamed via remote tabix (no bulk download). "
+            "Fine-mapping (when run) uses a 1000G reference-LD panel, not in-sample "
+            "LD — the documented SuSiE-RSS limitation for weak/underpowered eQTLs."),
+        "software": {"framework": "hvantk.algorithms.qtlcascade.gwas_pipeline"},
+    }
+    report_path = out_dir / f"report_{config.endpoint}_{config.chrom}_{config.lead}.json"
+    with open(report_path, "w") as fh:
+        json.dump(report, fh, indent=2)
+    report["results"]["report_json"] = str(report_path)
+    logger.info("verdict: %s", verdict)
+    return report

--- a/hvantk/algorithms/qtlcascade/resources/susie_coloc.R
+++ b/hvantk/algorithms/qtlcascade/resources/susie_coloc.R
@@ -39,8 +39,11 @@ cat(sprintf("CS_EQTL %d\n", cse))
 pp4 <- 0.0
 if (csg > 0 && cse > 0) {
   cr <- tryCatch(coloc.susie(sg, se), error = function(e) NULL)
-  if (!is.null(cr) && !is.null(cr$summary) && nrow(cr$summary) > 0)
-    pp4 <- max(cr$summary$PP.H4.abf)
+  if (!is.null(cr) && !is.null(cr$summary) && nrow(cr$summary) > 0) {
+    vals <- cr$summary$PP.H4.abf
+    vals <- vals[is.finite(vals)]
+    if (length(vals) > 0) pp4 <- max(vals)
+  }
 }
 cat(sprintf("COLOC_SUSIE_PP4 %.4f\n", pp4))
 

--- a/hvantk/algorithms/qtlcascade/resources/susie_coloc.R
+++ b/hvantk/algorithms/qtlcascade/resources/susie_coloc.R
@@ -1,0 +1,51 @@
+#!/usr/bin/env Rscript
+# SuSiE-RSS fine-mapping + coloc.susie for ONE GWAS x eQTL locus.
+# Shipped as a resource and invoked by finemap.py via subprocess.
+#
+# Usage: Rscript susie_coloc.R <work_dir> [r_libs_path]
+#   <work_dir>/merged.tsv : snp,pos,beta_gwas,se_gwas,beta_eqtl,se_eqtl
+#   <work_dir>/ld.tsv     : signed LD correlation matrix (ALT-dosage; same order)
+#   <work_dir>/meta.json  : {"gwas_N":..., "eqtl_N":...}
+# Emits machine-parseable "KEY value" lines (CS_GWAS, CS_EQTL,
+# COLOC_SUSIE_PP4, LD_S_GWAS, LD_S_EQTL, DONE) on stdout.
+
+args <- commandArgs(trailingOnly = TRUE)
+wd <- args[1]
+ul <- if (length(args) >= 2 && nzchar(args[2])) args[2] else Sys.getenv("R_LIBS_USER")
+if (nzchar(ul)) .libPaths(c(ul, .libPaths()))
+
+ok <- requireNamespace("susieR", quietly = TRUE) &&
+      requireNamespace("coloc", quietly = TRUE) &&
+      requireNamespace("jsonlite", quietly = TRUE)
+if (!ok) { cat("ERROR missing_r_packages\n"); quit(status = 2) }
+suppressMessages({ library(susieR); library(coloc); library(jsonlite) })
+
+m  <- read.delim(file.path(wd, "merged.tsv"))
+R  <- as.matrix(read.table(file.path(wd, "ld.tsv")))
+mt <- fromJSON(file.path(wd, "meta.json"))
+rownames(R) <- colnames(R) <- m$snp
+zg <- m$beta_gwas / m$se_gwas
+ze <- m$beta_eqtl / m$se_eqtl
+
+sg <- tryCatch(suppressWarnings(susie_rss(z = zg, R = R, n = mt$gwas_N, L = 10)),
+               error = function(e) NULL)
+se <- tryCatch(suppressWarnings(susie_rss(z = ze, R = R, n = mt$eqtl_N, L = 10)),
+               error = function(e) NULL)
+csg <- if (is.null(sg) || is.null(sg$sets$cs)) 0L else length(sg$sets$cs)
+cse <- if (is.null(se) || is.null(se$sets$cs)) 0L else length(se$sets$cs)
+cat(sprintf("CS_GWAS %d\n", csg))
+cat(sprintf("CS_EQTL %d\n", cse))
+
+pp4 <- 0.0
+if (csg > 0 && cse > 0) {
+  cr <- tryCatch(coloc.susie(sg, se), error = function(e) NULL)
+  if (!is.null(cr) && !is.null(cr$summary) && nrow(cr$summary) > 0)
+    pp4 <- max(cr$summary$PP.H4.abf)
+}
+cat(sprintf("COLOC_SUSIE_PP4 %.4f\n", pp4))
+
+sgd <- tryCatch(estimate_s_rss(zg, R, n = mt$gwas_N), error = function(e) NA)
+sed <- tryCatch(estimate_s_rss(ze, R, n = mt$eqtl_N), error = function(e) NA)
+cat(sprintf("LD_S_GWAS %s\n", ifelse(is.na(sgd), "NA", sprintf("%.3f", sgd))))
+cat(sprintf("LD_S_EQTL %s\n", ifelse(is.na(sed), "NA", sprintf("%.3f", sed))))
+cat("DONE\n")

--- a/hvantk/tests/test_gwas_coloc.py
+++ b/hvantk/tests/test_gwas_coloc.py
@@ -1,0 +1,178 @@
+"""Fast unit + CLI tests for the GWAS → effector coloc pipeline (gwas_coloc).
+
+The end-to-end positive control (AF→MYOZ1 CONFIRMED) lives in the
+network-marked test_gwas_coloc_myoz1_network.py (excluded from the fast run).
+"""
+
+import numpy as np
+from click.testing import CliRunner
+
+from hvantk.algorithms.qtlcascade.gwas_coloc import (
+    coloc_abf_two_traits,
+    run_locus_coloc,
+    eqtl_catalogue_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# ABF kernel — correctness on synthetic data
+# ---------------------------------------------------------------------------
+
+
+def _signal(n, peak_idx, peak_z, se):
+    z = np.linspace(-0.5, 0.5, n)  # mild deterministic noise
+    z[peak_idx] = peak_z
+    return z * se, np.full(n, se)
+
+
+def test_coloc_abf_shared_signal_high_pp4():
+    b1, s1 = _signal(100, 50, 8.0, 0.02)
+    b2, s2 = _signal(100, 50, 8.0, 0.03)  # same peak variant -> shared
+    res = coloc_abf_two_traits(b1, s1, b2, s2)
+    assert res["H4"] > 0.9
+    assert res["H3"] < 0.1
+    assert res["lead_idx"] == 50
+
+
+def test_coloc_abf_distinct_signal_high_pp3():
+    b1, s1 = _signal(100, 50, 8.0, 0.02)
+    b2, s2 = _signal(100, 10, 8.0, 0.03)  # different peak variant -> distinct
+    res = coloc_abf_two_traits(b1, s1, b2, s2)
+    assert res["H3"] > 0.9
+    assert res["H4"] < 0.1
+
+
+def test_coloc_abf_empty_returns_h0():
+    res = coloc_abf_two_traits(np.array([]), np.array([]), np.array([]), np.array([]))
+    assert res["H0"] == 1.0 and res["n_variants"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Region driver — ranks the shared-signal gene above the distinct one
+# ---------------------------------------------------------------------------
+
+
+def _gwas_dict(n, peak_idx, peak_z, se=0.02):
+    z = np.linspace(-0.5, 0.5, n)
+    z[peak_idx] = peak_z
+    return {(i + 1, "A", "G"): (z[i] * se, se, 1.0) for i in range(n)}
+
+
+def _eqtl_recs(n, peak_idx, peak_z, se=0.03):
+    z = np.linspace(-0.5, 0.5, n)
+    z[peak_idx] = peak_z
+    return [((i + 1, "A", "G"), z[i] * se, se, 1.0) for i in range(n)]
+
+
+def test_run_locus_coloc_ranks_shared_above_distinct():
+    n = 40
+    gwas = _gwas_dict(n, peak_idx=20, peak_z=7.0)
+    eqtl = {
+        "ENSG_SHARED": _eqtl_recs(n, peak_idx=20, peak_z=7.0),   # same peak -> coloc
+        "ENSG_DISTINCT": _eqtl_recs(n, peak_idx=3, peak_z=7.0),  # different peak
+    }
+    res = run_locus_coloc(gwas=gwas, eqtl=eqtl, region="chr1:1-40", min_snps=20)
+    assert not res.table.empty
+    top = res.table.iloc[0]
+    assert top["gene_id"] == "ENSG_SHARED"
+    assert top["PP4"] > 0.5
+    distinct = res.table[res.table["gene_id"] == "ENSG_DISTINCT"].iloc[0]
+    assert distinct["PP4"] < top["PP4"]
+
+
+def test_run_locus_coloc_min_snps_filter():
+    gwas = _gwas_dict(10, peak_idx=5, peak_z=7.0)
+    eqtl = {"ENSG_X": _eqtl_recs(10, peak_idx=5, peak_z=7.0)}
+    res = run_locus_coloc(gwas=gwas, eqtl=eqtl, region="chr1:1-10", min_snps=20)
+    assert res.table.empty  # only 10 shared variants < min_snps=20
+
+
+def test_run_locus_coloc_allele_flip_matches():
+    # eQTL stored with swapped alleles relative to GWAS -> must still match (beta flipped)
+    n = 40
+    gwas = _gwas_dict(n, peak_idx=20, peak_z=7.0)
+    z = np.linspace(-0.5, 0.5, n)
+    z[20] = 7.0
+    eqtl = {"ENSG_FLIP": [((i + 1, "G", "A"), -z[i] * 0.03, 0.03, 1.0) for i in range(n)]}
+    res = run_locus_coloc(gwas=gwas, eqtl=eqtl, region="chr1:1-40", min_snps=20)
+    assert not res.table.empty
+    assert res.table.iloc[0]["PP4"] > 0.5  # flip handled -> still colocalizes
+
+
+# ---------------------------------------------------------------------------
+# URL helper
+# ---------------------------------------------------------------------------
+
+
+def test_eqtl_catalogue_url_from_qtd():
+    url = eqtl_catalogue_url("QTD000251")
+    assert url.endswith("QTS000015/QTD000251/QTD000251.all.tsv.gz")
+
+
+def test_eqtl_catalogue_url_passthrough():
+    full = "https://example.org/x.all.tsv.gz"
+    assert eqtl_catalogue_url(full) == full
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_gwas_coloc_cli_requires_n_for_finemap(tmp_path):
+    from hvantk.tools.qtl.qtlcascade_cli import qtlcascade_group
+
+    r = CliRunner().invoke(
+        qtlcascade_group,
+        ["gwas-coloc", "--endpoint", "I9_AF", "--chrom", "10", "--lead", "73600000",
+         "--eqtl", "QTD000251", "-o", str(tmp_path / "out")],  # fine-map on, no -n
+    )
+    assert r.exit_code == 1
+    assert "fine-mapping requires gwas_N and eqtl_N" in r.output
+
+
+def test_gwas_coloc_cli_runs_with_mocked_pipeline(tmp_path, monkeypatch):
+    from hvantk.tools.qtl import qtlcascade_cli
+    import hvantk.algorithms.qtlcascade.gwas_pipeline as gp
+
+    fake = {
+        "region": "chr10:73100000-74100000",
+        "gwas": {"min_p_in_region": 2.7e-14},
+        "results": {"n_genes_tested": 51, "top_effector": "ENSG00000177791",
+                    "top_PP4": 0.812, "report_json": str(tmp_path / "r.json")},
+        "fine_map": {"available": True, "credible_sets_gwas": 1,
+                     "credible_sets_eqtl": 1, "coloc_susie_PP4": 0.71},
+        "verdict": "CONFIRMED (ABF + fine-mapping agree)",
+    }
+    monkeypatch.setattr(gp, "run_gwas_coloc_pipeline", lambda config: fake)
+
+    r = CliRunner().invoke(
+        qtlcascade_cli.qtlcascade_group,
+        ["gwas-coloc", "--endpoint", "I9_AF", "--chrom", "10", "--lead", "73600000",
+         "--eqtl", "QTD000251", "--no-fine-map", "-o", str(tmp_path)],
+    )
+    assert r.exit_code == 0, r.output
+    assert "CONFIRMED" in r.output
+    assert "ENSG00000177791" in r.output
+
+
+def test_pipeline_user_gene_absent_not_misattributed(tmp_path, monkeypatch):
+    # Regression: a user-specified gene absent from the coloc table must NOT
+    # inherit the top gene's PP4 (verdict must be about the requested gene).
+    import hvantk.algorithms.qtlcascade.gwas_coloc as gc
+    from hvantk.algorithms.qtlcascade.gwas_pipeline import (
+        GwasColocConfig, run_gwas_coloc_pipeline,
+    )
+
+    monkeypatch.setattr(gc, "fetch_finngen_region",
+                        lambda *a, **k: _gwas_dict(40, 20, 7.0))
+    monkeypatch.setattr(gc, "fetch_eqtl_region",
+                        lambda *a, **k: {"ENSG_OTHER": _eqtl_recs(40, 20, 7.0)})
+    cfg = GwasColocConfig(
+        endpoint="X", chrom="1", lead=1_000_000, eqtl_dataset="QTD",
+        gene_of_interest="ENSG_ABSENT", fine_map=False, output_dir=str(tmp_path),
+    )
+    rep = run_gwas_coloc_pipeline(cfg)
+    assert rep["results"]["goi_PP4_abf"] is None          # not the top gene's PP4
+    assert rep["results"]["top_effector"] == "ENSG_OTHER"  # top still reported
+    assert rep["verdict"].startswith("NO COLOC")

--- a/hvantk/tests/test_gwas_coloc.py
+++ b/hvantk/tests/test_gwas_coloc.py
@@ -128,7 +128,14 @@ def test_gwas_coloc_cli_requires_n_for_finemap(tmp_path):
          "--eqtl", "QTD000251", "-o", str(tmp_path / "out")],  # fine-map on, no -n
     )
     assert r.exit_code == 1
-    assert "fine-mapping requires gwas_N and eqtl_N" in r.output
+    # Validation errors go to stderr (err=True); Click 8.1 mixes it into .output,
+    # 8.2+ separates it — combine both so the assertion is version-robust.
+    combined = r.output
+    try:
+        combined += r.stderr
+    except (ValueError, AttributeError):
+        pass
+    assert "fine-mapping requires gwas_N and eqtl_N" in combined
 
 
 def test_gwas_coloc_cli_runs_with_mocked_pipeline(tmp_path, monkeypatch):

--- a/hvantk/tests/test_gwas_coloc_myoz1_network.py
+++ b/hvantk/tests/test_gwas_coloc_myoz1_network.py
@@ -1,0 +1,46 @@
+"""End-to-end positive-control regression: AF 10q22 → MYOZ1 must be CONFIRMED.
+
+Network + external tools (R+susieR+coloc, bcftools, 1000G). Auto-marked
+``network`` by the filename suffix, so it is excluded from the default fast
+run; execute with ``pytest -m network hvantk/tests/test_gwas_coloc_myoz1_network.py``.
+
+This guards the whole chain: ABF coloc recovers MYOZ1 as the top effector AND
+SuSiE/coloc.susie confirms it — the discrimination that makes the workflow
+trustworthy (cf. the CHD 17q21/NSF look-alike, which is REFUTED).
+"""
+
+import pytest
+
+from hvantk.algorithms.qtlcascade.finemap import finemap_available
+from hvantk.algorithms.qtlcascade.gwas_pipeline import (
+    GwasColocConfig,
+    run_gwas_coloc_pipeline,
+)
+
+MYOZ1 = "ENSG00000177791"
+
+
+@pytest.mark.skipif(not finemap_available()[0],
+                    reason="needs R+susieR+coloc and bcftools")
+def test_af_myoz1_positive_control_confirmed(tmp_path):
+    cfg = GwasColocConfig(
+        endpoint="I9_AF", chrom="10", lead=73600000,
+        eqtl_dataset="QTD000251",            # GTEx heart atrial appendage
+        gene_of_interest=MYOZ1,
+        gwas_N=261395, eqtl_N=372, fine_map=True,
+        output_dir=str(tmp_path), ld_cache_dir=str(tmp_path / "ld"),
+    )
+    report = run_gwas_coloc_pipeline(cfg)
+
+    # ABF: MYOZ1 is the top effector with high H4
+    assert report["results"]["top_effector"] == MYOZ1
+    assert report["results"]["top_PP4"] > 0.5
+
+    # Fine-mapping confirms it (credible set in each trait + shared)
+    fm = report["fine_map"]
+    assert fm["available"] is True
+    assert fm["credible_sets_gwas"] >= 1
+    assert fm["credible_sets_eqtl"] >= 1
+    assert fm["coloc_susie_PP4"] is not None and fm["coloc_susie_PP4"] > 0.5
+
+    assert report["verdict"].startswith("CONFIRMED")

--- a/hvantk/tools/ptm/ptm_cli.py
+++ b/hvantk/tools/ptm/ptm_cli.py
@@ -501,7 +501,11 @@ def ptm_report(ctx, output, landscape_json, population_json, title, description)
     "--variants-ht",
     type=str,
     required=True,
-    help="Path to PTM-annotated variant Hail Table (from `hvantk ptm annotate`).",
+    help=(
+        "Path to PTM-annotated variants (from `hvantk ptm annotate`): a Hail "
+        "Table directory, or a tabular file (.pkl/.parquet/.csv/.tsv, each "
+        "optionally gzip/bgz-compressed)."
+    ),
 )
 @click.option(
     "--expression-source",
@@ -547,6 +551,14 @@ def ptm_report(ctx, output, landscape_json, population_json, title, description)
     help="Optional two-column TSV mapping expression gene IDs to symbols.",
 )
 @click.option(
+    "--group-mapping",
+    type=click.Path(exists=True),
+    default=None,
+    help="Optional two-column TSV mapping raw expression-group labels to broader "
+    "analysis groups (e.g. 53 GTEx tissues -> 12 organ systems). Applied to each "
+    "gene's primary (argmax) group.",
+)
+@click.option(
     "--expression-metric",
     type=click.Choice(["median", "mean", "median_nonzero"], case_sensitive=False),
     default="median",
@@ -574,6 +586,13 @@ def ptm_report(ctx, output, landscape_json, population_json, title, description)
     show_default=True,
     help="Keep only genes whose max group expression meets this floor.",
 )
+@click.option(
+    "--af-observed-only/--include-zero-af",
+    default=True,
+    show_default=True,
+    help="Restrict the depletion comparison to variants observed in gnomAD "
+    "(AF > 0); --include-zero-af also keeps unobserved (AF = 0) variants.",
+)
 @click.option("--overwrite", is_flag=True)
 @click.pass_context
 def ptm_constraint(
@@ -590,11 +609,13 @@ def ptm_constraint(
     loeuf_field,
     ptm_category_field,
     gene_id_mapping,
+    group_mapping,
     expression_metric,
     min_cells_per_group,
     min_variants_per_group,
     flanking_codons,
     expressed_threshold,
+    af_observed_only,
     overwrite,
 ):
     """Stratified PTM constraint analysis across groups (tissue / cell type).
@@ -642,11 +663,13 @@ def ptm_constraint(
             loeuf_field=loeuf_field,
             ptm_category_field=ptm_category_field,
             gene_id_mapping=gene_id_mapping,
+            group_mapping=group_mapping,
             expression_metric=expression_metric.lower(),
             min_cells_per_group=min_cells_per_group,
             min_variants_per_group=min_variants_per_group,
             flanking_codons=flanking_codons,
             expressed_threshold=expressed_threshold,
+            af_observed_only=af_observed_only,
             overwrite=overwrite,
         )
 

--- a/hvantk/tools/qtl/qtlcascade_cli.py
+++ b/hvantk/tools/qtl/qtlcascade_cli.py
@@ -14,7 +14,12 @@ import logging
 import click
 
 from hvantk.core.config import CONTEXT_SETTINGS
-from hvantk.algorithms.qtlcascade.constants import DEFAULT_COLOC_H4_THRESHOLD
+from hvantk.algorithms.qtlcascade.constants import (
+    DEFAULT_COLOC_H4_THRESHOLD,
+    DEFAULT_COLOC_WINDOW_KB,
+    EQTL_CATALOGUE_DEFAULT_STUDY,
+    DEFAULT_FINEMAP_SUPERPOP,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +143,80 @@ def coloc_cmd(
     Path(output).parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(output, sep="\t", index=False)
     click.echo(f"Coloc results written to {output} ({len(df)} genes)")
+
+
+# ---------------------------------------------------------------------------
+# gwas-coloc — GWAS → effector coloc (FinnGen × eQTL Catalogue) + SuSiE confirm
+# ---------------------------------------------------------------------------
+
+
+@qtlcascade_group.command("gwas-coloc")
+@click.option("--endpoint", required=True, type=str,
+              help="FinnGen R10 endpoint code (e.g. I9_AF).")
+@click.option("--chrom", required=True, type=str, help="Chromosome (GRCh38, no 'chr').")
+@click.option("--lead", required=True, type=int, help="Lead variant position (GRCh38).")
+@click.option("--eqtl", "eqtl_dataset", required=True, type=str,
+              help="eQTL Catalogue dataset id / URL / local tabix (e.g. QTD000251).")
+@click.option("--eqtl-study", type=str, default=EQTL_CATALOGUE_DEFAULT_STUDY,
+              show_default=True, help="eQTL Catalogue study id.")
+@click.option("--window-kb", type=int, default=DEFAULT_COLOC_WINDOW_KB,
+              show_default=True, help="Regional window (±kb) around the lead.")
+@click.option("--gene", "gene_of_interest", type=str, default=None,
+              help="ENSG of interest to confirm (default: the ABF-top gene).")
+@click.option("--fine-map/--no-fine-map", default=True, show_default=True,
+              help="Run SuSiE/coloc.susie confirmation (needs R+susieR+coloc, bcftools).")
+@click.option("--gwas-n", "gwas_n", type=int, default=None,
+              help="GWAS sample size (required for fine-mapping).")
+@click.option("--eqtl-n", "eqtl_n", type=int, default=None,
+              help="eQTL sample size (required for fine-mapping).")
+@click.option("--superpop", type=str, default=DEFAULT_FINEMAP_SUPERPOP,
+              show_default=True, help="1000G super-population for the LD reference.")
+@click.option("--ld-cache-dir", type=str, default=None,
+              help="Cache directory for the 1000G LD reference.")
+@click.option("-o", "--output-dir", required=True, type=str, help="Output directory.")
+@click.pass_context
+def gwas_coloc_cmd(ctx, endpoint, chrom, lead, eqtl_dataset, eqtl_study, window_kb,
+                   gene_of_interest, fine_map, gwas_n, eqtl_n, superpop,
+                   ld_cache_dir, output_dir):
+    """GWAS → effector colocalization with optional SuSiE fine-map confirmation.
+
+    Ranks cis effectors at a GWAS locus by ABF H4, then (default) confirms the
+    lead effector with SuSiE/coloc.susie to separate genuine colocalization
+    (CONFIRMED) from single-variant-ABF artifacts (REFUTED).
+    """
+    from hvantk.algorithms.qtlcascade.gwas_pipeline import (
+        GwasColocConfig,
+        run_gwas_coloc_pipeline,
+    )
+
+    config = GwasColocConfig(
+        endpoint=endpoint, chrom=chrom, lead=lead, eqtl_dataset=eqtl_dataset,
+        eqtl_study=eqtl_study, window_kb=window_kb, gene_of_interest=gene_of_interest,
+        fine_map=fine_map, gwas_N=gwas_n, eqtl_N=eqtl_n, superpop=superpop,
+        ld_cache_dir=ld_cache_dir, output_dir=output_dir,
+    )
+    errors = config.validate()
+    if errors:
+        for e in errors:
+            click.echo(f"  ERROR: {e}", err=True)
+        ctx.exit(1)
+
+    report = run_gwas_coloc_pipeline(config)
+    res = report["results"]
+    gmp = report["gwas"]["min_p_in_region"]
+    click.echo(f"\nRegion {report['region']}  |  GWAS min-p {gmp:.1e}  |  "
+               f"{res['n_genes_tested']} genes tested")
+    click.echo(f"Top effector: {res['top_effector']} (PP4={res['top_PP4']})")
+    if report["fine_map"]:
+        fmr = report["fine_map"]
+        if fmr["available"]:
+            click.echo(f"Fine-map: credible sets GWAS={fmr['credible_sets_gwas']} "
+                       f"eQTL={fmr['credible_sets_eqtl']}; "
+                       f"coloc.susie PP4={fmr['coloc_susie_PP4']}")
+        else:
+            click.echo(f"Fine-map: {fmr['note']}", err=True)
+    click.echo(f"VERDICT: {report['verdict']}")
+    click.echo(f"Report: {res['report_json']}")
 
 
 # ---------------------------------------------------------------------------

--- a/hvantk/tools/qtl/qtlcascade_cli.py
+++ b/hvantk/tools/qtl/qtlcascade_cli.py
@@ -10,6 +10,7 @@ Commands::
 """
 
 import logging
+import math
 
 import click
 
@@ -164,7 +165,7 @@ def coloc_cmd(
 @click.option("--gene", "gene_of_interest", type=str, default=None,
               help="ENSG of interest to confirm (default: the ABF-top gene).")
 @click.option("--fine-map/--no-fine-map", default=True, show_default=True,
-              help="Run SuSiE/coloc.susie confirmation (needs R+susieR+coloc, bcftools).")
+              help="Run SuSiE/coloc.susie confirmation (needs R+susieR+coloc, bcftools, curl).")
 @click.option("--gwas-n", "gwas_n", type=int, default=None,
               help="GWAS sample size (required for fine-mapping).")
 @click.option("--eqtl-n", "eqtl_n", type=int, default=None,
@@ -204,7 +205,8 @@ def gwas_coloc_cmd(ctx, endpoint, chrom, lead, eqtl_dataset, eqtl_study, window_
     report = run_gwas_coloc_pipeline(config)
     res = report["results"]
     gmp = report["gwas"]["min_p_in_region"]
-    click.echo(f"\nRegion {report['region']}  |  GWAS min-p {gmp:.1e}  |  "
+    gmp_str = f"{gmp:.1e}" if isinstance(gmp, float) and math.isfinite(gmp) else "n/a"
+    click.echo(f"\nRegion {report['region']}  |  GWAS min-p {gmp_str}  |  "
                f"{res['n_genes_tested']} genes tested")
     click.echo(f"Top effector: {res['top_effector']} (PP4={res['top_PP4']})")
     if report["fine_map"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ include = [
   { path = "hvantk/skills/**/SKILL.md", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/catalog/*.json", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/tests/drift_fingerprint.json", format = ["sdist", "wheel"] },
+  { path = "hvantk/algorithms/**/resources/*.R", format = ["sdist", "wheel"] },
 ]
 exclude = [
     "hvantk/skills/**/tests/test_*.py",
@@ -42,6 +43,7 @@ PyYAML = "*"
 jsonschema = ">=4.0"
 psutil = "*"
 pysam = ">=0.22"
+certifi = "*"
 anndata = ">=0.10.0"
 scanpy = ">=1.10.0"
 gnomad = { version = "*", optional = true }


### PR DESCRIPTION
## Release: dev → main

Promotes the latest reviewed `dev` work to `main`. Three PRs since the last main release (`git log origin/main..dev`):

- **#190** — feat(qtlcascade): `hvantk qtlcascade gwas-coloc` — GWAS→effector colocalization (FinnGen R10 × eQTL Catalogue, all remote-tabix) with an optional SuSiE-RSS + `coloc.susie` fine-map confirmation layer and a provenance-stamped report. Validated end-to-end on the AF→MYOZ1 positive control (CONFIRMED) vs a CHD look-alike (REFUTED). Reviewed (Copilot + CodeRabbit) and addressed.
- **#191** — docs(qtlcascade): reproducible worked example for `gwas-coloc` (AF→MYOZ1 CONFIRMED vs CHD 17q21/NSF REFUTED), command reference, and verdict semantics. Reviewed (Copilot) and addressed.
- **#189** — feat(ptm): robust + reproducible stratified PTM constraint (median effect size, expression group-mapping, tabular variant inputs, AF>0 filtering), including post-review fixes: `.bgz` tabular reading, fail-loud on an absent AF field under `--af-observed-only`, and updated `--variants-ht` CLI help.

Dependency note: `certifi` is now declared as a runtime dependency (introduced in #190).

This is a release PR — **awaiting review before merge** (do not merge until reviewed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GWAS→eQTL colocalization workflow with optional fine-mapping to nominate effector genes
  * `hvantk qtlcascade gwas-coloc` command supporting Wakefield ABF and SuSiE-RSS methods
  * PTM constraint analysis now supports group mapping and allele frequency filtering

* **Documentation**
  * Added GWAS-eQTL colocalization examples, workflow guide, and CLI reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->