### PR TITLE
feat(rerank): hvantk rerank — calibrated multi-omic credibility re-ranking

### DIFF
--- a/hvantk/algorithms/rerank/__init__.py
+++ b/hvantk/algorithms/rerank/__init__.py
@@ -1,0 +1,6 @@
+# hvantk/algorithms/rerank/__init__.py
+from hvantk.algorithms.rerank.engine import rerank, RerankResult
+from hvantk.algorithms.rerank.config import (
+    Config, PriorSpec, CohortSpec, FeatureAxis, LabelSpec, validate)
+from hvantk.algorithms.rerank.veto import Veto, CaseControlArchitectureVeto, NoOpVeto
+from hvantk.algorithms.rerank.catalog import DiseaseProfile, build_config, AXES, axis

--- a/hvantk/algorithms/rerank/catalog/__init__.py
+++ b/hvantk/algorithms/rerank/catalog/__init__.py
@@ -1,0 +1,4 @@
+# hvantk/algorithms/rerank/catalog/__init__.py
+from hvantk.algorithms.rerank.catalog.profile import DiseaseProfile
+from hvantk.algorithms.rerank.catalog.registry import build_config, AXES, axis
+from hvantk.algorithms.rerank.catalog import builders as _builders  # noqa: F401

--- a/hvantk/algorithms/rerank/catalog/builders.py
+++ b/hvantk/algorithms/rerank/catalog/builders.py
@@ -1,0 +1,24 @@
+# hvantk/algorithms/rerank/catalog/builders.py
+"""Generic, path-free axis/label builders for the rerank CLI/library.
+Domain-specific builders (gnomAD/Cardoso/GenCC) live in the user's workspace as recipes."""
+import pandas as pd
+from hvantk.algorithms.rerank.config import FeatureAxis, LabelSpec
+
+
+def table_axis(name: str, path: str) -> FeatureAxis:
+    """A FeatureAxis backed by a gene-keyed table file (.parquet/.tsv/.csv).
+    The table must have a 'gene' column + one or more numeric feature columns."""
+    def loader():
+        if path.endswith(".parquet"):
+            return pd.read_parquet(path)
+        sep = "\t" if path.endswith((".tsv", ".bgz", ".gz")) else ","
+        return pd.read_csv(path, sep=sep)
+    return FeatureAxis(name, loader)
+
+
+def genelist_labels(path: str) -> LabelSpec:
+    """A LabelSpec from a file of gene symbols (one per line) or a table's first column."""
+    def load():
+        with open(path) as fh:
+            return {ln.strip().split()[0] for ln in fh if ln.strip() and not ln.startswith("#")}
+    return LabelSpec(load)

--- a/hvantk/algorithms/rerank/catalog/profile.py
+++ b/hvantk/algorithms/rerank/catalog/profile.py
@@ -1,0 +1,26 @@
+# local/rerank_engine/catalog/profile.py
+from dataclasses import dataclass, field
+from typing import Optional, Callable
+from hvantk.algorithms.rerank.config import PriorSpec, CohortSpec
+
+@dataclass
+class DiseaseProfile:
+    name: str
+    # inputs / universe
+    prior: Optional[PriorSpec] = None
+    cohort: Optional[CohortSpec] = None
+    # precomputed feature source: callable -> (matrix[gene+feature cols], {family: [cols]})
+    precomputed: Optional[Callable] = None
+    # tissue / cell-type context (drives expression/eqtl/ptm axes)
+    tissue: Optional[str] = None
+    cell_types: list = field(default_factory=list)
+    dev_window: Optional[str] = None
+    # labels
+    disease_terms: list = field(default_factory=list)
+    label_classifications: list = field(default_factory=lambda: ["Definitive", "Strong", "Moderate"])
+    extra_positive_genes: set = field(default_factory=set)
+    # per-cohort PTM feature parquet (built by chd_ptm_features.py prep step)
+    ptm_features_path: Optional[str] = None
+    # knobs
+    min_label_coverage: float = 0.5
+    extra_vetoed_genes: list = field(default_factory=list)

--- a/hvantk/algorithms/rerank/catalog/registry.py
+++ b/hvantk/algorithms/rerank/catalog/registry.py
@@ -1,0 +1,36 @@
+# local/rerank_engine/catalog/registry.py
+from hvantk.algorithms.rerank.config import Config
+from hvantk.algorithms.rerank.veto import NoOpVeto, CaseControlArchitectureVeto
+
+AXES = {}
+
+def axis(name):
+    def deco(fn):
+        AXES[name] = fn
+        return fn
+    return deco
+
+def _constraint_first(feats):
+    con = [f for f in feats if f.name == "constraint"]
+    rest = [f for f in feats if f.name != "constraint"]
+    return con + rest
+
+def _default_veto(profile):
+    return CaseControlArchitectureVeto() if profile.cohort is not None else NoOpVeto()
+
+def build_config(profile, axes, *, veto=None, calibration="isotonic", folds=5, tiers=5):
+    if profile.prior is None:
+        raise ValueError("DiseaseProfile.prior is required for rerank (build_config)")
+    feats = [AXES[a](profile) if isinstance(a, str) else a for a in axes]
+    feats = _constraint_first(feats)
+    return Config(
+        name=profile.name,
+        prior=profile.prior,
+        features=feats,
+        labels=AXES["labels"](profile),
+        cohort=profile.cohort,
+        veto=veto if veto is not None else _default_veto(profile),
+        extra_vetoed_genes=list(profile.extra_vetoed_genes),
+        min_label_coverage=profile.min_label_coverage,
+        calibration=calibration, folds=folds, tiers=tiers,
+    )

