### PR TITLE
feat(gnomad-metrics): add downloader (v2.1.1 + v4.0), make reprocess self-contained

### DIFF
--- a/docs_site/guide/data-sources.md
+++ b/docs_site/guide/data-sources.md
@@ -20,6 +20,7 @@ hvantk utils convert-bgz input.gz
 | ClinGen | `hvantk download clingen` | ~5 MB |
 | GenCC | `hvantk download gencc` | ~10 MB |
 | HGNC | `hvantk download hgnc` | ~20 MB |
+| gnomAD constraint | `hvantk download gnomad-metrics` | ~4.6 MB (v2.1.1) / ~82 MB (v4.0) |
 | UCSC Cell Browser | `hvantk download ucsc` | varies |
 | Expression Atlas | `hvantk download expression-atlas` | varies |
 
@@ -151,25 +152,31 @@ hvantk reprocess dbnsfp:variants \
 
 > **Note:** dbNSFP's builder reads BGZF input. If you only have a single combined `.gz`, pre-convert with `hvantk utils convert-bgz dbNSFP4.9a_variant.gz` before building.
 
-### gnomAD constraint metrics (~50 MB for gene-level)
+### gnomAD constraint metrics
 
-Gene-level constraint metrics (pLI, LOEUF, missense Z-score) from gnomAD v4.1.
-URL: https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv
+Per-gene constraint metrics (pLI, oe_lof / LOEUF, missense Z) from gnomAD. The
+tables are small and public, so hvantk ships a downloader
+(`hvantk download gnomad-metrics`; it is also in the built-in-downloader list above).
 
-**Download**:
+- **v2.1.1** (GRCh37, ~4.6 MB) — the default and the table hvantk standardises on
+  (keyed by `gene_id`).
+- **v4.0** (GRCh38, ~82 MB) — newer; per-transcript rows, dotted column names, and
+  **no `gene_id`** column, so build with `--plugin-arg key=transcript`. gnomAD did
+  not re-release constraint for v4.1.
+
+**Download + build** (end-to-end, defaults to v2.1.1 by-gene):
 
 ```bash
-wget https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv
-```
-
-**Build**:
-
-```bash
-# Place gnomad.v4.1.constraint_metrics.tsv in data/gnomad_metrics/ then:
 hvantk reprocess gnomad-metrics:metrics \
   --raw-dir data/gnomad_metrics/ \
-  --output gnomad_metrics.ht \
-  --skip-download
+  --output gnomad_metrics.ht
+
+# v4.0 (GRCh38) instead:
+hvantk download gnomad-metrics --version v4.0 \
+  --output data/gnomad_metrics/gnomad.v4.0.constraint_metrics.tsv
+hvantk reprocess gnomad-metrics:metrics --skip-download \
+  --raw-dir data/gnomad_metrics/ --output gnomad_metrics_v4.ht \
+  --plugin-arg key=transcript
 ```
 
 ### INSIDER interactome (~100 MB)

--- a/hvantk/skills/gnomad_metrics/SKILL.md
+++ b/hvantk/skills/gnomad_metrics/SKILL.md
@@ -12,33 +12,57 @@ Upstream: https://gnomad.broadinstitute.org/downloads
 
 - `gnomad-metrics:metrics` — per-gene constraint metrics, keyed by gene_id
 
+## Download
+
+The constraint tables are small and public, so the plugin ships a downloader
+(`hvantk download gnomad-metrics`). Two releases are supported:
+
+- **v2.1.1** (GRCh37, ~4.6 MB) — the default; `by_gene` (keyed by `gene_id`) or
+  `by_transcript`. This is what hvantk standardises on.
+- **v4.0** (GRCh38, ~82 MB) — `constraint_metrics`; per-transcript rows with
+  dotted column names (`lof.pLI`, `lof.oe_ci.upper` = LOEUF) and **no `gene_id`**
+  column, so build it with `--plugin-arg key=transcript`. (gnomAD did not
+  re-release constraint for v4.1, so v4.0 is the newest.)
+
+```bash
+hvantk download gnomad-metrics --output data/gnomad/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
+hvantk download gnomad-metrics --version v4.0 --output data/gnomad/gnomad.v4.0.constraint_metrics.tsv
+```
+
 ## Build
