### PR TITLE
fix(catalog): resolve remaining #185 deferred findings

### DIFF
--- a/hvantk/core/plugin/catalog_entry.schema.json
+++ b/hvantk/core/plugin/catalog_entry.schema.json
@@ -8,7 +8,23 @@
     "accession": { "type": "string", "minLength": 1 },
     "title": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
-    "data_source": { "type": "string", "minLength": 1 },
+    "data_source": {
+      "type": "string",
+      "enum": [
+        "ClinGen",
+        "ClinVar",
+        "dbNSFP",
+        "Ensembl",
+        "Expression_Atlas",
+        "GeVIR",
+        "gnomAD",
+        "GTEx",
+        "GWAS Catalog",
+        "INSIDER",
+        "MSigDB",
+        "UCSC"
+      ]
+    },
     "organism": { "type": "string", "minLength": 1 },
     "pubmedid": { "type": ["string", "null"] },
     "doi": { "type": "string" },

--- a/hvantk/resources/unified_registry.py
+++ b/hvantk/resources/unified_registry.py
@@ -136,12 +136,21 @@ class HvantkRegistry:
                     f"JSON array of objects"
                 )
 
-            primary = _DOMAIN_TO_OMICS.get(
-                _provider_primary_domain(provider) or "", None
-            )
+            domain = _provider_primary_domain(provider)
+            primary = _DOMAIN_TO_OMICS.get(domain or "")
             if primary is None:
-                # Unknown-domain plugins do not feed the omics buckets.
-                continue
+                # Fail-fast: a provider that ships a catalog must map to an
+                # omics bucket. Silently skipping it would drop its datasets
+                # from every browse/search surface AND bypass the duplicate-
+                # accession guard below — a misconfiguration we want to catch
+                # at load time, not paper over. Map the domain in
+                # _DOMAIN_TO_OMICS to resolve.
+                raise ValueError(
+                    f"provider {provider.name!r} ships a catalog "
+                    f"({catalog_path}) but its primary domain {domain!r} does "
+                    f"not map to an omics bucket; add it to _DOMAIN_TO_OMICS "
+                    f"(known domains: {sorted(_DOMAIN_TO_OMICS)})"
+                )
             for entry in entries:
                 if not isinstance(entry, dict):
                     raise ValueError(

--- a/hvantk/skills/gnomad_metrics/catalog/datasets.json
+++ b/hvantk/skills/gnomad_metrics/catalog/datasets.json
@@ -15,9 +15,7 @@
     "genome_build": "GRCh38",
     "variant_types": [
       "SNV",
-      "indel",
-      "SV",
-      "CNV"
+      "indel"
     ],
     "frequency_data": true,
     "clinical_significance": false,

--- a/hvantk/skills/gwas_catalog/SKILL.md
+++ b/hvantk/skills/gwas_catalog/SKILL.md
@@ -19,7 +19,7 @@ Read `hvantk/skills/_conventions/SKILL.md` first. This skill assumes every conve
 ## 2. Source identity
 
 - **Provider:** EBI GWAS Catalog. **Schema pinned by this skill:** v1.0 (34 columns, no `MAPPED_TRAIT_URI`).
-- **Catalog entry:** present. `hvantk/resources/registry/genomics/datasets.json` contains `GWAS_Catalog_v1.0_e115_r2026-04-27` (surfaced by `hvantk catalog show GWAS_Catalog_v1.0_e115_r2026-04-27`). URLs / cadence / license / citation live in the registry entry — not here.
+- **Catalog entry:** present. `hvantk/skills/gwas_catalog/catalog/datasets.json` contains `GWAS_Catalog_v1.0_e115_r2026-04-27` (surfaced by `hvantk catalog show GWAS_Catalog_v1.0_e115_r2026-04-27`). URLs / cadence / license / citation live in the plugin catalog entry — not here.
 
 ## 3. Backend choice + reasoning
 
@@ -98,7 +98,7 @@ Type coercions in transform (all string at import):
 
 Releases ~quarterly (tags like `e116_r2026-08-xx`). Per release:
 
-1. Update the GWAS Catalog entry in `registry/genomics/datasets.json` (`last_updated`, file path). Bump accession only on schema change.
+1. Update the GWAS Catalog entry in `hvantk/skills/gwas_catalog/catalog/datasets.json` (`last_updated`, file path). Bump accession only on schema change.
 2. Re-run the round-trip test (§9). If it passes, no builder change.
 3. On schema change: bump accession suffix, update the rename map in the builder, regenerate snapshots with `pytest --regenerate-snapshots`, revisit §3–§4 judgment calls.
 4. If EBI publishes v1.0.2 alongside v1.0: revisit judgment call #4 (option B).

--- a/hvantk/skills/gwas_catalog/catalog/datasets.json
+++ b/hvantk/skills/gwas_catalog/catalog/datasets.json
@@ -27,8 +27,8 @@
         "path": "gwas-catalog-download-associations-v1.0-full.tsv",
         "format": "tsv",
         "size_bytes": 556245182,
-        "url": "https://www.ebi.ac.uk/gwas/api/search/downloads/full",
-        "description": "Full associations TSV (v1.0, 34 columns) from the EBI GWAS Catalog e115 / r2026-04-27 release."
+        "url": "https://ftp.ebi.ac.uk/pub/databases/gwas/releases/latest/gwas-catalog-associations-full.zip",
+        "description": "Full associations TSV (v1.0, 34 columns), unzipped from the EBI GWAS Catalog latest-release archive (pinned content: e115 / r2026-04-27). The legacy api/search/downloads/full endpoint has been retired (404); this FTP archive is the URL the drift probe fingerprints."
       }
     ]
   }