--- a/hvantk/algorithms/rerank/config.py
+++ b/hvantk/algorithms/rerank/config.py
@@ -1,0 +1,77 @@
+# local/rerank_engine/config.py
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+import pandas as pd
+
+@dataclass
+class PriorSpec:
+    path: str; unit_col: str; stat_col: str
+    def load(self) -> pd.DataFrame:
+        sep = "\t" if self.path.endswith((".tsv",".bgz",".gz")) else ","
+        df = pd.read_csv(self.path, sep=sep)
+        return df.rename(columns={self.unit_col:"unit", self.stat_col:"prior_stat"})[["unit","prior_stat"]]
+
+@dataclass
+class LabelSpec:
+    loader: Callable[[], set]
+    def load(self) -> set: return set(self.loader())
+
+@dataclass
+class FeatureAxis:
+    name: str
+    loader: Callable[[], pd.DataFrame]   # returns DataFrame with a 'gene' column + feature columns
+    params: dict = field(default_factory=dict)
+    # Cache assumes one logical load per FeatureAxis instance; configs construct fresh instances per run.
+    _cached: Optional[pd.DataFrame] = field(default=None, init=False, repr=False, compare=False)
+    def __post_init__(self):
+        self._cached = None
+    def load(self) -> pd.DataFrame:
+        if self._cached is None:
+            self._cached = self.loader()
+        return self._cached
+
+@dataclass
+class CohortSpec:
+    variant_table_path: str
+    params: dict = field(default_factory=dict)
+    def load(self) -> pd.DataFrame:
+        cols = self.params.get("veto_cols", [])
+        key = self.params.get("key", "gene")
+        sep = "\t" if self.variant_table_path.endswith((".tsv", ".bgz", ".gz")) else ","
+        df = pd.read_csv(self.variant_table_path, sep=sep)
+        keep = [key] + [c for c in cols if c in df.columns]
+        return df[keep].drop_duplicates(key).rename(columns={key: "gene"})
+
+@dataclass
+class Config:
+    name: str
+    prior: PriorSpec
+    features: list
+    labels: LabelSpec
+    units: str = "gene"
+    cohort: Optional[CohortSpec] = None
+    veto: "object" = None
+    calibration: str = "isotonic"
+    folds: int = 5
+    tiers: int = 5
+    extra_vetoed_genes: list = field(default_factory=list)
+    """Genes to append to the output table after scoring, forced FRAGILE/vetoed (not in model matrix)."""
+    min_label_coverage: float = 0.5
+    """Minimum fraction of label-positive units that must appear in the feature matrix.
+    Set to 0.0 for intentional cross-disease transfer configs where labels come from a
+    different gene universe (e.g. NDD labels scored against a CHD feature matrix)."""
+    def __post_init__(self):
+        if self.veto is None:
+            from hvantk.algorithms.rerank.veto import NoOpVeto
+            self.veto = NoOpVeto()
+
+def validate(config: Config) -> None:
+    from hvantk.algorithms.rerank.veto import NoOpVeto
+    if config.units != "gene":
+        raise NotImplementedError(f"units={config.units!r}: only 'gene' is supported in v1")
+    if config.cohort is None and not isinstance(config.veto, NoOpVeto):
+        raise ValueError("a non-NoOp veto requires a cohort (variant-level data)")
+    if not config.features:
+        raise ValueError("at least one FeatureAxis is required")
+    if not config.labels.load():
+        raise ValueError("labels are empty: LabelSpec.load() returned no positive units")

--- a/hvantk/algorithms/rerank/engine.py
+++ b/hvantk/algorithms/rerank/engine.py
@@ -1,0 +1,56 @@
+# local/rerank_engine/engine.py
+from dataclasses import dataclass
+import numpy as np, pandas as pd
+from hvantk.algorithms.rerank.config import validate
+from hvantk.algorithms.rerank.features import FeatureAssembler
+from hvantk.algorithms.rerank.reranker import ReRanker
+from hvantk.algorithms.rerank.tiers import TierAssigner
+from hvantk.algorithms.rerank.evaluator import Evaluator, EvalResult
+
+@dataclass
+class RerankResult:
+    table: pd.DataFrame; metrics: EvalResult; coverage: dict
+
+def rerank(config) -> RerankResult:
+    validate(config)
+    matrix, coverage = FeatureAssembler().assemble(config)
+    prior = config.prior.load().rename(columns={"unit": "gene"})
+    pos = config.labels.load()
+    df = matrix.merge(prior, on="gene", how="left")
+    df["y"] = df["gene"].isin(pos).astype(int)
+    feat_cols = [c for c in matrix.columns if c != "gene"]
+    for c in feat_cols: df[c] = pd.to_numeric(df[c], errors="coerce")
+    y = df["y"].values
+    covered = sum(1 for g in pos if g in set(matrix["gene"]))
+    if pos and covered / len(pos) < config.min_label_coverage:
+        raise ValueError(
+            f"label/feature join coverage too low: only {covered}/{len(pos)} "
+            f"({covered/len(pos):.0%}) positive units are in the feature matrix — likely a gene-symbol/build mismatch")
+    scores = ReRanker(config.calibration, config.folds).score(df, feat_cols, y)
+    veto_table = df
+    if config.cohort is not None:
+        cohort_cols = config.cohort.load()
+        add = [c for c in cohort_cols.columns if c != "gene" and c not in veto_table.columns]
+        veto_table = df.merge(cohort_cols[["gene"] + add], on="gene", how="left")
+    veto_mask = config.veto.apply(veto_table).reset_index(drop=True)
+    tiers = TierAssigner(config.tiers).assign(scores, veto_mask)
+    # axis groups for ablation = one group per FeatureAxis (its own columns), baseline = first axis present
+    groups = {ax.name: [c for c in ax.load().columns if c != "gene" and c in feat_cols] for ax in config.features}
+    groups = {k:v for k,v in groups.items() if v}
+    baseline = next(iter(groups))
+    metrics = Evaluator().evaluate(df, feat_cols, y, scores, groups, baseline)
+    table = pd.DataFrame({"gene": df.gene, "prior_stat": df.prior_stat, "score": scores,
+                          "veto_flag": veto_mask.values, "y": y})
+    table = pd.concat([table.reset_index(drop=True), tiers.reset_index(drop=True)], axis=1)
+    # Append extra genes that were excluded from model scoring (e.g. paper-14 extras like HCAR1).
+    # They are forced to FRAGILE verdict with no model score.
+    if config.extra_vetoed_genes:
+        extra_y = {g: int(g in pos) for g in config.extra_vetoed_genes}
+        extra_rows = pd.DataFrame([{
+            "gene": g, "prior_stat": float("nan"), "score": float("nan"),
+            "veto_flag": True, "y": extra_y.get(g, 0),
+            "tier": "T0_FRAGILE", "verdict": "FRAGILE",
+        } for g in config.extra_vetoed_genes if g not in set(df.gene)])
+        if len(extra_rows):
+            table = pd.concat([table, extra_rows], ignore_index=True)
+    return RerankResult(table=table, metrics=metrics, coverage=coverage)

--- a/hvantk/algorithms/rerank/engine.py
+++ b/hvantk/algorithms/rerank/engine.py
@@ -26,6 +26,11 @@ def rerank(config) -> RerankResult:
         raise ValueError(
             f"label/feature join coverage too low: only {covered}/{len(pos)} "
             f"({covered/len(pos):.0%}) positive units are in the feature matrix — likely a gene-symbol/build mismatch")
