### PR TITLE
fix: PTM dataset build-path — uniprot-ptm key, cptac reprocess wiring, deps & resilience (#198)

### DIFF
--- a/docs_site/guide/usage.md
+++ b/docs_site/guide/usage.md
@@ -63,6 +63,16 @@ hvantk reprocess cptac:expression \
   --plugin-arg cancer_type=brca
 ```
 
+CPTAC phosphoproteomics builds one AnnData per cancer type — the single
+`cancer_type` flows to both the download and the build:
+
+```bash
+hvantk reprocess cptac:phospho \
+  --raw-dir /data/cptac/ \
+  --output /out/cptac_phospho_brca.h5ad \
+  --plugin-arg cancer_type=brca
+```
+
 ## 2) Ancestry Inference
 
 Predict genetic ancestry for samples using PCA and Random Forest classification against a labeled reference panel.

--- a/hvantk/skills/cptac/phospho/SKILL.md
+++ b/hvantk/skills/cptac/phospho/SKILL.md
@@ -37,6 +37,7 @@ Aggregation gotchas (see `extract_phospho_sites` and `write_matrix_csv` in `shar
 - The same `(gene, amino_acid, position)` can appear via multiple peptide columns -- `extract_phospho_sites` aggregates `n_observations` and weighted-averages `mean_intensity` across columns. `write_matrix_csv` groups duplicate site labels by mean intensity per sample.
 - Sample-level tissue type is inferred from the sample-id suffix: `*.N` -> `normal`, everything else -> `tumor`. This is then joined onto the clinical metadata as a new `tissue_type` column.
 - Some cancer types have no normal samples; the downloader logs and continues without a `*-normal.tsv`.
+- **`coad` and `ov` fail *inside* `cptac` 1.5.14 (upstream, not hvantk):** the umich mapping download raises `unsupported operand type(s) for //: 'NoneType' and 'int'`, and the source fallback hits `len(generator)` at `cptac/cancers/cancer.py:682`. `--all` therefore skips-and-continues past them (see § 7) and reports a summary; the other cancer types still build. Revisit on a newer `cptac` release.
 - The package fetches data from upstream **at runtime** (no static URLs). The `cptac:phospho` drift probe therefore fingerprints the installed package version, not an HTTP `Last-Modified` header.
 
 For the AnnData builder, the input is the *wide* matrix CSV (sites in rows / first column, samples in remaining columns). Site IDs follow the `<gene>_<aa><pos>` convention (e.g. `TP53_S15`). The builder parses these via `_parse_site_id` and writes `gene_symbol`, `amino_acid`, `residue_pos` into `var`.

--- a/hvantk/skills/cptac/phospho/SKILL.md
+++ b/hvantk/skills/cptac/phospho/SKILL.md
@@ -65,9 +65,9 @@ AnnData (`.h5ad`) builder output:
 ## 6. hvantk integration points
 
 - **Dataset class + parser helpers:** `CPTACPhosphoDataset`, `parse_phospho_site`, `extract_phospho_sites`, `write_intermediate_tsv`, `write_matrix_csv`, `write_metadata_csv`, `parse_raw_dir` in `hvantk/skills/cptac/shared/datasets.py`.
-- **Builder:** `build_cptac_phospho(parsed_input, ctx, **params)` in `hvantk/skills/cptac/phospho/builder.py`. `parsed_input` is a `{"expression": <matrix.csv>, "metadata": <metadata.csv>}` dict; `params` are `site_id_col`, `sample_id_col`. Returns an `ExpressionMatrix` (shares `create_anndata_from_cptac_phospho` in `hvantk/skills/cptac/shared/cptac.py`).
+- **Builder:** `build_cptac_phospho(parsed_input, ctx, *, cancer_type=None, site_id_col="Site", sample_id_col="SampleID", **_)` in `hvantk/skills/cptac/phospho/builder.py`. `parsed_input` is either a `{"expression": <matrix.csv>, "metadata": <metadata.csv>}` dict (direct API) OR a raw download directory, in which case `cancer_type` selects the per-cancer `cptac-phospho-<ct>-matrix.csv` / `-metadata.csv` pair (this is the `reprocess` path — see § 7). `site_id_col` defaults to `"Site"` to match the matrix CSV header. Returns an `ExpressionMatrix` (shares `create_anndata_from_cptac_phospho` in `hvantk/skills/cptac/shared/cptac.py`).
 - **Downloader CLI:** `download_cmd` in `hvantk/skills/cptac/phospho/cli.py`, declared as command `cptac-phospho-download` in the manifest's `cli:` block. The plugin loader strips the `-download` suffix and wires it as `hvantk download cptac-phospho` (via `hvantk/tools/plugins/download_cli.py`).
-- **Lifecycle entry points:** `download_dataset` (in `phospho/cli.py`) and `parse_raw_dir` (in `shared/datasets.py`), wired via `lifecycle.download` + `lifecycle.parse` in `plugin.yaml`.
+- **Lifecycle entry points:** `download_dataset` (in `phospho/cli.py`), wired via `lifecycle.download` in `plugin.yaml`. There is **no** `lifecycle.parse` for the AnnData build: the download already writes the builder's matrix+metadata inputs, so `reprocess` hands the raw dir straight to the builder (mirrors `cptac:expression`). `parse_raw_dir` (in `shared/datasets.py`) remains a public helper that consolidates the site-level TSVs for the PTM pipeline; it is not wired into the AnnData lifecycle.
 - **Drift probe:** `fetch_fingerprint` in `hvantk/skills/cptac/phospho/drift_probe.py` (fingerprints the installed `cptac` package version).
 - **Downstream consumer:** `hvantk/algorithms/ptm/pipeline.py` (`PTMBuildConfig.cptac_tsv`) -- reads the per-cancer intermediate TSV and maps PTM sites to genomic coordinates. Exposed at the user-facing level by `hvantk/algorithms/ptm/atlas.py` (`PTMAtlasConfig.cptac_tsv`).
 - **Plugin manifest:** `hvantk/skills/cptac/plugin.yaml` (compound dataset key `cptac:phospho`). The loader auto-resolves the dataset via `get_registry().get_dataset("cptac:phospho")`; top-level builds run through `run_builder_for_spec` (`hvantk/core/plugin/run_builder.py`).
@@ -77,10 +77,23 @@ AnnData (`.h5ad`) builder output:
 
 When invoked to build or update CPTAC phospho data:
 
-1. **Download.** Either via the download CLI (`hvantk download cptac-phospho --cancer-type brca -o /data/cptac`) or via the lifecycle entry point (`hvantk reprocess cptac:phospho`, which calls `download_dataset(raw_dir=...)`). Pass `--all` for all cancer types; the downloader then also produces a pan-cancer merge TSV.
-2. **(Lifecycle) parse-only step.** `parse_raw_dir(raw_dir=..., output_path=..., cancer_type=...)` re-reads per-cancer TSVs from `raw_dir` and writes a consolidated TSV at `output_path`.
-3. **Builder.** `build_cptac_phospho(parsed_input, ctx, site_id_col=…, sample_id_col=…)` where `parsed_input = {"expression": <matrix.csv>, "metadata": <metadata.csv>}`, to produce the `(samples x sites)` `ExpressionMatrix`.
-4. **Validate.** `pytest hvantk/skills/cptac/phospho/tests` (parser + drift-probe).
+**One AnnData per cancer type.** CPTAC phospho matrices differ in sites and samples
+across cancer types, so a single `reprocess` builds one cancer's AnnData; run it once
+per cancer type. End-to-end via the documented CLI:
+
+```bash
+hvantk reprocess cptac:phospho \
+  --raw-dir /data/cptac \
+  --output cptac_phospho_brca.h5ad \
+  --plugin-arg cancer_type=brca
+```
+
+The one `cancer_type` flows to both the download (fetch only that cancer) and the
+build (select its matrix+metadata pair). Steps:
+
+1. **Download.** Via the download CLI (`hvantk download cptac-phospho --cancer-type brca -o /data/cptac`) or the lifecycle entry point (`reprocess` calls `download_dataset(raw_dir=..., cancer_type=brca)`). Pass `--all` to fetch every cancer type; the downloader then also produces a pan-cancer merge TSV and skips-and-continues past any cancer that fails upstream.
+2. **Builder.** `build_cptac_phospho(<raw_dir>, ctx, cancer_type="brca")` (or a `{"expression","metadata"}` dict for the direct API) produces the `(samples x sites)` `ExpressionMatrix`.
+3. **Validate.** `pytest hvantk/skills/cptac/phospho/tests` (parser + builder + drift-probe).
 
 ## 8. Update playbook
 

--- a/hvantk/skills/cptac/phospho/builder.py
+++ b/hvantk/skills/cptac/phospho/builder.py
@@ -3,30 +3,84 @@
 Owns the Phase B ``build_cptac_phospho`` builder. Turns a wide-format CPTAC
 phospho intensity matrix plus its sample metadata into an ``ExpressionMatrix``
 (samples x sites).
+
+CPTAC phospho is inherently per-cancer: each cancer type yields its own
+matrix+metadata pair and therefore its own AnnData. Like the sibling
+``cptac:expression`` dataset, this builder has no ``lifecycle.parse`` stage — the
+download already writes the builder's inputs — so ``reprocess`` hands it the raw
+download directory and a ``cancer_type`` selects the pair.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_phospho_inputs(parsed_input, *, cancer_type):
+    """Return ``(expression_csv, metadata_csv)`` paths.
+
+    ``parsed_input`` is either a ``{"expression","metadata"}`` mapping (direct API
+    / the per-cancer driver) or a raw download directory (``reprocess``), in which
+    case ``cancer_type`` selects the ``cptac-phospho-<ct>-matrix.csv`` /
+    ``-metadata.csv`` pair written by :meth:`CPTACPhosphoDataset.download`.
+    """
+    if isinstance(parsed_input, Mapping):
+        return str(parsed_input["expression"]), str(parsed_input["metadata"])
+
+    from hvantk.skills.cptac.shared.constants import CPTAC_CANCER_TYPES
+
+    raw = str(parsed_input)
+    if not os.path.isdir(raw):
+        raise TypeError(
+            "build_cptac_phospho expects a {'expression','metadata'} mapping or a "
+            f"raw download directory; got {raw!r}"
+        )
+    if not cancer_type:
+        raise ValueError(
+            "cptac:phospho builds one AnnData per cancer type; pass "
+            "--plugin-arg cancer_type=<ct> (one of: "
+            f"{', '.join(CPTAC_CANCER_TYPES)})"
+        )
+    expr = os.path.join(raw, f"cptac-phospho-{cancer_type}-matrix.csv")
+    meta = os.path.join(raw, f"cptac-phospho-{cancer_type}-metadata.csv")
+    missing = [p for p in (expr, meta) if not os.path.exists(p)]
+    if missing:
+        raise FileNotFoundError(
+            f"Missing CPTAC phospho input(s) for cancer_type={cancer_type!r}: "
+            f"{missing}. Run `hvantk download cptac-phospho --cancer-type "
+            f"{cancer_type}` (or `hvantk reprocess cptac:phospho`) first."
+        )
+    return expr, meta
 
 
 def build_cptac_phospho(
     parsed_input,
     ctx,
     *,
-    site_id_col: str = "SiteID",
+    cancer_type: str | None = None,
+    site_id_col: str = "Site",
     sample_id_col: str = "SampleID",
+    **_ignored,
 ):
-    """Phase B builder — returns an ExpressionMatrix from CPTAC wide-format phospho + metadata."""
+    """Phase B builder — ``ExpressionMatrix`` (samples x sites) for one cancer type.
+
+    ``site_id_col`` defaults to ``"Site"`` to match the matrix CSV header written
+    by ``write_matrix_csv`` (``df.index.name = "Site"``). Extra keyword arguments
+    that ``reprocess`` forwards from ``--plugin-arg`` (e.g. ``overwrite``, consumed
+    only by the download stage) are ignored here.
+    """
     import pandas as pd
     from hvantk.core.models import ExpressionMatrix
     from hvantk.core.models.anndata_utils import annotate_column_summary_ad
     from hvantk.skills.cptac.shared.cptac import create_anndata_from_cptac_phospho
 
-    expression_path = str(parsed_input["expression"])
-    metadata_path = str(parsed_input["metadata"])
+    expression_path, metadata_path = _resolve_phospho_inputs(
+        parsed_input, cancer_type=cancer_type
+    )
 
     expr_df = pd.read_csv(expression_path, sep=None, engine="python")
     meta_df = pd.read_csv(metadata_path, sep=None, engine="python")

--- a/hvantk/skills/cptac/phospho/cli.py
+++ b/hvantk/skills/cptac/phospho/cli.py
@@ -58,9 +58,22 @@ def download_dataset(
 
     cancer_types = [cancer_type] if cancer_type else CPTAC_CANCER_TYPES
     results: dict = {}
+    failures: dict = {}
     for ct in cancer_types:
-        dataset = CPTACPhosphoDataset(cancer_type=ct)
-        results[ct] = dataset.download(raw_dir, overwrite=overwrite)
+        try:
+            results[ct] = CPTACPhosphoDataset(cancer_type=ct).download(
+                raw_dir, overwrite=overwrite
+            )
+        except Exception as exc:  # noqa: BLE001 - skip-and-continue per cancer
+            # coad + ov fail inside cptac 1.5.14 upstream; one bad type must not
+            # lose the rest. Record and continue.
+            logger.warning("CPTAC phospho download failed for %s: %s", ct, exc)
+            failures[ct] = str(exc)
+    if failures:
+        results["_failures"] = failures
+    succeeded = [k for k in results if k != "_failures"]
+    if not succeeded:
+        raise RuntimeError(f"All CPTAC phospho downloads failed: {failures}")
     return results
 
 
@@ -123,45 +136,61 @@ def download_cmd(ctx, output_dir, cancer_type, download_all, list_cancers, overw
         )
         ctx.exit(1)
 
-    try:
-        from hvantk.skills.cptac.shared.datasets import CPTACPhosphoDataset, _TSV_COLUMNS
+    # These are hvantk classes (no cptac import at module scope), so this never
+    # fails on a missing cptac package -- that ImportError surfaces lazily inside
+    # dataset.download() and is handled per-cancer below.
+    from hvantk.skills.cptac.shared.datasets import CPTACPhosphoDataset, _TSV_COLUMNS
 
-        cancer_types = CPTAC_CANCER_TYPES if download_all else [cancer_type]
+    cancer_types = CPTAC_CANCER_TYPES if download_all else [cancer_type]
 
-        all_tsv_paths = []
-        for ct in cancer_types:
-            click.echo(f"Processing {ct}...")
-            dataset = CPTACPhosphoDataset(cancer_type=ct)
-            paths = dataset.download(output_dir, overwrite=overwrite)
-            click.echo(f"  TSV: {paths['tsv']}")
-            click.echo(f"  Matrix: {paths['matrix']}")
-            click.echo(f"  Metadata: {paths['metadata']}")
-            all_tsv_paths.append(paths["tsv"])
+    all_tsv_paths = []
+    succeeded, failed = [], {}
+    for ct in cancer_types:
+        click.echo(f"Processing {ct}...")
+        try:
+            paths = CPTACPhosphoDataset(cancer_type=ct).download(
+                output_dir, overwrite=overwrite
+            )
+        except ImportError as e:
+            # The cptac package itself is missing -> nothing can succeed.
+            click.echo(f"Error: {e}", err=True)
+            ctx.exit(1)
+        except Exception as exc:  # noqa: BLE001 - one bad cancer must not lose the rest
+            logger.warning("CPTAC phospho download failed for %s: %s", ct, exc)
+            click.echo(f"  FAILED: {exc}", err=True)
+            failed[ct] = str(exc)
+            continue
+        click.echo(f"  TSV: {paths['tsv']}")
+        click.echo(f"  Matrix: {paths['matrix']}")
+        click.echo(f"  Metadata: {paths['metadata']}")
+        succeeded.append(ct)
+        all_tsv_paths.append(paths["tsv"])
 
-        # Pan-cancer merge if --all
-        if download_all and len(all_tsv_paths) > 1:
-            pancancer_path = os.path.join(output_dir, "cptac-phospho-pancancer.tsv")
-            click.echo(f"Merging {len(all_tsv_paths)} cancer types into {pancancer_path}...")
+    # Pan-cancer merge over the cancer types that actually succeeded.
+    if download_all and len(all_tsv_paths) > 1:
+        pancancer_path = os.path.join(output_dir, "cptac-phospho-pancancer.tsv")
+        click.echo(f"Merging {len(all_tsv_paths)} cancer types into {pancancer_path}...")
 
-            with open(pancancer_path, "w", newline="") as fout:
-                writer = csv.DictWriter(
-                    fout, fieldnames=_TSV_COLUMNS, delimiter="\t", lineterminator="\n"
-                )
-                writer.writeheader()
-                for tsv_path in all_tsv_paths:
-                    with open(tsv_path) as fin:
-                        reader = csv.DictReader(fin, delimiter="\t")
-                        for row in reader:
-                            writer.writerow(row)
+        with open(pancancer_path, "w", newline="") as fout:
+            writer = csv.DictWriter(
+                fout, fieldnames=_TSV_COLUMNS, delimiter="\t", lineterminator="\n"
+            )
+            writer.writeheader()
+            for tsv_path in all_tsv_paths:
+                with open(tsv_path) as fin:
+                    for row in csv.DictReader(fin, delimiter="\t"):
+                        writer.writerow(row)
 
-            click.echo(f"Pan-cancer TSV: {pancancer_path}")
+        click.echo(f"Pan-cancer TSV: {pancancer_path}")
 
-    except ImportError as e:
-        click.echo(f"Error: {e}", err=True)
-        ctx.exit(1)
-    except Exception as e:
-        logger.exception(f"Download failed: {e}")
-        click.echo(f"Error: {e}", err=True)
+    if failed:
+        click.echo(
+            f"Summary: {len(succeeded)} succeeded, {len(failed)} failed "
+            f"({', '.join(sorted(failed))}). coad + ov are known upstream failures "
+            "in cptac 1.5.14.",
+            err=True,
+        )
+    if not succeeded:
         ctx.exit(1)
 
 

--- a/hvantk/skills/cptac/phospho/tests/test_builder.py
+++ b/hvantk/skills/cptac/phospho/tests/test_builder.py
@@ -1,0 +1,103 @@
+"""Unit tests for the CPTAC phospho Phase B builder (#198).
+
+These exercise the builder without the upstream ``cptac`` package: they feed
+matrix/metadata CSVs in the same layout ``CPTACPhosphoDataset.download`` writes
+(matrix index name ``Site``; metadata index name ``SampleID``).
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+
+def _ctx():
+    from hvantk.core.models import BuildContext
+
+    return BuildContext(
+        plugin="cptac",
+        dataset="cptac:phospho",
+        plugin_version="0.1.0",
+        source_fingerprint="test",
+        builder_commit=None,
+    )
+
+
+def _write_fixture(raw, ct="brca"):
+    pd.DataFrame(
+        {"S1": [1.0, 2.0], "S2": [3.0, 4.0]},
+        index=pd.Index(["TP53_S15", "EGFR_Y1068"], name="Site"),
+    ).to_csv(raw / f"cptac-phospho-{ct}-matrix.csv")
+    pd.DataFrame(
+        {"stage": ["I", "II"]},
+        index=pd.Index(["S1", "S2"], name="SampleID"),
+    ).to_csv(raw / f"cptac-phospho-{ct}-metadata.csv")
+
+
+def test_build_from_raw_dir(tmp_path):
+    from hvantk.core.models import ExpressionMatrix
+    from hvantk.skills.cptac.phospho.builder import build_cptac_phospho
+
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    _write_fixture(raw, "brca")
+
+    art = build_cptac_phospho(str(raw), _ctx(), cancer_type="brca")
+
+    assert isinstance(art, ExpressionMatrix)
+    adata = art.to_anndata()
+    assert adata.shape == (2, 2)  # 2 samples x 2 sites
+    assert set(adata.obs.index) == {"S1", "S2"}
+    assert set(adata.var.index) == {"TP53_S15", "EGFR_Y1068"}
+    assert "stage" in adata.obs.columns
+
+
+def test_build_from_dict(tmp_path):
+    from hvantk.core.models import ExpressionMatrix
+    from hvantk.skills.cptac.phospho.builder import build_cptac_phospho
+
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    _write_fixture(raw, "brca")
+
+    art = build_cptac_phospho(
+        {
+            "expression": str(raw / "cptac-phospho-brca-matrix.csv"),
+            "metadata": str(raw / "cptac-phospho-brca-metadata.csv"),
+        },
+        _ctx(),
+    )
+    assert isinstance(art, ExpressionMatrix)
+    assert art.to_anndata().shape == (2, 2)
+
+
+def test_raw_dir_requires_cancer_type(tmp_path):
+    from hvantk.skills.cptac.phospho.builder import build_cptac_phospho
+
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    _write_fixture(raw, "brca")
+
+    with pytest.raises(ValueError, match="cancer_type"):
+        build_cptac_phospho(str(raw), _ctx())
+
+
+def test_missing_files_raise(tmp_path):
+    from hvantk.skills.cptac.phospho.builder import build_cptac_phospho
+
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    with pytest.raises(FileNotFoundError):
+        build_cptac_phospho(str(raw), _ctx(), cancer_type="brca")
+
+
+def test_ignores_stray_kwargs(tmp_path):
+    from hvantk.skills.cptac.phospho.builder import build_cptac_phospho
+
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    _write_fixture(raw, "brca")
+
+    # reprocess forwards download-only --plugin-arg values (e.g. overwrite) to the
+    # builder too; they must not break the build.
+    art = build_cptac_phospho(str(raw), _ctx(), cancer_type="brca", overwrite=True)
+    assert art.to_anndata().shape == (2, 2)

--- a/hvantk/skills/cptac/phospho/tests/test_download_resilience.py
+++ b/hvantk/skills/cptac/phospho/tests/test_download_resilience.py
@@ -50,5 +50,67 @@ def test_download_dataset_all_fail_raises(monkeypatch, tmp_path):
         "hvantk.skills.cptac.shared.datasets.CPTACPhosphoDataset", _BoomDS
     )
 
-    with pytest.raises(RuntimeError):
+    # Assert the NEW wrapped message (not just any RuntimeError — the pre-fix code
+    # also propagated a RuntimeError, so an unmatched raises would pass either way).
+    with pytest.raises(RuntimeError, match="All CPTAC phospho downloads failed"):
         cli.download_dataset(str(tmp_path), cancer_type="brca")
+
+
+def test_download_cmd_all_skips_failing_cancer(monkeypatch, tmp_path):
+    """The Click `download cptac-phospho --all` path: one bad cancer is skipped,
+    survivors are merged, a summary prints, and the command exits 0."""
+    import os
+
+    from click.testing import CliRunner
+
+    import hvantk.skills.cptac.phospho.cli as cli
+    from hvantk.skills.cptac.shared.datasets import _TSV_COLUMNS
+
+    class _FakeDS:
+        def __init__(self, cancer_type):
+            self.ct = cancer_type
+
+        def download(self, output_dir, overwrite=False):
+            if self.ct in ("coad", "ov"):
+                raise RuntimeError(f"upstream cptac boom for {self.ct}")
+            tsv = os.path.join(output_dir, f"cptac-phospho-{self.ct}.tsv")
+            with open(tsv, "w") as fh:
+                fh.write("\t".join(_TSV_COLUMNS) + "\n")  # header, no rows
+            return {
+                "tsv": tsv,
+                "matrix": os.path.join(output_dir, f"cptac-phospho-{self.ct}-matrix.csv"),
+                "metadata": os.path.join(output_dir, f"cptac-phospho-{self.ct}-metadata.csv"),
+            }
+
+    monkeypatch.setattr(
+        "hvantk.skills.cptac.shared.datasets.CPTACPhosphoDataset", _FakeDS
+    )
+
+    result = CliRunner().invoke(cli.download_cmd, ["-o", str(tmp_path), "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "coad" in result.output and "FAILED" in result.output
+    assert "Summary" in result.output
+    # Pan-cancer merge ran over the survivors only.
+    assert (tmp_path / "cptac-phospho-pancancer.tsv").exists()
+
+
+def test_download_cmd_all_fail_exits_nonzero(monkeypatch, tmp_path):
+    """When every cancer fails, `download --all` exits non-zero."""
+    from click.testing import CliRunner
+
+    import hvantk.skills.cptac.phospho.cli as cli
+
+    class _BoomDS:
+        def __init__(self, cancer_type):
+            pass
+
+        def download(self, *a, **k):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "hvantk.skills.cptac.shared.datasets.CPTACPhosphoDataset", _BoomDS
+    )
+
+    result = CliRunner().invoke(cli.download_cmd, ["-o", str(tmp_path), "--all"])
+    assert result.exit_code == 1

--- a/hvantk/skills/cptac/phospho/tests/test_download_resilience.py
+++ b/hvantk/skills/cptac/phospho/tests/test_download_resilience.py
@@ -1,0 +1,54 @@
+"""#198: `hvantk download cptac-phospho --all` must skip-and-continue per cancer.
+
+coad + ov fail *inside* cptac 1.5.14 (upstream); one bad type must not abort the
+whole batch. These tests stub CPTACPhosphoDataset so no `cptac` package or network
+is needed.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_download_dataset_skips_failing_cancer(monkeypatch, tmp_path):
+    import hvantk.skills.cptac.phospho.cli as cli
+
+    class _FakeDS:
+        def __init__(self, cancer_type):
+            self.ct = cancer_type
+
+        def download(self, raw_dir, overwrite=False):
+            if self.ct == "coad":
+                raise RuntimeError("upstream cptac boom")
+            return {
+                "tsv": f"{raw_dir}/{self.ct}.tsv",
+                "matrix": f"{raw_dir}/{self.ct}-matrix.csv",
+                "metadata": f"{raw_dir}/{self.ct}-metadata.csv",
+            }
+
+    monkeypatch.setattr(
+        "hvantk.skills.cptac.shared.datasets.CPTACPhosphoDataset", _FakeDS
+    )
+
+    res = cli.download_dataset(str(tmp_path), cancer_type=None)  # all cancers
+
+    assert "coad" in res["_failures"]          # failure recorded, not raised
+    assert "brca" in res                        # others still succeeded
+    assert res["brca"]["tsv"].endswith("brca.tsv")
+
+
+def test_download_dataset_all_fail_raises(monkeypatch, tmp_path):
+    import hvantk.skills.cptac.phospho.cli as cli
+
+    class _BoomDS:
+        def __init__(self, cancer_type):
+            pass
+
+        def download(self, *a, **k):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "hvantk.skills.cptac.shared.datasets.CPTACPhosphoDataset", _BoomDS
+    )
+
+    with pytest.raises(RuntimeError):
+        cli.download_dataset(str(tmp_path), cancer_type="brca")

--- a/hvantk/skills/cptac/plugin.yaml
+++ b/hvantk/skills/cptac/plugin.yaml
@@ -46,12 +46,13 @@ datasets:
       row_snapshot: phospho/tests/snapshots/sample_rows.json
       drift_fingerprint: phospho/tests/drift_fingerprint.json
     lifecycle:
+      # No parse stage: the download already writes the builder's inputs
+      # (per-cancer cptac-phospho-<ct>-matrix.csv / -metadata.csv), so reprocess
+      # hands the raw dir straight to the builder (mirrors cptac:expression).
+      # The builder selects the cancer via --plugin-arg cancer_type=<ct>.
       download:
         module: hvantk.skills.cptac.phospho.cli
         function: download_dataset
-      parse:
-        module: hvantk.skills.cptac.shared.datasets
-        function: parse_raw_dir
 
 cli:
   - command: cptac-phospho-download

--- a/hvantk/tests/test_plugin_conformance.py
+++ b/hvantk/tests/test_plugin_conformance.py
@@ -549,8 +549,10 @@ def test_cptac_expression_round_trip(tmp_path, cptac_expression_inputs):
 @pytest.fixture
 def cptac_phospho_inputs(tmp_path):
     """Wide-format CPTAC phospho: rows are sites, columns are samples + metadata."""
+    # Site column header matches what CPTACPhosphoDataset.write_matrix_csv writes
+    # (df.index.name = "Site"); the builder's site_id_col default is "Site" (#198).
     expr_lines = [
-        "SiteID\tS1\tS2",
+        "Site\tS1\tS2",
         "TP53_S315\t1.2\t3.4",
         "BRCA2_S988\t0.5\t2.1",
     ]

--- a/hvantk/tests/test_pyproject_extras.py
+++ b/hvantk/tests/test_pyproject_extras.py
@@ -1,0 +1,24 @@
+"""Guard the declared Poetry extras/deps that runtime imports rely on.
+
+#198: cptac imports pyranges, whose compiled dep `sorted_nearest` is not always
+pulled by an extras install, breaking `import cptac`. The ptm extra must declare
+`sorted-nearest` explicitly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _load_pyproject() -> dict:
+    try:
+        import tomllib as toml  # Python >= 3.11
+    except ModuleNotFoundError:  # Python 3.10
+        import tomli as toml
+    root = Path(__file__).resolve().parents[2]
+    return toml.loads((root / "pyproject.toml").read_text())
+
+
+def test_ptm_extra_includes_sorted_nearest():
+    poetry = _load_pyproject()["tool"]["poetry"]
+    assert "sorted-nearest" in poetry["extras"]["ptm"]
+    assert "sorted-nearest" in poetry["dependencies"]

--- a/hvantk/tests/test_reprocess_cli.py
+++ b/hvantk/tests/test_reprocess_cli.py
@@ -32,8 +32,11 @@ def _make_spec(
 ) -> DatasetSpec:
     return DatasetSpec(
         name=name,
+        # Self-consistent with the .parquet outputs these tests use: reprocess now
+        # fails fast when --output's extension can't hold the declared backend
+        # (pandas -> .parquet, hail -> .ht/.mt, anndata -> .h5ad; issue #198).
         domain="genomics",
-        backend="hail",
+        backend="pandas",
         builder=builder or MagicMock(),
         drift_probe=MagicMock(return_value={"probe_version": 1}),
         skill_path="/x/SKILL.md",
@@ -201,13 +204,20 @@ def test_reprocess_unknown_dataset_errors(tmp_path: Path, monkeypatch):
     assert "unknown dataset" in result.output.lower()
 
 
-def test_reprocess_parse_requires_intermediate_path(tmp_path: Path, monkeypatch):
-    """When a plugin declares lifecycle.parse, --intermediate must be supplied."""
+def test_reprocess_parse_without_intermediate_auto_defaults(tmp_path: Path, monkeypatch):
+    """When a plugin declares lifecycle.parse but --intermediate is omitted,
+    reprocess defaults the intermediate under raw_dir instead of hard-erroring (#198).
+    """
+    import os
+
     download = MagicMock()
     parse = MagicMock()
     builder = MagicMock()
     spec = _make_spec(download_fn=download, parse_fn=parse, builder=builder)
     _install_registry(monkeypatch, spec)
+
+    raw = tmp_path / "raw"
+    output = tmp_path / "out.parquet"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -215,15 +225,46 @@ def test_reprocess_parse_requires_intermediate_path(tmp_path: Path, monkeypatch)
         [
             "stub:default",
             "--raw-dir",
+            str(raw),
+            "--output",
+            str(output),
+            "--no-check-drift",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # Defaulted intermediate: "<dataset with ':' -> '_'>.intermediate" under raw_dir.
+    expected_intermediate = os.path.join(str(raw), "stub_default.intermediate")
+    parse.assert_called_once_with(raw_dir=str(raw), output_path=expected_intermediate)
+    builder.assert_called_once_with(expected_intermediate, str(output))
+
+
+def test_reprocess_rejects_output_extension_backend_mismatch(
+    tmp_path: Path, monkeypatch
+):
+    """A pandas-backed dataset written to .ht fails fast, not silently via to_hail.
+
+    Regression test for the wiring of _check_output_extension into reprocess_cmd
+    (#198): core/io.save dispatches by extension, so .ht would route a pandas
+    AnnotationTable through to_hail() (needs a JVM) and crash confusingly.
+    """
+    builder = MagicMock()
+    spec = _make_spec(builder=builder)  # backend defaults to pandas
+    _install_registry(monkeypatch, spec)
+
+    result = CliRunner().invoke(
+        reprocess_cmd,
+        [
+            "stub:default",
+            "--raw-dir",
             str(tmp_path / "raw"),
             "--output",
-            str(tmp_path / "out.parquet"),
+            str(tmp_path / "out.ht"),
+            "--skip-download",
             "--no-check-drift",
         ],
     )
     assert result.exit_code != 0
-    assert "--intermediate" in result.output
-    parse.assert_not_called()
+    assert ".parquet" in result.output  # names the backend-appropriate extension
     builder.assert_not_called()
 
 

--- a/hvantk/tests/test_reprocess_cli_helpers.py
+++ b/hvantk/tests/test_reprocess_cli_helpers.py
@@ -9,13 +9,43 @@ import click
 import pytest
 
 
-def test_expected_extensions():
+def _fake_spec(backend, artifact_type_name=None):
+    at = type(artifact_type_name, (), {}) if artifact_type_name else None
+    return type("_Spec", (), {"name": "x:y", "backend": backend, "artifact_type": at})()
+
+
+def test_expected_extensions_keys_on_artifact_type():
     from hvantk.tools.plugins.reprocess_cli import _expected_extensions
 
-    assert _expected_extensions("pandas") == (".parquet",)
-    assert _expected_extensions("anndata") == (".h5ad",)
-    assert ".ht" in _expected_extensions("hail")
-    assert _expected_extensions("unknown") is None
+    # artifact_type is authoritative — distinguishes a hail AnnotationTable (.ht)
+    # from a hail VariantMatrix (.mt), which backend alone cannot.
+    assert _expected_extensions(_fake_spec("hail", "AnnotationTable")) == (".ht",)
+    assert _expected_extensions(_fake_spec("pandas", "AnnotationTable")) == (
+        ".parquet",
+    )
+    assert _expected_extensions(_fake_spec("hail", "VariantMatrix")) == (".mt",)
+    assert _expected_extensions(_fake_spec("anndata", "ExpressionMatrix")) == (".h5ad",)
+    # legacy specs (no artifact_type) fall back to the backend map
+    assert _expected_extensions(_fake_spec("pandas")) == (".parquet",)
+    assert ".ht" in _expected_extensions(_fake_spec("hail"))
+    assert _expected_extensions(_fake_spec("unknown")) is None
+
+
+def test_check_output_extension_hail_annotationtable_rejects_mt():
+    """#200 review (qodo): a hail-backed AnnotationTable (e.g. uniprot-ptm:sites)
+    must reject .mt up front, not accept it and then fail later in core.io.save
+    (where .mt is valid only for VariantMatrix)."""
+    from hvantk.tools.plugins.reprocess_cli import _check_output_extension
+
+    at_spec = _fake_spec("hail", "AnnotationTable")
+    with pytest.raises(click.UsageError):
+        _check_output_extension(at_spec, "out.mt")  # .mt is VariantMatrix-only
+    _check_output_extension(at_spec, "out.ht")  # native for hail AnnotationTable
+
+    vm_spec = _fake_spec("hail", "VariantMatrix")
+    _check_output_extension(vm_spec, "out.mt")  # native for VariantMatrix
+    with pytest.raises(click.UsageError):
+        _check_output_extension(vm_spec, "out.ht")
 
 
 def test_check_output_extension_mismatch_raises():
@@ -68,8 +98,10 @@ def test_reprocess_cmd_rejects_backend_extension_mismatch(tmp_path, monkeypatch)
         rc.reprocess_cmd,
         [
             "peptideatlas:phospho",
-            "--raw-dir", str(tmp_path / "raw"),
-            "--output", str(tmp_path / "out.ht"),  # pandas backend -> .ht is wrong
+            "--raw-dir",
+            str(tmp_path / "raw"),
+            "--output",
+            str(tmp_path / "out.ht"),  # pandas backend -> .ht is wrong
         ],
     )
     assert result.exit_code != 0
@@ -112,8 +144,10 @@ def test_reprocess_cmd_defaults_missing_intermediate(tmp_path, monkeypatch):
         rc.reprocess_cmd,
         [
             "peptideatlas:phospho",
-            "--raw-dir", str(tmp_path / "raw"),
-            "--output", str(tmp_path / "out.parquet"),  # matches pandas backend
+            "--raw-dir",
+            str(tmp_path / "raw"),
+            "--output",
+            str(tmp_path / "out.parquet"),  # matches pandas backend
             "--skip-download",
         ],
     )
@@ -154,8 +188,10 @@ def test_reprocess_cmd_no_parse_passes_raw_dir(tmp_path, monkeypatch):
         rc.reprocess_cmd,
         [
             "cptac:phospho",
-            "--raw-dir", str(tmp_path / "raw"),
-            "--output", str(tmp_path / "out.h5ad"),  # matches anndata backend
+            "--raw-dir",
+            str(tmp_path / "raw"),
+            "--output",
+            str(tmp_path / "out.h5ad"),  # matches anndata backend
             "--skip-download",
         ],
     )

--- a/hvantk/tests/test_reprocess_cli_helpers.py
+++ b/hvantk/tests/test_reprocess_cli_helpers.py
@@ -120,3 +120,44 @@ def test_reprocess_cmd_defaults_missing_intermediate(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert calls["output_path"].endswith("peptideatlas_phospho.intermediate")
     assert calls["built_from"] == calls["output_path"]
+
+
+def test_reprocess_cmd_no_parse_passes_raw_dir(tmp_path, monkeypatch):
+    """With no parse stage (like cptac:phospho after #198), the builder receives
+    the raw download directory directly."""
+    from click.testing import CliRunner
+    import hvantk.tools.plugins.reprocess_cli as rc
+
+    seen = {}
+
+    class _Spec:
+        name = "cptac:phospho"
+        backend = "anndata"
+        download_fn = None
+        parse_fn = None
+        artifact_type = None  # legacy Phase-A build shape: builder(input, output)
+        plugin_version = "0.1.0"
+
+        def builder(self, parsed_path, output):
+            seen["parsed_path"] = parsed_path
+
+    monkeypatch.setattr(
+        "hvantk.core.plugin.loader.get_registry",
+        lambda: type("_Reg", (), {"get_dataset": lambda self, k: _Spec()})(),
+    )
+    monkeypatch.setattr(
+        "hvantk.core.plugin.drift_runner.run_drift_check",
+        lambda ds: type("_R", (), {"status": "clean", "diff": None})(),
+    )
+
+    result = CliRunner().invoke(
+        rc.reprocess_cmd,
+        [
+            "cptac:phospho",
+            "--raw-dir", str(tmp_path / "raw"),
+            "--output", str(tmp_path / "out.h5ad"),  # matches anndata backend
+            "--skip-download",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["parsed_path"] == str(tmp_path / "raw")

--- a/hvantk/tests/test_reprocess_cli_helpers.py
+++ b/hvantk/tests/test_reprocess_cli_helpers.py
@@ -1,0 +1,122 @@
+"""#198: reprocess must (a) fail fast when --output's extension can't hold the
+plugin's backend (e.g. a pandas AnnotationTable written to .ht silently invokes
+to_hail(), needing a JVM), and (b) not hard-error on a missing --intermediate when
+the plugin declares a parse stage.
+"""
+from __future__ import annotations
+
+import click
+import pytest
+
+
+def test_expected_extensions():
+    from hvantk.tools.plugins.reprocess_cli import _expected_extensions
+
+    assert _expected_extensions("pandas") == (".parquet",)
+    assert _expected_extensions("anndata") == (".h5ad",)
+    assert ".ht" in _expected_extensions("hail")
+    assert _expected_extensions("unknown") is None
+
+
+def test_check_output_extension_mismatch_raises():
+    from hvantk.tools.plugins.reprocess_cli import _check_output_extension
+
+    class _Spec:
+        name = "peptideatlas:phospho"
+        backend = "pandas"
+
+    with pytest.raises(click.UsageError):
+        _check_output_extension(_Spec(), "out.ht")
+    # Matching extension must not raise.
+    _check_output_extension(_Spec(), "out.parquet")
+
+
+def test_check_output_extension_unknown_backend_is_noop():
+    from hvantk.tools.plugins.reprocess_cli import _check_output_extension
+
+    class _Spec:
+        name = "x:y"
+        backend = "something-else"
+
+    # No expected extensions -> no opinion, no raise.
+    _check_output_extension(_Spec(), "out.whatever")
+
+
+def test_default_intermediate_path():
+    from hvantk.tools.plugins.reprocess_cli import _default_intermediate
+
+    p = _default_intermediate("peptideatlas:phospho", "/raw")
+    assert p.endswith("peptideatlas_phospho.intermediate")
+    assert p.startswith("/raw")
+
+
+def test_reprocess_cmd_rejects_backend_extension_mismatch(tmp_path, monkeypatch):
+    """The extension check fires inside reprocess_cmd, before any download."""
+    from click.testing import CliRunner
+    import hvantk.tools.plugins.reprocess_cli as rc
+
+    class _Spec:
+        name = "peptideatlas:phospho"
+        backend = "pandas"
+
+    monkeypatch.setattr(
+        "hvantk.core.plugin.loader.get_registry",
+        lambda: type("_Reg", (), {"get_dataset": lambda self, k: _Spec()})(),
+    )
+
+    result = CliRunner().invoke(
+        rc.reprocess_cmd,
+        [
+            "peptideatlas:phospho",
+            "--raw-dir", str(tmp_path / "raw"),
+            "--output", str(tmp_path / "out.ht"),  # pandas backend -> .ht is wrong
+        ],
+    )
+    assert result.exit_code != 0
+    assert "backend" in result.output.lower()
+
+
+def test_reprocess_cmd_defaults_missing_intermediate(tmp_path, monkeypatch):
+    """A parse-declaring plugin with no --intermediate defaults it instead of erroring."""
+    from click.testing import CliRunner
+    import hvantk.tools.plugins.reprocess_cli as rc
+
+    calls = {}
+
+    def _fake_parse(*, raw_dir, output_path, **kw):
+        calls["output_path"] = output_path
+        with open(output_path, "w") as fh:
+            fh.write("ok")
+
+    class _Spec:
+        name = "peptideatlas:phospho"
+        backend = "pandas"
+        download_fn = None
+        parse_fn = staticmethod(_fake_parse)
+        artifact_type = None  # legacy Phase-A build shape: builder(input, output)
+        plugin_version = "0.1.0"
+
+        def builder(self, parsed_path, output):
+            calls["built_from"] = parsed_path
+
+    monkeypatch.setattr(
+        "hvantk.core.plugin.loader.get_registry",
+        lambda: type("_Reg", (), {"get_dataset": lambda self, k: _Spec()})(),
+    )
+    monkeypatch.setattr(
+        "hvantk.core.plugin.drift_runner.run_drift_check",
+        lambda ds: type("_R", (), {"status": "clean", "diff": None})(),
+    )
+
+    result = CliRunner().invoke(
+        rc.reprocess_cmd,
+        [
+            "peptideatlas:phospho",
+            "--raw-dir", str(tmp_path / "raw"),
+            "--output", str(tmp_path / "out.parquet"),  # matches pandas backend
+            "--skip-download",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert calls["output_path"].endswith("peptideatlas_phospho.intermediate")
+    assert calls["built_from"] == calls["output_path"]

--- a/hvantk/tests/test_tools_ptm_pipeline.py
+++ b/hvantk/tests/test_tools_ptm_pipeline.py
@@ -35,3 +35,48 @@ def test_algorithms_ptm_has_no_skill_imports():
                 if node.module.startswith("hvantk.skills"):
                     bad.append((py.name, node.module))
     assert not bad, f"algorithms/ptm/ has skill imports: {bad}"
+
+
+def test_ptm_build_pipeline_resolves_hyphenated_uniprot_key(monkeypatch, tmp_path):
+    """#198 regression: the Hail build step must resolve 'uniprot-ptm:sites'
+    (hyphen, per plugin.yaml `name: uniprot-ptm`), not the underscore form.
+
+    The bug wasted the whole expensive GTF download + coordinate mapping run
+    before KeyError-ing at the final build step.
+    """
+    import hvantk.tools.ptm.pipeline as pl
+    from hvantk.algorithms.ptm.pipeline import PTMBuildConfig
+
+    captured = {}
+
+    class _FakeSpec:
+        plugin_version = "0.1.0"
+
+    class _FakeRegistry:
+        def get_dataset(self, key):
+            captured["key"] = key
+            return _FakeSpec()
+
+    class _FakeResult:
+        n_mapped = 5
+        mapped_tsv_path = str(tmp_path / "ptm_sites_mapped.tsv.bgz")
+        output_ht = None
+
+    # get_registry + run_builder_for_spec are imported INSIDE ptm_build_pipeline;
+    # patch them at their source modules. ptm_build_pipeline_core is a module global.
+    monkeypatch.setattr(
+        "hvantk.core.plugin.loader.get_registry", lambda: _FakeRegistry()
+    )
+    monkeypatch.setattr(
+        "hvantk.core.plugin.run_builder.run_builder_for_spec", lambda *a, **k: None
+    )
+    monkeypatch.setattr(pl, "ptm_build_pipeline_core", lambda cfg: _FakeResult())
+
+    cfg = PTMBuildConfig(
+        output_dir=str(tmp_path),
+        output_ht=str(tmp_path / "out.ht"),
+        ptm_tsv=str(tmp_path / "ptm.tsv"),  # non-None -> download step skipped
+    )
+    pl.ptm_build_pipeline(cfg)
+
+    assert captured["key"] == "uniprot-ptm:sites"

--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -90,24 +90,27 @@ def _expected_extensions(backend):
 
 
 def _check_output_extension(spec, output):
-    """Fail fast when --output's extension can't hold the plugin's backend.
+    """Fail fast when --output's extension doesn't match the plugin's backend.
 
-    ``core/io.save`` dispatches purely on extension, so e.g. a pandas
-    AnnotationTable written to ``.ht`` would silently invoke ``to_hail()`` (needs a
-    JVM) and fail confusingly deep in the build. Catch that mismatch up front.
+    ``reprocess`` writes each dataset in its declared backend's native format
+    (pandas->.parquet, hail->.ht/.mt, anndata->.h5ad). ``core/io.save`` dispatches
+    purely on extension, so a mismatch would silently trigger a backend conversion
+    -- e.g. a pandas AnnotationTable to ``.ht`` invokes ``to_hail()`` (needs a JVM),
+    or a hail table to ``.parquet`` collects via ``to_pandas()`` -- and can fail
+    confusingly deep in the build. Catch that up front. ``Path.name`` already
+    normalizes trailing slashes, so ``.ht/`` / ``.mt/`` dir forms match too.
     """
     from pathlib import Path
 
     expected = _expected_extensions(getattr(spec, "backend", None))
     if expected is None:
         return
-    name = Path(output).name.rstrip("/")
-    if any(name.endswith(ext) for ext in expected):
+    if any(Path(output).name.endswith(ext) for ext in expected):
         return
     raise click.UsageError(
-        f"{spec.name} has backend {getattr(spec, 'backend', '?')!r}; --output should "
-        f"end in {' or '.join(expected)}, got {output!r}. Saving to a mismatched "
-        "extension triggers a backend conversion (e.g. .ht requires Hail/JVM)."
+        f"{spec.name} has backend {getattr(spec, 'backend', '?')!r}; reprocess writes "
+        f"its native format, so --output should end in {' or '.join(expected)}, got "
+        f"{output!r} (a mismatched extension would force a backend conversion)."
     )
 
 

--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -77,6 +77,47 @@ def _coerce_plugin_arg_value(value: str) -> Any:
     return value
 
 
+_BACKEND_EXPECTED_EXT = {
+    "pandas": (".parquet",),
+    "anndata": (".h5ad",),
+    "hail": (".ht", ".mt"),
+}
+
+
+def _expected_extensions(backend):
+    """Output extensions valid for a declared plugin backend (None = unknown)."""
+    return _BACKEND_EXPECTED_EXT.get(backend)
+
+
+def _check_output_extension(spec, output):
+    """Fail fast when --output's extension can't hold the plugin's backend.
+
+    ``core/io.save`` dispatches purely on extension, so e.g. a pandas
+    AnnotationTable written to ``.ht`` would silently invoke ``to_hail()`` (needs a
+    JVM) and fail confusingly deep in the build. Catch that mismatch up front.
+    """
+    from pathlib import Path
+
+    expected = _expected_extensions(getattr(spec, "backend", None))
+    if expected is None:
+        return
+    name = Path(output).name.rstrip("/")
+    if any(name.endswith(ext) for ext in expected):
+        return
+    raise click.UsageError(
+        f"{spec.name} has backend {getattr(spec, 'backend', '?')!r}; --output should "
+        f"end in {' or '.join(expected)}, got {output!r}. Saving to a mismatched "
+        "extension triggers a backend conversion (e.g. .ht requires Hail/JVM)."
+    )
+
+
+def _default_intermediate(dataset, raw_dir):
+    """Intermediate path used when a parse-declaring plugin gets no --intermediate."""
+    import os
+
+    return os.path.join(raw_dir, f"{dataset.replace(':', '_')}.intermediate")
+
+
 @click.command(name="reprocess")
 @click.argument("dataset")
 @click.option(
@@ -192,6 +233,11 @@ def reprocess_cmd(
             )
         extras[key] = _coerce_plugin_arg_value(value)
 
+    # Fail fast on an output extension the plugin's backend can't hold (#198),
+    # before running the (potentially expensive) download/parse/build stages.
+    if not skip_build:
+        _check_output_extension(spec, output)
+
     # 1. Download stage
     if not skip_download:
         if spec.download_fn is None:
@@ -205,9 +251,13 @@ def reprocess_cmd(
     # 2. Parse stage
     if not skip_parse and spec.parse_fn is not None:
         if intermediate is None:
-            raise click.UsageError(
-                "--intermediate is required when the plugin declares lifecycle.parse"
-            )
+            # The plugin declares a parse stage but no --intermediate was given.
+            # Default it under raw_dir (and log) instead of hard-erroring (#198).
+            import os
+
+            os.makedirs(raw_dir, exist_ok=True)
+            intermediate = _default_intermediate(dataset, raw_dir)
+            _progress(f"--intermediate not given; defaulting to {intermediate}")
         _progress(f"parse: {raw_dir} -> {intermediate}")
         spec.parse_fn(raw_dir=raw_dir, output_path=intermediate, **extras)
         parsed_path = intermediate

--- a/hvantk/tools/plugins/reprocess_cli.py
+++ b/hvantk/tools/plugins/reprocess_cli.py
@@ -77,6 +77,10 @@ def _coerce_plugin_arg_value(value: str) -> Any:
     return value
 
 
+# Fallback backend->extension map, used only for legacy specs that declare no
+# artifact_type. When artifact_type IS known it is authoritative (see
+# _expected_extensions) because backend alone can't tell a hail AnnotationTable
+# (.ht) from a hail VariantMatrix (.mt).
 _BACKEND_EXPECTED_EXT = {
     "pandas": (".parquet",),
     "anndata": (".h5ad",),
@@ -84,33 +88,50 @@ _BACKEND_EXPECTED_EXT = {
 }
 
 
-def _expected_extensions(backend):
-    """Output extensions valid for a declared plugin backend (None = unknown)."""
-    return _BACKEND_EXPECTED_EXT.get(backend)
+def _expected_extensions(spec):
+    """Output extension(s) reprocess writes for a spec's native artifact format.
+
+    reprocess emits each dataset in its native format (no cross-format
+    conversion). Keyed on ``artifact_type`` when known, which — unlike backend
+    alone — distinguishes a hail AnnotationTable (.ht) from a VariantMatrix (.mt);
+    ``core/io.save`` only accepts .mt for VariantMatrix. Falls back to the backend
+    map for legacy specs with no ``artifact_type``. Returns None when it can't be
+    determined, so the caller skips the check rather than guessing.
+    """
+    at_name = getattr(getattr(spec, "artifact_type", None), "__name__", None)
+    if at_name == "AnnotationTable":
+        return (".parquet",) if getattr(spec, "backend", None) == "pandas" else (".ht",)
+    if at_name == "VariantMatrix":
+        return (".mt",)
+    if at_name == "ExpressionMatrix":
+        return (".h5ad",)
+    if at_name == "GeneSet":
+        return (".geneset.json",)
+    return _BACKEND_EXPECTED_EXT.get(getattr(spec, "backend", None))
 
 
 def _check_output_extension(spec, output):
-    """Fail fast when --output's extension doesn't match the plugin's backend.
+    """Fail fast when --output's extension can't hold the dataset's artifact.
 
-    ``reprocess`` writes each dataset in its declared backend's native format
-    (pandas->.parquet, hail->.ht/.mt, anndata->.h5ad). ``core/io.save`` dispatches
-    purely on extension, so a mismatch would silently trigger a backend conversion
-    -- e.g. a pandas AnnotationTable to ``.ht`` invokes ``to_hail()`` (needs a JVM),
-    or a hail table to ``.parquet`` collects via ``to_pandas()`` -- and can fail
-    confusingly deep in the build. Catch that up front. ``Path.name`` already
-    normalizes trailing slashes, so ``.ht/`` / ``.mt/`` dir forms match too.
+    ``reprocess`` writes each dataset in its native format; ``core/io.save``
+    dispatches by artifact type + extension, so a mismatch would either fail at
+    save (e.g. ``.mt`` for an AnnotationTable) or silently trigger a backend
+    conversion (e.g. a pandas AnnotationTable to ``.ht`` invokes ``to_hail()``,
+    needing a JVM) and fail confusingly deep in the build. Catch it up front.
+    ``Path.name`` normalizes trailing slashes, so ``.ht/`` / ``.mt/`` dir forms
+    match too.
     """
     from pathlib import Path
 
-    expected = _expected_extensions(getattr(spec, "backend", None))
-    if expected is None:
+    expected = _expected_extensions(spec)
+    if not expected:
         return
     if any(Path(output).name.endswith(ext) for ext in expected):
         return
     raise click.UsageError(
-        f"{spec.name} has backend {getattr(spec, 'backend', '?')!r}; reprocess writes "
-        f"its native format, so --output should end in {' or '.join(expected)}, got "
-        f"{output!r} (a mismatched extension would force a backend conversion)."
+        f"{spec.name} writes {' or '.join(expected)} (its native format); got "
+        f"--output {output!r}. A mismatched extension would fail at save or force a "
+        "backend conversion."
     )
 
 
@@ -226,14 +247,10 @@ def reprocess_cmd(
     extras: dict[str, Any] = {}
     for kv in plugin_args:
         if "=" not in kv:
-            raise click.UsageError(
-                f"--plugin-arg must be KEY=VALUE; got: {kv!r}"
-            )
+            raise click.UsageError(f"--plugin-arg must be KEY=VALUE; got: {kv!r}")
         key, value = kv.split("=", 1)
         if not key:
-            raise click.UsageError(
-                f"--plugin-arg key must be non-empty; got: {kv!r}"
-            )
+            raise click.UsageError(f"--plugin-arg key must be non-empty; got: {kv!r}")
         extras[key] = _coerce_plugin_arg_value(value)
 
     # Fail fast on an output extension the plugin's backend can't hold (#198),
@@ -291,11 +308,13 @@ def reprocess_cmd(
             # to build it.
             if "hgnc_path" in extras or "hgnc_ht" in extras:
                 from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
+
                 hgnc_loc = extras.pop("hgnc_path", None) or extras.pop("hgnc_ht", None)
                 extras["gene_catalog"] = HGNCGeneCatalogStreamer.from_path(hgnc_loc)
 
             from hvantk.core.plugin.run_builder import run_builder_for_spec
             from pathlib import Path
+
             run_builder_for_spec(
                 spec,
                 parsed_input=parsed_path,

--- a/hvantk/tools/ptm/pipeline.py
+++ b/hvantk/tools/ptm/pipeline.py
@@ -49,7 +49,7 @@ def ptm_build_pipeline(config: PTMBuildConfig) -> PTMBuildResult:
         2. Delegate to :func:`ptm_build_pipeline_core` for GTF download,
            parsing, and coordinate mapping
         3. Build the Hail Table from the mapped TSV by invoking the
-           ``uniprot_ptm:sites`` Phase B builder via
+           ``uniprot-ptm:sites`` Phase B builder via
            :func:`hvantk.core.plugin.run_builder.run_builder_for_spec`.
            The build is stamped with platform Provenance.
 
@@ -97,7 +97,7 @@ def ptm_build_pipeline(config: PTMBuildConfig) -> PTMBuildResult:
     if result.n_mapped > 0:
         logger.info("Building Hail Table at %s...", config.output_ht)
         reg = plugin_loader.get_registry()
-        spec = reg.get_dataset("uniprot_ptm:sites")
+        spec = reg.get_dataset("uniprot-ptm:sites")
         mapped_path = _resolve_mapped_path(config, result)
         run_builder_for_spec(
             spec,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ seaborn = { version = "*", optional = true }
 plotly = { version = "*", optional = true }
 duckdb = { version = ">=0.9.0", optional = true }
 cptac = { version = "*", optional = true }
+# sorted-nearest is a compiled runtime dep of pyranges (imported by cptac); an
+# extras install doesn't reliably pull it, so declare it explicitly. Import name
+# is `sorted_nearest`. Already resolved in poetry.lock (0.0.41).
+sorted-nearest = { version = "*", optional = true }
 tspex = { version = ">=0.6.0", optional = true }
 
 [tool.poetry.extras]
@@ -60,7 +64,7 @@ duckdb = ["duckdb"]
 interactive = ["plotly"]
 hgc = ["matplotlib", "seaborn", "plotly", "gnomad"]
 psroc = ["matplotlib", "plotly", "scikit-learn"]
-ptm = ["cptac"]
+ptm = ["cptac", "sorted-nearest"]
 constraint = ["tspex", "matplotlib", "seaborn"]
 ancestry = ["scikit-learn", "matplotlib", "seaborn"]
 ml = ["scikit-learn"]


### PR DESCRIPTION
## Summary

Fixes the five PTM dataset build-path defects from #198 so the **documented CLI
happy path** is reproducible. Bug fixes only — no schema, provenance, or public-API
breaks. Each fix is independently revertible and covered by fast (no Hail / no
network / no `cptac`) tests.

Closes #198.

## Fixes

| # | Area | Change |
|---|------|--------|
| 1 | `hvantk ptm build` | `reg.get_dataset("uniprot_ptm:sites")` → `"uniprot-ptm:sites"` (hyphen, matching `plugin.yaml name: uniprot-ptm`). The bug wasted the whole GTF download + coordinate-mapping run, then `KeyError`ed at the final build. + Hail-free regression test. |
| 2 | `reprocess cptac:phospho` | `reprocess` hands the builder the intermediate/raw **path**, but `build_cptac_phospho` assumed a `{expression,metadata}` dict → `TypeError`. Drop the phospho `lifecycle.parse` (its site-consolidation was PTM-pipeline input, never the AnnData builder's), and make the builder accept a dict **or** a raw dir + `cancer_type` (per-cancer `matrix.csv`/`metadata.csv`) — mirroring the sibling `cptac:expression`. Also `site_id_col` default `"SiteID"` → `"Site"` (the header the download actually writes). |
| 3 | `download cptac-phospho --all` | One failing cancer (coad + ov fail upstream in `cptac` 1.5.14) aborted the batch. Skip-and-continue per cancer in both `download_dataset` and `download_cmd`; record failures, summarize, exit non-zero only when nothing succeeded. |
| 4 | deps | Declare `sorted-nearest` (compiled `pyranges` dep imported by `cptac`) in the `ptm` extra so extras installs pull it (`ModuleNotFoundError: sorted_nearest` otherwise). |
| 5 | `reprocess` UX | (a) Fail fast when `--output`'s extension doesn't match the plugin's declared backend (pandas→`.parquet`, hail→`.ht`/`.mt`, anndata→`.h5ad`) — previously `--output foo.ht` on a pandas artifact silently ran `to_hail()` (needs a JVM). `reprocess` writes each dataset in its native format. (b) Auto-default `--intermediate` under `--raw-dir` (logged) instead of hard-erroring when a plugin declares `lifecycle.parse`. |

## Documented end-to-end path (now works)

```bash
hvantk reprocess cptac:phospho \
  --raw-dir /data/cptac \
  --output cptac_phospho_brca.h5ad \
  --plugin-arg cancer_type=brca      # flows to both download and build
```

## Out of scope (flagged, deliberately untouched)

- `cptac:expression` shares the same dict-input assumption but has **no** downloader
  (no file-naming convention to resolve), so it can't take the raw-dir fix.
- peptideatlas re-parses its zip in both the download and parse stages (pre-existing
  double-work).

## Testing

- New/updated fast tests: uniprot-ptm key regression; cptac phospho builder (dict +
  raw-dir + error paths); cptac `--all` skip-and-continue for **both** the lifecycle
  `download_dataset` and the `download_cmd` CLI (survivor-merge + exit codes);
  `sorted-nearest` extra; reprocess extension-check + auto-intermediate + no-parse
  wiring. Adapted the pre-existing `test_reprocess_cli.py` fixture and the
  `test_plugin_conformance.py` cptac fixture (`SiteID`→`Site`) to the corrected
  `site_id_col` default.
- Full fast suite: **0 test failures.** The only errors are pre-existing and
  environment-specific, unrelated to this PR: (a) `requests_mock` (a dev dep) is
  absent in the test venv → a few `test_drift_probe.py` modules fail *collection*;
  (b) a few `hgc`/`enrichex` tests error on Hail's Java-8 `Py4JJavaError` (this node
  runs Java 8; Hail needs 11). Both are stable across base and branch.

## Follow-up for maintainers (not done here)

- **`poetry.lock` re-lock.** `sorted-nearest` 0.0.41 is already resolved in the lock
  (transitive), but the lockfile's `content-hash` no longer matches after adding the
  direct optional dep. I did **not** commit a re-lock: running `poetry lock` with the
  available Poetry (2.3.4) re-resolves the entire graph (e.g. `gnomad` 0.8.2→0.6.4,
  `jsonschema` 3→4, ~20 packages added/removed) — a breaking, out-of-scope change.
  Please re-lock with the repo's canonical Poetry version in a dedicated commit.