--- a/hvantk/skills/gwas_catalog/catalog/datasets.json
+++ b/hvantk/skills/gwas_catalog/catalog/datasets.json
@@ -28,7 +28,7 @@
         "format": "tsv",
         "size_bytes": 556245182,
         "url": "https://ftp.ebi.ac.uk/pub/databases/gwas/releases/latest/gwas-catalog-associations-full.zip",
-        "description": "Full associations TSV (v1.0, 34 columns), unzipped from the EBI GWAS Catalog latest-release archive (pinned content: e115 / r2026-04-27). The legacy api/search/downloads/full endpoint has been retired (404); this FTP archive is the URL the drift probe fingerprints."
+        "description": "Full associations TSV (v1.0, 34 columns), unzipped from the EBI GWAS Catalog full-associations archive. The `url` is the rolling latest-release endpoint (the same one the drift probe fingerprints) and may resolve to a newer release over time; the specific release this entry was built from is recorded in `accession` (e115 / r2026-04-27). The legacy api/search/downloads/full endpoint has been retired (404)."
       }
     ]
   }

--- a/hvantk/tests/test_cli_qtlcascade.py
+++ b/hvantk/tests/test_cli_qtlcascade.py
@@ -1,19 +1,20 @@
-import sys
 from unittest.mock import patch, MagicMock
 
 from click.testing import CliRunner
 
 from hvantk.tools.qtl.qtlcascade_cli import qtlcascade_group
 
-_MOCK_HAIL_CONTEXT = MagicMock()
-
 
 def test_cascade_cmd():
     runner = CliRunner()
     mock_ht = MagicMock()
-    with patch.dict(
-        sys.modules,
-        {"hail": MagicMock(), "hvantk.core.hail_context": _MOCK_HAIL_CONTEXT},
+    # Mock init_hail at the seam the command actually calls
+    # (hvantk.core.utils.hail_context.init_hail) so no real Hail backend is
+    # started, plus build_cascade so no Hail ops run. Patching sys.modules
+    # instead is order-fragile: it only intercepts Hail if hail_context hasn't
+    # already bound the real module earlier in the suite.
+    with patch(
+        "hvantk.core.utils.hail_context.init_hail"
     ), patch(
         "hvantk.algorithms.qtlcascade.cascade.build_cascade", return_value=mock_ht
     ) as mock_build:
@@ -56,9 +57,8 @@ def test_coloc_cmd(tmp_path):
         }
     )
 