+    n_pos = int(y.sum()); n_neg = int(len(y) - n_pos)
+    if min(n_pos, n_neg) < config.folds:
+        raise ValueError(
+            f"too few examples for {config.folds}-fold OOF: {n_pos} positive / {n_neg} negative units "
+            f"(need >= {config.folds} of each class). Provide more labels or lower Config.folds.")
     scores = ReRanker(config.calibration, config.folds).score(df, feat_cols, y)
     veto_table = df
     if config.cohort is not None:

--- a/hvantk/algorithms/rerank/evaluator.py
+++ b/hvantk/algorithms/rerank/evaluator.py
@@ -1,0 +1,43 @@
+# local/rerank_engine/evaluator.py
+from dataclasses import dataclass
+import numpy as np, pandas as pd
+from sklearn.metrics import roc_auc_score, average_precision_score, brier_score_loss
+from sklearn.calibration import calibration_curve
+from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.model_selection import StratifiedKFold, cross_val_predict
+from hvantk.algorithms.rerank.reranker import ReRanker
+
+
+def _raw_oof(matrix, cols, y):
+    gbm = HistGradientBoostingClassifier(max_depth=3, max_iter=250, learning_rate=0.05,
+        l2_regularization=1.0, min_samples_leaf=20, class_weight="balanced", random_state=42)
+    cv = StratifiedKFold(5, shuffle=True, random_state=42)
+    return cross_val_predict(gbm, matrix[cols].values, y, cv=cv, method="predict_proba")[:, 1]
+
+@dataclass
+class EvalResult:
+    auc: float; pr_auc: float; brier: float; ablation: pd.DataFrame; calibration: tuple
+
+def _boot_ci(y, p1, p0, n=1000):
+    rng = np.random.default_rng(42); idx = np.arange(len(y)); d=[]
+    for _ in range(n):
+        b = rng.choice(idx, len(idx), True)
+        if 0 < y[b].sum() < len(b): d.append(roc_auc_score(y[b], p1[b]) - roc_auc_score(y[b], p0[b]))
+    return [round(v,3) for v in np.percentile(d, [2.5,50,97.5])]
+
+class Evaluator:
+    def evaluate(self, matrix, feat_cols, y, scores, axis_groups, baseline_axis):
+        y = np.asarray(y); scores = np.asarray(scores)
+        auc = roc_auc_score(y, scores); pr = average_precision_score(y, scores)
+        cs = (scores - scores.min())/(scores.max()-scores.min()+1e-12)
+        brier = brier_score_loss(y, cs)
+        cal = calibration_curve(y, cs, n_bins=8, strategy="quantile")
+        base_cols = axis_groups[baseline_axis]
+        p_base = _raw_oof(matrix, base_cols, y); base_auc = roc_auc_score(y, p_base)
+        rows = [{"family": baseline_axis, "auc": round(base_auc,3), "d_lo":0.0,"d_md":0.0,"d_hi":0.0}]
+        for fam, cols in axis_groups.items():
+            if fam == baseline_axis: continue
+            cc = list(dict.fromkeys(base_cols + cols))
+            p = _raw_oof(matrix, cc, y); lo, md, hi = _boot_ci(y, p, p_base)
+            rows.append({"family": fam, "auc": round(roc_auc_score(y,p),3), "d_lo":lo,"d_md":md,"d_hi":hi})
+        return EvalResult(round(auc,3), round(pr,3), round(brier,4), pd.DataFrame(rows), cal)

--- a/hvantk/algorithms/rerank/features.py
+++ b/hvantk/algorithms/rerank/features.py
@@ -1,0 +1,12 @@
+# local/rerank_engine/features.py
+import functools, pandas as pd
+
+class FeatureAssembler:
+    def assemble(self, config):
+        frames = [ax.load() for ax in config.features]
+        matrix = functools.reduce(lambda l, r: l.merge(r, on="gene", how="outer"), frames)
+        coverage = {}
+        for ax, fr in zip(config.features, frames):
+            present = matrix["gene"].isin(set(fr["gene"]))
+            coverage[ax.name] = round(float(present.mean()), 3)
+        return matrix, coverage

--- a/hvantk/algorithms/rerank/features.py
+++ b/hvantk/algorithms/rerank/features.py
@@ -1,9 +1,24 @@
-# local/rerank_engine/features.py
-import functools, pandas as pd
+# hvantk/algorithms/rerank/features.py
+import functools
+import logging
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
 
 class FeatureAssembler:
     def assemble(self, config):
-        frames = [ax.load() for ax in config.features]
+        frames = []
+        for ax in config.features:
+            fr = ax.load()
+            if fr["gene"].duplicated().any():
+                n_dup = int(fr["gene"].duplicated().sum())
+                logger.warning(
+                    "rerank feature axis '%s': %d duplicate gene key(s) dropped (kept first) "
+                    "to avoid a cartesian blow-up on the outer join", ax.name, n_dup)
+                fr = fr.drop_duplicates("gene", keep="first")
+            frames.append(fr)
         matrix = functools.reduce(lambda l, r: l.merge(r, on="gene", how="outer"), frames)
         coverage = {}
         for ax, fr in zip(config.features, frames):

--- a/hvantk/algorithms/rerank/reranker.py
+++ b/hvantk/algorithms/rerank/reranker.py
@@ -1,0 +1,25 @@
+# local/rerank_engine/reranker.py
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.model_selection import StratifiedKFold, cross_val_predict
+
+
+def _gbm():   # ported from chd_score_lib.gbm()
+    return HistGradientBoostingClassifier(max_depth=3, max_iter=250, learning_rate=0.05,
+        l2_regularization=1.0, min_samples_leaf=20, class_weight="balanced", random_state=42)
+
+
+class ReRanker:
+    """Calibrated GBM scorer: inner isotonic calibration nested inside an outer
+    5-fold cross_val_predict for out-of-fold, no-leakage calibrated probabilities.
+    Matches Phase-1 chd_calibrate.py exactly."""
+    def __init__(self, calibration="isotonic", folds=5):
+        self.calibration = calibration
+        self.folds = folds
+
+    def score(self, matrix, feat_cols, y):
+        X = matrix[feat_cols].values
+        cv = StratifiedKFold(self.folds, shuffle=True, random_state=42)
+        clf = CalibratedClassifierCV(_gbm(), method=self.calibration, cv=self.folds)
+        return cross_val_predict(clf, X, y, cv=cv, method="predict_proba")[:, 1]