+
+`hvantk reprocess` runs download + build end-to-end (the downloader drops the
+file into `--raw-dir`; the builder resolves it):
 
 ```bash
 hvantk reprocess gnomad-metrics:metrics \
-  --raw-dir <dir-with-lof_metrics-tsv> \
-  --output <out.ht>
+  --raw-dir data/gnomad/ \
+  --output gnomad_metrics.ht
 ```
 
-Optional field selection can be passed through as a plugin arg, e.g.
-`--plugin-arg fields='["gene_id", "pLI", "oe_lof"]'`.
+Building the Hail Table needs Java 11 and adequate driver heap (locally:
+`PYSPARK_SUBMIT_ARGS="--driver-memory 8g pyspark-shell"`). Optional field
+selection: `--plugin-arg fields='["gene_id", "pLI", "oe_lof"]'`. For v4.0, pass
+`--plugin-arg key=transcript` (no `gene_id` column).
 
 The builder is `build_gnomad_metrics_metrics` in
 `hvantk/skills/gnomad_metrics/builder.py`, with signature
-`(parsed_input, ctx, **params) -> AnnotationTable`. It imports the gnomAD
-lof_metrics TSV inline via `hl.import_table(..., impute=True, key="gene_id")`,
-optionally selects `params["fields"]`, and wraps the result with provenance
-(`schema_id="gnomad-metrics-v1"`). The plugin loader auto-resolves this
-dataset from `plugin.yaml`; top-level builds run through
-`run_builder_for_spec` (`hvantk/core/plugin/run_builder.py`).
+`(parsed_input, ctx, **params) -> AnnotationTable`. `parsed_input` may be a file
+path or a `raw_dir` (the builder resolves the `*.bgz`/`*.tsv` inside it, so
+`reprocess` works end-to-end). It imports the table via
+`hl.import_table(..., impute=True, key=params.get("key", "gene_id"))`, optionally
+selects `params["fields"]`, and wraps the result with provenance
+(`schema_id="gnomad-metrics-v1"`). The plugin loader auto-resolves this dataset
+from `plugin.yaml`; top-level builds run through `run_builder_for_spec`
+(`hvantk/core/plugin/run_builder.py`).
 
 ## Phase K notes
 
 This plugin was promoted as part of Phase K of the data-model platform
 refactor. The drift probe (`drift_probe.py`, `fetch_fingerprint`) is a
-stub; a real probe should be implemented in a follow-up. The downloader is
-not implemented; upstream files are expected to be externally materialized
-for now.
+stub; a real probe should be implemented in a follow-up. The downloader
+(`cli.py`, `download_dataset` / `download_cmd`) fetches the constraint tables
+from the public gnomAD GCS bucket — see the Download section above.
 
 ## Schema
 

--- a/hvantk/skills/gnomad_metrics/builder.py
+++ b/hvantk/skills/gnomad_metrics/builder.py
@@ -3,6 +3,7 @@
 Owns the Phase B ``build_gnomad_metrics_metrics`` builder. Imports the
 gnomAD lof_metrics TSV keyed by ``gene_id`` and wraps with Provenance.
 """
+
 from __future__ import annotations
 
 import logging
@@ -31,15 +32,33 @@ def build_gnomad_metrics_metrics(
     **params
         Optional: fields (list of str) to select from the table.
     """
+    from pathlib import Path
+
     from hvantk.core.models import AnnotationTable
 
     fields = params.get("fields", None)