-    with patch.dict(
-        sys.modules,
-        {"hail": MagicMock(), "hvantk.core.hail_context": _MOCK_HAIL_CONTEXT},
+    with patch(
+        "hvantk.core.utils.hail_context.init_hail"
     ), patch(
         "hvantk.algorithms.qtlcascade.coloc.run_coloc_per_gene", return_value=mock_df
     ):

--- a/hvantk/tests/test_plugins_cli.py
+++ b/hvantk/tests/test_plugins_cli.py
@@ -94,7 +94,7 @@ def test_validate_rejects_catalog_entry_missing_required_field(tmp_path):
     from hvantk.tools.plugins.plugins_cli import plugins_group
     (tmp_path / "catalog").mkdir()
     (tmp_path / "catalog" / "datasets.json").write_text(
-        '[{"title": "x", "description": "d", "data_source": "Custom", '
+        '[{"title": "x", "description": "d", "data_source": "ClinGen", '
         '"organism": "Homo sapiens", "files": []}]'  # missing "accession"
     )
     (tmp_path / "plugin.yaml").write_text(
@@ -112,7 +112,7 @@ def test_validate_rejects_duplicate_accession_within_catalog(tmp_path):
     from hvantk.tools.plugins.plugins_cli import plugins_group
     (tmp_path / "catalog").mkdir()
     entry = ('{"accession": "DUP", "title": "x", "description": "d", '
-             '"data_source": "Custom", "organism": "Homo sapiens", "files": []}')
+             '"data_source": "ClinGen", "organism": "Homo sapiens", "files": []}')
     (tmp_path / "catalog" / "datasets.json").write_text(f"[{entry}, {entry}]")
     (tmp_path / "plugin.yaml").write_text(
         "api_version: 2\nname: tmp-plug\nversion: 0.1.0\n"

--- a/hvantk/tests/test_unified_registry_per_plugin.py
+++ b/hvantk/tests/test_unified_registry_per_plugin.py
@@ -119,3 +119,36 @@ def test_duplicate_accession_across_plugins_is_error(monkeypatch, tmp_path):
         ur.HvantkRegistry()
 
 
+def test_unmapped_primary_domain_is_error(monkeypatch, tmp_path):
+    """A catalog-owning provider whose primary domain isn't in _DOMAIN_TO_OMICS
+    must fail fast, not silently drop its datasets (regression for #185)."""
+    import json
+    import pytest
+    import hvantk.resources.unified_registry as ur
+
+    class _FakeProvider:
+        def __init__(self, name, catalog_path, domain):
+            self.name = name
+            self.catalog_path = str(catalog_path)
+            self.primary_domain = domain
+            self.datasets = ()
+
+    cat = tmp_path / "c.json"
+    cat.write_text(
+        json.dumps([{
+            "accession": "X1", "title": "X1", "description": "x",
+            "data_source": "Custom", "organism": "Homo sapiens", "files": [],
+        }])
+    )
+
+    class _FakeRegistry:
+        def list_providers(self):
+            return [_FakeProvider("prov-x", cat, "metabolomics")]
+
+    monkeypatch.setattr(
+        "hvantk.core.plugin.loader.get_registry", lambda: _FakeRegistry()
+    )
+    with pytest.raises(ValueError, match="metabolomics"):
+        ur.HvantkRegistry()
+
+

--- a/hvantk/tests/test_unified_registry_per_plugin.py
+++ b/hvantk/tests/test_unified_registry_per_plugin.py
@@ -102,7 +102,7 @@ def test_duplicate_accession_across_plugins_is_error(monkeypatch, tmp_path):
     def _entry(acc):
         return {
             "accession": acc, "title": acc, "description": "x",
-            "data_source": "Custom", "organism": "Homo sapiens", "files": [],
+            "data_source": "ClinGen", "organism": "Homo sapiens", "files": [],
         }
 
     cat_a = tmp_path / "a.json"; cat_a.write_text(json.dumps([_entry("DUP")]))
@@ -137,7 +137,7 @@ def test_unmapped_primary_domain_is_error(monkeypatch, tmp_path):
     cat.write_text(
         json.dumps([{
             "accession": "X1", "title": "X1", "description": "x",
-            "data_source": "Custom", "organism": "Homo sapiens", "files": [],
+            "data_source": "ClinGen", "organism": "Homo sapiens", "files": [],
         }])
     )
 


### PR DESCRIPTION
Resolves the four open items from #185 (the mechanical subset landed earlier in #187). Each was a deferred CodeRabbit finding from the release PR #184.

## Changes

| Item | Change |
|------|--------|
| **`data_source` enum** | `catalog_entry.schema.json` — tighten `data_source` from free-text to an enum of the 12 canonical values actually in use. Free-text let typos/aliases pass validation and silently broke `--data-source` / `search(data_source=…)` filtering. |
| **`gwas_catalog` URL** | `catalog/datasets.json` — replace the retired 404 `api/search/downloads/full` endpoint with the live EBI FTP latest-release archive (the URL `drift_probe.py` already fingerprints). Also fixed two stale `registry/genomics/datasets.json` references in `SKILL.md` (that path no longer exists post plugin-sourced-catalog migration). |
| **`gnomad_metrics` types** | `catalog/datasets.json` — narrow `variant_types` to `["SNV","indel"]` to match the only declared `*.sites.vcf.bgz` files (SV/CNV products were listed but never shipped). |
| **registry fail-fast** | `unified_registry.py` — `raise` instead of silently `continue`-skipping a catalog-owning provider whose `primary_domain` isn't in `_DOMAIN_TO_OMICS`. Silent skip dropped the provider's datasets from every browse/search surface **and** bypassed the duplicate-accession guard. Currently unreachable (all in-tree domains map), so this is a fail-fast guard for a future unmapped-domain plugin. Includes a regression test. |

## Drive-by: fix flaky `test_cli_qtlcascade.py`

`test_cascade_cmd` / `test_coloc_cmd` failed in the full suite (passed in isolation) due to test-order pollution — they patched `sys.modules["hail"]` and the wrong path `hvantk.core.hail_context` (real one is `hvantk.core.utils.hail_context`), so `init_hail()` was never actually mocked. In a full run an earlier test binds the real `hail` into `hail_context`, so the command runs real `init_hail()` and dies on the mocked `hail` submodule import (`AttributeError('__spec__')`). Fixed by mocking `init_hail` at the real seam; no Hail import/init happens at all now, deterministic regardless of order. (Pre-existing on `dev`, unrelated to the catalog work — folded in here on request.)

## Verification

- All **307 catalog entries across 12 files** validate against the updated schema (0 rejected) using the project's own `jsonschema.validate` path.
- `pytest hvantk/tests/test_unified_registry_per_plugin.py` → **8/8 pass**, including the new `test_unmapped_primary_domain_is_error` and the real-registry build (confirms the fail-fast change is safe for the current tree).
- **Full fast suite: 1004 passed, 0 failed, 4 skipped** (previously 2 failed in `test_cli_qtlcascade.py`).

Refs #185 (kept open — close manually once verified merged).