--- a/hvantk/algorithms/rerank/tiers.py
+++ b/hvantk/algorithms/rerank/tiers.py
@@ -1,0 +1,13 @@
+# local/rerank_engine/tiers.py
+import numpy as np, pandas as pd
+
+class TierAssigner:
+    def __init__(self, tiers=5): self.tiers = tiers
+    def assign(self, scores, veto_mask):
+        s = pd.Series(np.asarray(scores)); veto = pd.Series(np.asarray(veto_mask)).reset_index(drop=True)
+        labels = [f"T{i+1}" for i in range(self.tiers)]
+        tier = pd.qcut(s.rank(method="first"), self.tiers, labels=labels).astype(str)
+        final_tier = np.where(veto, "T0_FRAGILE", tier)
+        top2 = set(labels[-2:])
+        verdict = np.where(veto, "FRAGILE", np.where(pd.Series(final_tier).isin(top2), "ROBUST", "INTERMEDIATE"))
+        return pd.DataFrame({"tier": final_tier, "verdict": verdict})

--- a/hvantk/algorithms/rerank/veto.py
+++ b/hvantk/algorithms/rerank/veto.py
@@ -1,0 +1,22 @@
+# local/rerank_engine/veto.py
+from abc import ABC, abstractmethod
+import numpy as np, pandas as pd
+
+class Veto(ABC):
+    @abstractmethod
+    def apply(self, unit_table: pd.DataFrame) -> pd.Series: ...
+
+class NoOpVeto(Veto):
+    def apply(self, unit_table: pd.DataFrame) -> pd.Series:
+        return pd.Series(False, index=unit_table.index)
+
+class CaseControlArchitectureVeto(Veto):
+    """Ported from chd_veto.py: recurrent control-shared driver / too-few variants / QC-leak common variant."""
+    def apply(self, unit_table: pd.DataFrame) -> pd.Series:
+        df = unit_table
+        nv = pd.to_numeric(df.n_case_var, errors="coerce")
+        conc = pd.to_numeric(df.conc, errors="coerce")
+        daf = pd.to_numeric(df.get("driver_af", df.get("driver_af_f")), errors="coerce").fillna(0)
+        arch_fragile = (nv <= 2) | ((conc >= 0.6) & (daf > 5e-5))
+        qc_flag = daf > 1e-3
+        return (arch_fragile | qc_flag).fillna(False)

--- a/hvantk/algorithms/rerank/veto.py
+++ b/hvantk/algorithms/rerank/veto.py
@@ -1,21 +1,37 @@
-# local/rerank_engine/veto.py
+# hvantk/algorithms/rerank/veto.py
 from abc import ABC, abstractmethod
-import numpy as np, pandas as pd
+import pandas as pd
+
 
 class Veto(ABC):
     @abstractmethod
     def apply(self, unit_table: pd.DataFrame) -> pd.Series: ...
 
+
 class NoOpVeto(Veto):
     def apply(self, unit_table: pd.DataFrame) -> pd.Series:
         return pd.Series(False, index=unit_table.index)
 
+
 class CaseControlArchitectureVeto(Veto):
-    """Ported from chd_veto.py: recurrent control-shared driver / too-few variants / QC-leak common variant."""
+    """Ported from chd_veto.py: recurrent control-shared driver / too-few variants / QC-leak common variant.
+
+    Requires case/control architecture columns ``n_case_var``, ``conc`` and ``driver_af``
+    in the veto table (supplied via the cohort and/or feature tables). Use
+    :class:`NoOpVeto` for tables that lack this architecture.
+    """
     def apply(self, unit_table: pd.DataFrame) -> pd.Series:
         df = unit_table
-        nv = pd.to_numeric(df.n_case_var, errors="coerce")
-        conc = pd.to_numeric(df.conc, errors="coerce")
+        has_driver = ("driver_af" in df.columns) or ("driver_af_f" in df.columns)
+        missing = [c for c in ("n_case_var", "conc") if c not in df.columns]
+        if missing or not has_driver:
+            need = missing + ([] if has_driver else ["driver_af"])
+            raise ValueError(
+                "CaseControlArchitectureVeto requires case/control architecture columns "
+                f"{need} in the veto table (supplied via the cohort and/or feature tables). "
+                "Use NoOpVeto (omit the cohort) for tables without this architecture.")
+        nv = pd.to_numeric(df["n_case_var"], errors="coerce")
+        conc = pd.to_numeric(df["conc"], errors="coerce")
         daf = pd.to_numeric(df.get("driver_af", df.get("driver_af_f")), errors="coerce").fillna(0)
         arch_fragile = (nv <= 2) | ((conc >= 0.6) & (daf > 5e-5))
         qc_flag = daf > 1e-3

--- a/hvantk/core/tool/api.py
+++ b/hvantk/core/tool/api.py
@@ -23,6 +23,7 @@ Domain = Literal[
     "enrichex",
     "hgc",
     "infra",
+    "rerank",
 ]
 
 ToolType = Literal["command", "command_group"]

--- a/hvantk/core/tool/manifest.schema.json
+++ b/hvantk/core/tool/manifest.schema.json
@@ -24,7 +24,8 @@
         "qtl",
         "enrichex",
         "hgc",
-        "infra"
+        "infra",
+        "rerank"
       ]
     },
     "type": {

--- a/hvantk/hvantk.py
+++ b/hvantk/hvantk.py
@@ -19,6 +19,7 @@ from hvantk.tools.plugins.plugins_cli import plugins_group
 from hvantk.tools.plugins.tools_cli import tools_group
 from hvantk.tools.plugins.drift_cli import drift_cmd
 from hvantk.tools.plugins.reprocess_cli import reprocess_cmd
+from hvantk.tools.rerank import rerank_cmd
 
 # Main CLI entry point for the package (hvantk)
 
@@ -94,6 +95,7 @@ cli.add_command(plugins_group)
 cli.add_command(tools_group)
 cli.add_command(drift_cmd)
 cli.add_command(reprocess_cmd)
+cli.add_command(rerank_cmd)
 
 
 def main():

--- a/hvantk/tests/rerank/conftest.py
+++ b/hvantk/tests/rerank/conftest.py
@@ -1,0 +1,7 @@
+# hvantk/tests/rerank/conftest.py
+# Limit OpenMP / BLAS thread count so GBM cross-validation tests don't
+# spawn 100+ threads on many-core HPC nodes and get OOM-killed.
+import os
+os.environ.setdefault("OMP_NUM_THREADS", "2")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "2")
+os.environ.setdefault("MKL_NUM_THREADS", "2")