+    # Key column: v2.1.1 by_gene has "gene_id"; v4.0 constraint_metrics has no
+    # gene_id column (per-transcript rows), so callers pass e.g. key="transcript".
+    key = params.get("key", "gene_id")
+
+    # `hvantk reprocess` hands a download-only plugin's builder the raw_dir (no
+    # parse stage); resolve the constraint file inside it. An explicit file path
+    # (run_builder_for_spec / tests) is used as-is.
+    src = Path(parsed_input)
+    if src.is_dir():
+        candidates = sorted(src.glob("*.bgz")) + sorted(src.glob("*.tsv"))
+        if not candidates:
+            raise FileNotFoundError(
+                f"No gnomAD constraint file (*.bgz/*.tsv) found in {src}"
+            )
+        src = candidates[0]
+        logger.info("Resolved gnomAD constraint file: %s", src)
 
     ht = hl.import_table(
-        paths=str(parsed_input),
+        paths=str(src),
         impute=True,
         min_partitions=100,
-        key="gene_id",
+        key=key,
     )
 
     # 2. Optional field selection

--- a/hvantk/skills/gnomad_metrics/cli.py
+++ b/hvantk/skills/gnomad_metrics/cli.py
@@ -1,0 +1,213 @@
+"""CLI command and lifecycle entry point for downloading gnomAD constraint
+gene metrics.
+
+The gnomAD constraint tables are small (v2.1.1 by-gene ~4.6 MB, v4.0
+constraint metrics ~82 MB) and served from the public gnomAD GCS bucket, so
+they qualify for a built-in downloader.
+
+Examples:
+    # Default: gnomAD v2.1.1 per-gene constraint (the hvantk standard)
+    hvantk gnomad-metrics-download --output data/gnomad/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
+
+    # v4.0 (GRCh38) constraint metrics
+    hvantk gnomad-metrics-download --version v4.0 --output data/gnomad/gnomad.v4.0.constraint_metrics.tsv
+"""
+
+import logging
+from pathlib import Path
+
+import click
+
+from hvantk.core.config import (
+    CONTEXT_SETTINGS,
+)  # noqa: F401  (parity with sibling CLIs)
+from hvantk.skills.gnomad_metrics.shared.constants import (
+    DEFAULT_VERSION,
+    GNOMAD_CONSTRAINT_TABLES,
+    constraint_filename,
+    constraint_url,
+    resolve_table,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def download_gnomad_metrics(
+    output_path: str,
+    version: str = DEFAULT_VERSION,
+    table: str | None = None,
+    overwrite: bool = False,
+) -> str:
+    """Download a gnomAD constraint table to ``output_path``.
+
+    Parameters
+    ----------
+    output_path : str
+        Path to save the downloaded file.
+    version : str
+        gnomAD constraint release (``v2.1.1`` or ``v4.0``).
+    table : str, optional
+        Table within the release. Defaults to the per-release default
+        (``by_gene`` for v2.1.1, ``constraint_metrics`` for v4.0).
+    overwrite : bool
+        Whether to overwrite an existing file.
+
+    Returns
+    -------
+    str
+        Path to the downloaded file.
+
+    Raises
+    ------
+    ValueError
+        If ``version``/``table`` is unknown.
+    FileExistsError
+        If the file exists and ``overwrite`` is False.
+    RuntimeError
+        If the download or write fails.
+    """
+    import urllib.error
+    import urllib.request
+
+    url = constraint_url(version, table)  # validates version/table first
+    resolved_table = resolve_table(version, table)
+
+    output = Path(output_path)
+    if output.exists() and not overwrite:
+        raise FileExistsError(f"File already exists: {output_path}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        logger.info(
+            "Downloading gnomAD constraint (%s / %s) from %s",
+            version,
+            resolved_table,
+            url,
+        )
+        urllib.request.urlretrieve(url, output)
+        logger.info("Downloaded to %s", output_path)
+        return str(output)
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Failed to download gnomAD constraint: {e}") from e
+    except OSError as e:
+        raise RuntimeError(f"Failed to write file: {e}") from e
+
+
+def download_dataset(
+    raw_dir: str,
+    version: str = DEFAULT_VERSION,
+    table: str | None = None,
+    overwrite: bool = False,
+    **kwargs,
+) -> str:
+    """Lifecycle entry point for the plugin loader.
+
+    Per the ``DatasetSpec`` contract, a lifecycle ``download_fn`` accepts
+    ``raw_dir=<path>`` and writes the raw upstream file under that directory,
+    named with its canonical gnomAD basename.
+
+    Parameters
+    ----------
+    raw_dir : str
+        Directory under which the raw file is placed.
+    version : str
+        gnomAD constraint release (default ``v2.1.1``).
+    table : str, optional
+        Table within the release (default: per-release default).
+    overwrite : bool
+        Whether to overwrite an existing file.
+    **kwargs
+        Reserved for future lifecycle keyword arguments; ignored today.
+
+    Returns
+    -------
+    str
+        Path to the downloaded raw file.
+    """
+    raw = Path(raw_dir)
+    raw.mkdir(parents=True, exist_ok=True)
+    target = raw / constraint_filename(version, table)
+    return download_gnomad_metrics(
+        str(target), version=version, table=table, overwrite=overwrite
+    )
+
+
+@click.command(
+    "gnomad-metrics-download",
+    short_help="Download gnomAD constraint gene metrics (pLI, oe_lof/LOEUF, mis_z)",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=str,
+    required=True,
+    help="Output path for the downloaded file.",
+)
+@click.option(
+    "--version",
+    type=click.Choice(sorted(GNOMAD_CONSTRAINT_TABLES)),
+    default=DEFAULT_VERSION,
+    show_default=True,
+    help="gnomAD constraint release.",
+)
+@click.option(
+    "--table",
+    type=str,
+    default=None,
+    help=(
+        "Table within the release. v2.1.1: by_gene (default), by_transcript. "
+        "v4.0: constraint_metrics (default)."
+    ),
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Overwrite existing file if present.",
+)
+@click.pass_context
+def download_cmd(ctx, output_path, version, table, overwrite):
+    """Download the gnomAD constraint gene-metrics table.
+
+    gnomAD constraint provides per-gene intolerance scores (pLI, oe_lof and
+    its upper bound LOEUF, missense z) widely used to rank genes by their
+    tolerance to variation.
+
+    v2.1.1 (GRCh37, ~4.6 MB) is the hvantk default and builds cleanly via
+    ``hvantk reprocess gnomad-metrics:metrics`` (keyed by gene_id). v4.0
+    (GRCh38, ~82 MB) has a different, transcript-level schema — see the SKILL.
+
+    Upstream: https://gnomad.broadinstitute.org/downloads
+
+    Examples:
+
+        hvantk gnomad-metrics-download --output data/gnomad/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
+
+        hvantk gnomad-metrics-download --version v4.0 --output data/gnomad/gnomad.v4.0.constraint_metrics.tsv
+    """
+    try:
+        url = constraint_url(version, table)
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        ctx.exit(1)
+
+    click.echo(f"Downloading gnomAD constraint ({version}) from {url} ...")
+    try:
+        result_path = download_gnomad_metrics(
+            output_path, version=version, table=table, overwrite=overwrite
+        )
+        click.echo(f"Downloaded to: {result_path}")
+    except FileExistsError as e:
+        click.echo(f"Error: {e}", err=True)
+        click.echo("Use --overwrite to replace existing file.")
+        ctx.exit(1)
+    except RuntimeError as e:
+        click.echo(f"Download failed: {e}", err=True)
+        ctx.exit(1)
+
+
+# Backward-compatible alias mirroring sibling plugin CLIs.
+gnomad_metrics_downloader = download_cmd
+
+
+if __name__ == "__main__":
+    download_cmd()

--- a/hvantk/skills/gnomad_metrics/plugin.yaml
+++ b/hvantk/skills/gnomad_metrics/plugin.yaml
@@ -21,6 +21,10 @@ datasets:
     drift_probe:
       module: hvantk.skills.gnomad_metrics.drift_probe
       function: fetch_fingerprint
+    lifecycle:
+      download:
+        module: hvantk.skills.gnomad_metrics.cli
+        function: download_dataset
     skill: SKILL.md
     tests:
       command: pytest hvantk/skills/gnomad_metrics/tests
@@ -28,3 +32,8 @@ datasets:
       schema_snapshot: tests/snapshots/schema.json
       row_snapshot: tests/snapshots/sample_rows.json
       drift_fingerprint: tests/drift_fingerprint.json
+
+cli:
+  - command: gnomad-metrics-download
+    module: hvantk.skills.gnomad_metrics.cli
+    function: download_cmd

--- a/hvantk/skills/gnomad_metrics/shared/__init__.py
+++ b/hvantk/skills/gnomad_metrics/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helpers for the gnomad-metrics skill."""

--- a/hvantk/skills/gnomad_metrics/shared/constants.py
+++ b/hvantk/skills/gnomad_metrics/shared/constants.py
@@ -1,0 +1,79 @@
+"""Plugin-local constants for the gnomad-metrics skill.
+
+gnomAD constraint download coordinates. The tables live in the public gnomAD
+release bucket (``gcp-public-data--gnomad``) over plain HTTPS, no auth.
+
+Two releases are supported by the downloader:
+
+- ``v2.1.1`` (GRCh37) — flat column names, one row per gene, includes a
+  ``gene_id`` column. ``by_gene`` is the table hvantk standardises on
+  (pLI / oe_lof / LOEUF / mis_z, keyed by ``gene_id``). ``by_transcript`` is
+  the same metrics at transcript resolution.
+- ``v4.0`` (GRCh38) — one row per transcript (with a ``mane_select`` flag),
+  **dotted** column names (``lof.pLI``, ``lof.oe_ci.upper`` = LOEUF,
+  ``mis.z_score`` …) and **no ``gene_id`` column**. Building it needs a
+  non-default key (see ``build_gnomad_metrics_metrics`` ``key`` param).
+
+Note: the v2.1.1 path segment is ``2.1.1`` (no ``v`` prefix); v4.0 is ``v4.0``.
+gnomAD did not re-release constraint for v4.1, so v4.0 is the newest.
+"""
+
+# Public gnomAD release bucket (HTTPS, no auth).
+GNOMAD_RELEASE_BASE_URL = (
+    "https://storage.googleapis.com/gcp-public-data--gnomad/release"
+)
+
+# version -> table -> object path (relative to GNOMAD_RELEASE_BASE_URL).
+GNOMAD_CONSTRAINT_TABLES = {
+    "v2.1.1": {
+        "by_gene": "2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz",
+        "by_transcript": (
+            "2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.txt.bgz"
+        ),
+    },
+    "v4.0": {
+        "constraint_metrics": ("v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"),
+    },
+}
+
+# Default release + per-release default table.
+DEFAULT_VERSION = "v2.1.1"
+DEFAULT_TABLE = {
+    "v2.1.1": "by_gene",
+    "v4.0": "constraint_metrics",
+}
+
+
+def resolve_table(version: str, table: str | None = None) -> str:
+    """Validate ``version``/``table`` and return the resolved table name.
+
+    Raises
+    ------
+    ValueError
+        If ``version`` is unknown, or ``table`` is not valid for ``version``.
+    """
+    if version not in GNOMAD_CONSTRAINT_TABLES:
+        raise ValueError(
+            f"Unknown gnomAD constraint version {version!r}; "
+            f"choose from {sorted(GNOMAD_CONSTRAINT_TABLES)}"
+        )
+    tables = GNOMAD_CONSTRAINT_TABLES[version]
+    if table is None:
+        table = DEFAULT_TABLE[version]
+    if table not in tables:
+        raise ValueError(
+            f"Unknown table {table!r} for gnomAD {version}; "
+            f"choose from {sorted(tables)}"
+        )
+    return table
+
+
+def constraint_url(version: str, table: str | None = None) -> str:
+    """Return the download URL for a gnomAD constraint table."""
+    table = resolve_table(version, table)
+    return f"{GNOMAD_RELEASE_BASE_URL}/{GNOMAD_CONSTRAINT_TABLES[version][table]}"
+
+
+def constraint_filename(version: str, table: str | None = None) -> str:
+    """Return the canonical basename for a gnomAD constraint table."""
+    return constraint_url(version, table).rsplit("/", 1)[-1]

--- a/hvantk/skills/gnomad_metrics/tests/test_download.py
+++ b/hvantk/skills/gnomad_metrics/tests/test_download.py
@@ -1,0 +1,125 @@
+"""Tests for the gnomad-metrics downloader (URL map, lifecycle, CLI)."""
+
+from __future__ import annotations
+
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from hvantk.skills.gnomad_metrics import cli as gnomad_cli
+from hvantk.skills.gnomad_metrics.shared import constants as C
+
+# --------------------------------------------------------------------------- #
+# URL map (pure, no network)
+# --------------------------------------------------------------------------- #
+
+
+def test_default_is_v211_by_gene():
+    assert C.DEFAULT_VERSION == "v2.1.1"
+    assert C.DEFAULT_TABLE["v2.1.1"] == "by_gene"
+    url = C.constraint_url(C.DEFAULT_VERSION)
+    assert url.endswith("2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz")
+    assert url.startswith(
+        "https://storage.googleapis.com/gcp-public-data--gnomad/release/"
+    )
+
+
+def test_v211_by_transcript_and_v40_urls():
+    assert C.constraint_url("v2.1.1", "by_transcript").endswith(
+        "gnomad.v2.1.1.lof_metrics.by_transcript.txt.bgz"
+    )
+    v40 = C.constraint_url("v4.0")
+    assert v40.endswith("v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv")
+    assert C.constraint_filename("v4.0") == "gnomad.v4.0.constraint_metrics.tsv"
+
+
+@pytest.mark.parametrize(
+    "version,table",
+    [("v9.9", None), ("v2.1.1", "nope"), ("v4.0", "by_gene")],
+)
+def test_unknown_version_or_table_raises(version, table):
+    with pytest.raises(ValueError):
+        C.constraint_url(version, table)
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle download_dataset (mocked network)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_urlretrieve(recorder):
+    def _inner(url, filename):
+        Path(filename).write_bytes(b"fake gnomad constraint payload")
+        recorder.append((url, str(filename)))
+        return filename, None
+
+    return _inner
+
+
+def test_download_dataset_default_writes_by_gene(tmp_path, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(urllib.request, "urlretrieve", _fake_urlretrieve(calls))
+
+    out = gnomad_cli.download_dataset(str(tmp_path))
+
+    assert Path(out).name == "gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz"
+    assert Path(out).exists()
+    assert len(calls) == 1
+    requested_url, _ = calls[0]
+    assert requested_url == C.constraint_url("v2.1.1", "by_gene")
+
+
+def test_download_dataset_v40(tmp_path, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(urllib.request, "urlretrieve", _fake_urlretrieve(calls))
+
+    out = gnomad_cli.download_dataset(str(tmp_path), version="v4.0")
+
+    assert Path(out).name == "gnomad.v4.0.constraint_metrics.tsv"
+    assert calls[0][0] == C.constraint_url("v4.0")
+
+
+def test_download_dataset_no_overwrite(tmp_path, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(urllib.request, "urlretrieve", _fake_urlretrieve(calls))
+    gnomad_cli.download_dataset(str(tmp_path))  # first write
+    with pytest.raises(FileExistsError):
+        gnomad_cli.download_dataset(str(tmp_path))  # second without overwrite
+    # overwrite=True succeeds
+    gnomad_cli.download_dataset(str(tmp_path), overwrite=True)
+
+
+# --------------------------------------------------------------------------- #
+# Click command (mocked network)
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_download_cmd(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    calls: list = []
+    monkeypatch.setattr(urllib.request, "urlretrieve", _fake_urlretrieve(calls))
+
+    target = tmp_path / "out.bgz"
+    result = CliRunner().invoke(gnomad_cli.download_cmd, ["--output", str(target)])
+    assert result.exit_code == 0, result.output
+    assert target.exists()
+    assert calls[0][0] == C.constraint_url("v2.1.1", "by_gene")
+
+
+# --------------------------------------------------------------------------- #
+# Real reachability (network-gated, deselected by default)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.network
+@pytest.mark.parametrize("version", ["v2.1.1", "v4.0"])
+def test_gnomad_constraint_urls_reachable(version):
+    import urllib.request as _r
+
+    url = C.constraint_url(version)
+    req = _r.Request(url, method="HEAD")
+    with _r.urlopen(req, timeout=30) as resp:
+        assert resp.status == 200
+        assert int(resp.headers.get("Content-Length", "0")) > 0


### PR DESCRIPTION
## What

The `gnomad-metrics` plugin previously had **no downloader** ("upstream files
are expected to be externally materialized"). gnomAD's per-gene constraint
tables are small and public, so this adds a built-in downloader and makes
`hvantk reprocess gnomad-metrics:metrics` run end-to-end.

- **`hvantk download gnomad-metrics`** — auto-wired via the manifest `cli:`
  block. Options: `--version v2.1.1|v4.0`, `--table`, `--output`, `--overwrite`.
- **`hvantk reprocess gnomad-metrics:metrics`** — now downloads + builds without
  a manual pre-download step.

### Versions supported
- **v2.1.1** (GRCh37, ~4.6 MB) — the default and the table hvantk standardises
  on; `by_gene` (keyed by `gene_id`) or `by_transcript`.
- **v4.0** (GRCh38, ~82 MB) — `constraint_metrics`; per-transcript rows, dotted
  column names (`lof.pLI`, `lof.oe_ci.upper` = LOEUF), and **no `gene_id`**
  column, so build with `--plugin-arg key=transcript`. gnomAD did not re-release
  constraint for v4.1, so v4.0 is the newest.

## Changes
- **`cli.py`** (new) + **`shared/constants.py`** (new): `download_dataset`
  lifecycle entry + `gnomad-metrics-download` Click command; version/table → URL
  map with validation.
- **`plugin.yaml`**: `lifecycle.download` + top-level `cli:` (loader
  auto-registers `hvantk download gnomad-metrics`).
- **`builder.py`**: parameterize the import `key` (default `gene_id`; v4.0 uses
  `key=transcript`) and resolve the constraint file when `parsed_input` is a
  `raw_dir` — `reprocess` hands download-only builders the `raw_dir`, so this is
  what makes the end-to-end build work.
- **Tests** (`tests/test_download.py`, new): URL map + validation, mocked
  `download_dataset` (v2.1.1 default + v4.0 + overwrite), Click command, and a
  `@network` real-reachability check on both URLs.
- **Docs**: SKILL.md gains a Download section (and the "downloader not
  implemented" note is removed); `docs_site/guide/data-sources.md` moves gnomAD
  into the built-in-downloader table and **fixes a stale/broken URL** (it pointed
  at `release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv`, which 404s —
  v4 constraint lives under `release/v4.0/`).

## Verification
- `pytest hvantk/skills/gnomad_metrics/tests`: **10 unit + 2 `@network` (real
  HEAD, both URLs 200) + 1 `@hail` round-trip** pass.
- `flake8 --select=E9,F63,F7,F82`: clean. `black` (23.12): clean.
- End-to-end `hvantk reprocess gnomad-metrics:metrics` (v2.1.1) builds an
  `AnnotationTable` of **19,704 genes**, keyed by `gene_id`, with pLI / oe_lof /
  oe_lof_upper (LOEUF) / mis_z.

## Follow-up (out of scope)
The `raw_dir` → file resolution is fixed here for gnomad-metrics. The same latent
gap likely affects other **download-only** plugins (e.g. `hgnc`) whose builders
also receive `raw_dir` from `reprocess` and pass it straight to
`hl.import_table`. Worth handling generically in `reprocess` /
`run_builder_for_spec` in a follow-up; kept out of this PR to stay focused.