--- a/hvantk/tests/rerank/test_catalog.py
+++ b/hvantk/tests/rerank/test_catalog.py
@@ -1,0 +1,115 @@
+# hvantk/tests/rerank/test_catalog.py
+# Trimmed for hvantk CI: domain-specific axis builders (constraint/burden/subgenic/labels/ptm)
+# stay in local/rerank_engine/catalog/axes.py (workspace recipes).
+# Only registry mechanics + generic builders are tested here.
+from hvantk.algorithms.rerank.catalog.profile import DiseaseProfile
+
+
+def test_profile_defaults():
+    p = DiseaseProfile(name="t")
+    assert p.cohort is None and p.precomputed is None and p.tissue is None
+    assert p.min_label_coverage == 0.5
+    assert p.label_classifications == ["Definitive", "Strong", "Moderate"]
+    assert p.cell_types == [] and p.disease_terms == [] and p.extra_vetoed_genes == []
+    assert p.extra_positive_genes == set()
+
+
+# Task 2: Registry mechanics tests
+import pandas as pd
+from hvantk.algorithms.rerank.config import FeatureAxis
+from hvantk.algorithms.rerank.catalog.profile import DiseaseProfile
+from hvantk.algorithms.rerank.catalog.registry import axis, AXES, build_config, _constraint_first, _default_veto
+from hvantk.algorithms.rerank.veto import NoOpVeto, CaseControlArchitectureVeto
+
+
+def test_constraint_first_reorders():
+    feats = [FeatureAxis("expression", lambda: pd.DataFrame({"gene": ["A"], "x": [1.0]})),
+             FeatureAxis("constraint", lambda: pd.DataFrame({"gene": ["A"], "z": [1.0]}))]
+    out = _constraint_first(feats)
+    assert out[0].name == "constraint"
+
+
+def test_default_veto_depends_on_cohort():
+    from hvantk.algorithms.rerank.config import CohortSpec
+    assert isinstance(_default_veto(DiseaseProfile(name="t")), NoOpVeto)
+    p = DiseaseProfile(name="t", cohort=CohortSpec("x.tsv", params={}))
+    assert isinstance(_default_veto(p), CaseControlArchitectureVeto)
+
+
+def test_build_config_string_and_override():
+    import pandas as pd
+    from hvantk.algorithms.rerank.config import FeatureAxis, LabelSpec
+    from hvantk.algorithms.rerank.catalog.registry import axis, AXES, build_config
+    from hvantk.algorithms.rerank.catalog.profile import DiseaseProfile
+    from hvantk.algorithms.rerank.veto import NoOpVeto
+    _saved = dict(AXES)
+    try:
+        @axis("labels")
+        def _labels(profile):
+            return LabelSpec(lambda: {"A"})
+
+        @axis("dummy_constraint")
+        def _dummy_constraint(profile):
+            return FeatureAxis("constraint", lambda: pd.DataFrame({"gene": ["A", "B"], "z": [1.0, 2.0]}))
+
+        from hvantk.algorithms.rerank.config import PriorSpec
+        p = DiseaseProfile(name="t", disease_terms=[],
+                           prior=PriorSpec(path="/dev/null", unit_col="gene", stat_col="score"))
+        override = FeatureAxis("expression", lambda: pd.DataFrame({"gene": ["A", "B"], "x": [3.0, 4.0]}))
+        cfg = build_config(p, axes=["dummy_constraint", override])
+        assert cfg.name == "t"
+        assert [f.name for f in cfg.features][0] == "constraint"
+        assert "expression" in [f.name for f in cfg.features]
+        assert isinstance(cfg.veto, NoOpVeto)
+    finally:
+        AXES.clear()
+        AXES.update(_saved)
+
+
+# Task 3: Generic builders (table_axis / genelist_labels) - path-free synthetic tests
+def test_table_axis_parquet(tmp_path):
+    import pandas as pd
+    from hvantk.algorithms.rerank.catalog.builders import table_axis
+    df = pd.DataFrame({"gene": ["A", "B"], "x": [1.0, 2.0]})
+    p = tmp_path / "feat.parquet"
+    df.to_parquet(p)
+    ax = table_axis("myaxis", str(p))
+    loaded = ax.load()
+    assert list(loaded.columns) == ["gene", "x"]
+    assert ax.name == "myaxis"
+
+
+def test_table_axis_tsv(tmp_path):
+    from hvantk.algorithms.rerank.catalog.builders import table_axis
+    p = tmp_path / "feat.tsv"
+    p.write_text("gene\tx\nA\t1.0\nB\t2.0\n")
+    ax = table_axis("tsv_axis", str(p))
+    loaded = ax.load()
+    assert list(loaded["gene"]) == ["A", "B"]
+
+
+def test_genelist_labels(tmp_path):
+    from hvantk.algorithms.rerank.catalog.builders import genelist_labels
+    p = tmp_path / "genes.txt"
+    p.write_text("GENE1\nGENE2\n# comment\n\n")
+    ls = genelist_labels(str(p))
+    s = ls.load()
+    assert s == {"GENE1", "GENE2"}
+
+
+def test_axis_registry_decorator():
+    """axis() decorator registers a builder in AXES and it can be looked up."""
+    from hvantk.algorithms.rerank.catalog.registry import axis, AXES
+    _saved = dict(AXES)
+    try:
+        @axis("test_synthetic")
+        def _build(profile):
+            return FeatureAxis("test_synthetic", lambda: pd.DataFrame({"gene": ["X"], "v": [1.0]}))
+
+        assert "test_synthetic" in AXES
+        p = DiseaseProfile(name="t")
+        ax = AXES["test_synthetic"](p)
+        assert ax.name == "test_synthetic"
+    finally:
+        AXES.clear()
+        AXES.update(_saved)

--- a/hvantk/tests/rerank/test_cli.py
+++ b/hvantk/tests/rerank/test_cli.py
@@ -1,0 +1,21 @@
+# hvantk/tests/rerank/test_cli.py
+import numpy as np, pandas as pd, yaml
+from click.testing import CliRunner
+from hvantk.tools.rerank import rerank_cmd
+
+
+def test_rerank_cli_end_to_end(tmp_path):
+    rng = np.random.default_rng(0); n = 150; genes = [f"g{i}" for i in range(n)]
+    y = (rng.random(n) < 0.3).astype(int)
+    pd.DataFrame({"gene": genes, "p": rng.random(n)}).to_csv(tmp_path/"prior.tsv", sep="\t", index=False)
+    pd.DataFrame({"gene": genes, "x": y + rng.normal(0, .5, n)}).to_parquet(tmp_path/"feat.parquet")
+    (tmp_path/"labels.txt").write_text("\n".join(g for g, yy in zip(genes, y) if yy == 1))
+    cfg = {"name": "toy",
+           "prior": {"path": str(tmp_path/"prior.tsv"), "unit_col": "gene", "stat_col": "p"},
+           "features": [{"name": "constraint", "path": str(tmp_path/"feat.parquet")}],
+           "labels": {"path": str(tmp_path/"labels.txt")}, "min_label_coverage": 0.0}
+    (tmp_path/"c.yaml").write_text(yaml.safe_dump(cfg))
+    out = tmp_path/"out.tsv"
+    r = CliRunner().invoke(rerank_cmd, ["-c", str(tmp_path/"c.yaml"), "-o", str(out)])
+    assert r.exit_code == 0, r.output
+    t = pd.read_csv(out, sep="\t"); assert len(t) == n and {"gene", "score", "verdict"} <= set(t.columns)

--- a/hvantk/tests/rerank/test_config.py
+++ b/hvantk/tests/rerank/test_config.py
@@ -1,0 +1,38 @@
+# local/rerank_engine/tests/test_config.py
+import pytest, pandas as pd
+from hvantk.algorithms.rerank.config import Config, PriorSpec, FeatureAxis, LabelSpec, validate
+from hvantk.algorithms.rerank.veto import NoOpVeto
+
+def _mk():
+    return Config(name="t",
+        prior=PriorSpec(path="x.tsv", unit_col="gene", stat_col="minp"),
+        features=[FeatureAxis("constraint", lambda: pd.DataFrame({"gene":["A"],"mis_z":[1.0]}))],
+        labels=LabelSpec(lambda: {"A"}))
+
+def test_defaults():
+    c = _mk()
+    assert c.units == "gene" and c.cohort is None and isinstance(c.veto, NoOpVeto) and c.tiers == 5
+    assert c.calibration == "isotonic" and c.folds == 5
+
+def test_validate_rejects_variant_units():
+    c = _mk(); c.units = "variant"
+    with pytest.raises(NotImplementedError):
+        validate(c)
+
+def test_validate_requires_noop_veto_when_no_cohort():
+    from hvantk.algorithms.rerank.veto import CaseControlArchitectureVeto
+    c = _mk(); c.veto = CaseControlArchitectureVeto()   # cohort is None -> invalid
+    with pytest.raises(ValueError):
+        validate(c)
+
+def test_validate_passes_minimal():
+    validate(_mk())   # no raise
+
+def test_validate_rejects_empty_labels():
+    import pytest, pandas as pd
+    from hvantk.algorithms.rerank.config import Config, PriorSpec, FeatureAxis, LabelSpec, validate
+    c = Config(name="t", prior=PriorSpec("x.tsv","gene","minp"),
+               features=[FeatureAxis("a", lambda: pd.DataFrame({"gene":["A"],"x":[1.0]}))],
+               labels=LabelSpec(lambda: set()))
+    with pytest.raises(ValueError):
+        validate(c)

--- a/hvantk/tests/rerank/test_evaluator.py
+++ b/hvantk/tests/rerank/test_evaluator.py
@@ -1,0 +1,14 @@
+# local/rerank_engine/tests/test_evaluator.py
+import numpy as np, pandas as pd
+from hvantk.algorithms.rerank.evaluator import Evaluator
+
+def test_metrics_and_ablation_shapes():
+    rng = np.random.default_rng(0); n=300
+    y = (rng.random(n)<0.3).astype(int)
+    base = y + rng.normal(0,0.5,n); extra = rng.normal(0,1,n)   # extra is noise
+    m = pd.DataFrame({"gene":[f"g{i}" for i in range(n)], "base":base, "extra":extra})
+    scores = (base - base.min())/(base.max()-base.min())
+    ev = Evaluator().evaluate(m, ["base","extra"], y, scores,
+            axis_groups={"baseline":["base"], "extra":["extra"]}, baseline_axis="baseline")
+    assert 0.5 < ev.auc <= 1.0 and 0.0 < ev.brier < 0.5
+    assert "extra" in set(ev.ablation.family) and {"d_lo","d_md","d_hi"} <= set(ev.ablation.columns)

--- a/hvantk/tests/rerank/test_features.py
+++ b/hvantk/tests/rerank/test_features.py
@@ -1,0 +1,19 @@
+# local/rerank_engine/tests/test_features.py
+import pandas as pd
+from hvantk.algorithms.rerank.config import FeatureAxis
+from hvantk.algorithms.rerank.features import FeatureAssembler
+
+class _Cfg:
+    def __init__(self):
+        self.features=[
+          FeatureAxis("a", lambda: pd.DataFrame({"gene":["A","B"],"x":[1.0,2.0]})),
+          FeatureAxis("b", lambda: pd.DataFrame({"gene":["A"],"y":[9.0]})),
+        ]
+        self.cohort=None
+
+def test_assemble_outer_join_and_coverage():
+    m, cov = FeatureAssembler().assemble(_Cfg())
+    assert set(m.gene) == {"A","B"}
+    assert list(m.columns) == ["gene","x","y"]
+    assert m.loc[m.gene=="B","y"].isna().all()         # B missing from axis b -> NaN
+    assert cov["b"] == 0.5                              # 1 of 2 genes covered

--- a/hvantk/tests/rerank/test_reranker.py
+++ b/hvantk/tests/rerank/test_reranker.py
@@ -1,0 +1,13 @@
+# local/rerank_engine/tests/test_reranker.py
+import numpy as np, pandas as pd
+from sklearn.metrics import roc_auc_score
+from hvantk.algorithms.rerank.reranker import ReRanker
+
+def test_oof_scores_are_calibrated_and_discriminate():
+    rng = np.random.default_rng(0); n=400
+    y = (rng.random(n) < 0.3).astype(int)
+    x = y + rng.normal(0, 0.5, n)            # informative feature
+    m = pd.DataFrame({"gene":[f"g{i}" for i in range(n)], "x": x})
+    p = ReRanker(folds=5).score(m, ["x"], y)
+    assert p.shape == (n,) and ((p>=0)&(p<=1)).all()
+    assert roc_auc_score(y, p) > 0.8         # informative feature -> good OOF AUC

--- a/hvantk/tests/rerank/test_smoke.py
+++ b/hvantk/tests/rerank/test_smoke.py
@@ -1,0 +1,18 @@
+# hvantk/tests/rerank/test_smoke.py
+import numpy as np, pandas as pd
+from hvantk.algorithms.rerank import rerank, Config, PriorSpec, FeatureAxis, LabelSpec
+
+
+def test_engine_end_to_end(tmp_path):
+    rng = np.random.default_rng(0); n = 200
+    genes = [f"g{i}" for i in range(n)]; y = (rng.random(n) < 0.3).astype(int)
+    feat = pd.DataFrame({"gene": genes, "x": y + rng.normal(0, 0.5, n)})
+    prior = pd.DataFrame({"gene": genes, "p": rng.random(n)}); pf = tmp_path/"p.tsv"
+    prior.to_csv(pf, sep="\t", index=False)
+    pos = {g for g, yy in zip(genes, y) if yy == 1}
+    cfg = Config(name="t", prior=PriorSpec(str(pf), "gene", "p"),
+                 features=[FeatureAxis("x", lambda: feat)], labels=LabelSpec(lambda: pos),
+                 min_label_coverage=0.0)
+    res = rerank(cfg)
+    assert len(res.table) == n and res.metrics.auc > 0.7
+    assert {"gene", "score", "tier", "verdict"} <= set(res.table.columns)

--- a/hvantk/tests/rerank/test_tiers.py
+++ b/hvantk/tests/rerank/test_tiers.py
@@ -1,0 +1,12 @@
+# local/rerank_engine/tests/test_tiers.py
+import numpy as np, pandas as pd
+from hvantk.algorithms.rerank.tiers import TierAssigner
+
+def test_tiers_and_veto_override():
+    scores = np.linspace(0, 1, 10)
+    veto = pd.Series([False]*9 + [True])      # highest-scoring unit is vetoed
+    out = TierAssigner(tiers=5).assign(scores, veto)
+    assert out.loc[9, "tier"] == "T0_FRAGILE" and out.loc[9, "verdict"] == "FRAGILE"
+    assert out.loc[0, "verdict"] == "INTERMEDIATE"   # lowest non-vetoed -> low tier, not ROBUST
+    assert set(out.verdict) <= {"FRAGILE","INTERMEDIATE","ROBUST"}
+    assert "ROBUST" in set(out.verdict)

--- a/hvantk/tests/rerank/test_veto.py
+++ b/hvantk/tests/rerank/test_veto.py
@@ -1,0 +1,18 @@
+# local/rerank_engine/tests/test_veto.py
+import pandas as pd
+from hvantk.algorithms.rerank.veto import CaseControlArchitectureVeto, NoOpVeto
+
+def test_noop_vetoes_nothing():
+    t = pd.DataFrame({"gene":["A","B"]})
+    assert NoOpVeto().apply(t).tolist() == [False, False]
+
+def test_architecture_veto_rules():
+    t = pd.DataFrame({
+        "gene":     ["few","recurrent","qc","clean"],
+        "n_case_var":[2,      9,          24,   8],
+        "conc":      [0.3,    0.9,        0.5,  0.2],
+        "driver_af": [0.0,    1e-4,       6e-3, 1e-6],
+    })
+    v = CaseControlArchitectureVeto().apply(t).tolist()
+    # few(n<=2)=T ; recurrent(conc>=.6 & af>5e-5)=T ; qc(af>1e-3)=T ; clean=F
+    assert v == [True, True, True, False]

--- a/hvantk/tests/test_algorithm_metadata_phases_e_h.py
+++ b/hvantk/tests/test_algorithm_metadata_phases_e_h.py
@@ -122,7 +122,7 @@ def test_existing_algorithm_meta_still_works():
     assert meta.outputs == {}
 
 
-@pytest.mark.parametrize("domain", ["enrichex", "expression", "qtlcascade", "hgc"])
+@pytest.mark.parametrize("domain", ["enrichex", "expression", "qtlcascade", "hgc", "rerank"])
 def test_domain_has_no_skill_imports(domain):
     root = Path(__file__).resolve().parents[1] / "algorithms" / domain
     bad = []

--- a/hvantk/tools/rerank/__init__.py
+++ b/hvantk/tools/rerank/__init__.py
@@ -1,0 +1,3 @@
+# hvantk/tools/rerank/__init__.py
+from hvantk.tools.rerank.rerank_cli import rerank_cmd
+__all__ = ["rerank_cmd"]

--- a/hvantk/tools/rerank/rerank.tool.yaml
+++ b/hvantk/tools/rerank/rerank.tool.yaml
@@ -1,0 +1,20 @@
+api_version: 1
+name: rerank
+domain: rerank
+type: command
+description: Re-rank genes by multi-omic credibility from a declarative YAML config.
+cli:
+  module: hvantk.tools.rerank
+  function: rerank_cmd
+purpose:
+  short: Calibrated credibility re-ranking of a gene burden by multi-omic feature tables.
+  long: |
+    Given a YAML config naming a prior (gene burden), one or more gene-keyed
+    feature tables (constraint, expression, ...), a label gene-list, and an
+    optional cohort variant table (enabling the architecture/QC veto), `rerank`
+    fits a calibrated out-of-fold model, assigns credibility tiers, and reports
+    per-axis delta-AUC over the constraint baseline. The disease-specific feature
+    tables are produced by user recipes; the engine is disease-agnostic.
+requires:
+  hail: false
+  network: false

--- a/hvantk/tools/rerank/rerank_cli.py
+++ b/hvantk/tools/rerank/rerank_cli.py
@@ -1,0 +1,31 @@
+# hvantk/tools/rerank/rerank_cli.py
+import click, yaml, pandas as pd
+from hvantk.core.config import CONTEXT_SETTINGS
+from hvantk.algorithms.rerank import rerank, Config, PriorSpec, CohortSpec, LabelSpec
+from hvantk.algorithms.rerank.catalog.builders import table_axis, genelist_labels
+
+
+@click.command(name="rerank", context_settings=CONTEXT_SETTINGS,
+               help="Re-rank genes by multi-omic credibility from a declarative YAML config.")
+@click.option("-c", "--config", "config_path", required=True, type=click.Path(exists=True),
+              help="YAML config: prior, features (gene-keyed tables), labels, optional cohort.")
+@click.option("-o", "--output", required=True, type=click.Path(), help="Output ranked TSV.")
+def rerank_cmd(config_path, output):
+    with open(config_path) as fh:
+        spec = yaml.safe_load(fh)
+    prior = PriorSpec(spec["prior"]["path"], spec["prior"]["unit_col"], spec["prior"]["stat_col"])
+    feats = [table_axis(f["name"], f["path"]) for f in spec["features"]]
+    labels = genelist_labels(spec["labels"]["path"])
+    cohort = None
+    if spec.get("cohort"):
+        cohort = CohortSpec(spec["cohort"]["path"],
+                            params={"veto_cols": spec["cohort"].get("veto_cols", []), "key": "gene"})
+    from hvantk.algorithms.rerank.veto import CaseControlArchitectureVeto, NoOpVeto
+    cfg = Config(name=spec.get("name", "rerank"), prior=prior, features=feats, labels=labels,
+                 cohort=cohort, veto=CaseControlArchitectureVeto() if cohort else NoOpVeto(),
+                 min_label_coverage=float(spec.get("min_label_coverage", 0.5)))
+    res = rerank(cfg)
+    res.table.to_csv(output, sep="\t", index=False)
+    click.echo(f"Wrote {len(res.table)} genes -> {output}")
+    click.echo("Per-axis ablation (delta-AUC over constraint):")
+    click.echo(res.metrics.ablation.to_string(index=False))

--- a/hvantk/tools/rerank/rerank_cli.py
+++ b/hvantk/tools/rerank/rerank_cli.py
@@ -1,8 +1,8 @@
 # hvantk/tools/rerank/rerank_cli.py
-import click, yaml, pandas as pd
+import click
+import yaml
+
 from hvantk.core.config import CONTEXT_SETTINGS
-from hvantk.algorithms.rerank import rerank, Config, PriorSpec, CohortSpec, LabelSpec
-from hvantk.algorithms.rerank.catalog.builders import table_axis, genelist_labels
 
 
 @click.command(name="rerank", context_settings=CONTEXT_SETTINGS,
@@ -11,16 +11,33 @@ from hvantk.algorithms.rerank.catalog.builders import table_axis, genelist_label
               help="YAML config: prior, features (gene-keyed tables), labels, optional cohort.")
 @click.option("-o", "--output", required=True, type=click.Path(), help="Output ranked TSV.")
 def rerank_cmd(config_path, output):
+    # Heavy ML imports are deferred to invocation time so that importing the hvantk CLI
+    # (and every other subcommand) does NOT require scikit-learn, which is an OPTIONAL
+    # dependency. Mirrors the psroc/ancestry deferral pattern.
+    from hvantk.algorithms.rerank import rerank, Config, PriorSpec, CohortSpec
+    from hvantk.algorithms.rerank.catalog.builders import table_axis, genelist_labels
+    from hvantk.algorithms.rerank.veto import CaseControlArchitectureVeto, NoOpVeto
+
     with open(config_path) as fh:
         spec = yaml.safe_load(fh)
-    prior = PriorSpec(spec["prior"]["path"], spec["prior"]["unit_col"], spec["prior"]["stat_col"])
-    feats = [table_axis(f["name"], f["path"]) for f in spec["features"]]
-    labels = genelist_labels(spec["labels"]["path"])
+    if not isinstance(spec, dict):
+        raise click.ClickException(
+            f"config {config_path}: expected a YAML mapping, got {type(spec).__name__}")
+    for key in ("prior", "features", "labels"):
+        if key not in spec:
+            raise click.ClickException(f"config {config_path}: missing required key '{key}'")
+    try:
+        prior = PriorSpec(spec["prior"]["path"], spec["prior"]["unit_col"], spec["prior"]["stat_col"])
+        feats = [table_axis(f["name"], f["path"]) for f in spec["features"]]
+        labels = genelist_labels(spec["labels"]["path"])
+    except (KeyError, TypeError) as exc:
+        raise click.ClickException(
+            f"config {config_path}: malformed prior/features/labels block ({exc})")
+
     cohort = None
     if spec.get("cohort"):
         cohort = CohortSpec(spec["cohort"]["path"],
                             params={"veto_cols": spec["cohort"].get("veto_cols", []), "key": "gene"})
-    from hvantk.algorithms.rerank.veto import CaseControlArchitectureVeto, NoOpVeto
     cfg = Config(name=spec.get("name", "rerank"), prior=prior, features=feats, labels=labels,
                  cohort=cohort, veto=CaseControlArchitectureVeto() if cohort else NoOpVeto(),
                  min_label_coverage=float(spec.get("min_label_coverage", 0.5)))


### PR DESCRIPTION
# PR: feat/rerank → dev — `hvantk rerank` (calibrated multi-omic credibility re-ranking)

**Branch:** `feat/rerank` (3 commits) → **target:** `dev`. Diff: 27 files, +675, **additive only** (no existing
hvantk code removed). Status: ready for review; **not merged** (awaiting approval; never main directly).

> NOTE: this repo was `git init`'d locally and has no remote yet, and its history is disconnected from
> github.com/bigbio/hvantk. To raise this as a *real* GitHub PR, connect the repo to bigbio/hvantk (or a fork),
> reconcile history, install `gh`, and authenticate — then push `feat/rerank` and open the PR with this body.

## What this adds
A first-class **`hvantk rerank`** command + library: a disease-agnostic "annotations → calibrated credibility
re-ranking" engine, promoted from the validated workspace package (`local/rerank_engine/`, 27-test
science-regression).

- **`hvantk/algorithms/rerank/`** — engine (Config, FeatureAssembler, ReRanker [CalibratedClassifierCV nested
  OOF], TierAssigner, Evaluator, `rerank()`) + catalog framework (`DiseaseProfile`, `@axis`/`AXES`,
  `build_config`) + generic path-free builders (`table_axis`, `genelist_labels`). Public API via
  `from hvantk.algorithms.rerank import rerank, DiseaseProfile, build_config, ...`.
- **`hvantk/tools/rerank/`** — `hvantk rerank --config X.yaml -o out.tsv` (YAML → DiseaseProfile → build_config
  → rerank → ranked table + per-axis ΔAUC-over-constraint ablation) + `rerank.tool.yaml`; registered in
  `hvantk/hvantk.py`.
- **`hvantk/tests/rerank/`** — 21 path-free synthetic tests (engine + registry + CLI smoke), run under hvantk's
  default pytest (no Hail, no workspace data).

Disease-specific configs + data recipes + the CHD/epilepsy/NDD science-regression stay in the gitignored
workspace (`local/`), importing the moved engine — one engine, no fork.

## Validation (two-sided gate, both green)
- **hvantk CI:** `pytest hvantk/tests/rerank/` → **21 passed** (path-free).
- **Science-regression (workspace, importing the moved engine):** **27 passed** — CHD oracle reproduces
  constraint AUC 0.696 / hybrid 0.799 / verdicts 540-784-39 / feat_cols 51; epilepsy transfer 0.764;
  chd_ndd veto fires (39, HCAR1 FRAGILE); PTM experiment runs.
- Engine files moved **verbatim** (import-prefix only; diff-confirmed byte-identical).

## Reviewer notes / deferred polish (non-blocking; can fold into this PR)
- Rename `Config.extra_vetoed_genes` → `forced_fragile_genes` (clearer).
- `local/` recipes still `sys.path.insert` the workspace scratch dir to import Phase-1 reference scripts
  (workspace-only; not in the hvantk-tracked code).
- `expression` builder live path is brain-only (per-tissue dispatch deferred) — but that builder is a *recipe*
  in `local/`, not shipped in hvantk.
- `hvantk/tests/rerank/conftest.py` caps OMP/BLAS threads (avoids 128-core OOM in GBM CV).

## Risk
Additive; no existing hvantk module touched except a 2-line registration in `hvantk.py`. The engine is import-
prefix-identical to the validated workspace version; the science-regression is the behavior-preservation guard.
