### PR TITLE
feat(hgc): expose GVCF-combiner partitioning and tree-merge knobs

### DIFF
--- a/docs_site/tools/hgc.md
+++ b/docs_site/tools/hgc.md
@@ -86,6 +86,48 @@ hvantk hgc pipeline \
 
 See [Pipeline Orchestration](#pipeline-orchestration) for detailed documentation.
 
+#### Tuning combiner parallelism (`--import-interval-size`)
+
+Hail's gVCF combiner partitions the import by **even genomic intervals**, and derives
+**one partition per interval**. The interval size therefore sets a *ceiling* on how many
+cores can do useful work in the combine stage — the stage that dominates joint-genotyping
+runtime.
+
+The default is Hail's genome default of **1.2 Mb**, which is sized for whole-genome gVCFs.
+For a **region-restricted** run (a single chromosome, an exome, a gene panel) it can
+produce far fewer partitions than you have cores, leaving most of them idle:
+
+| Input region | Partitions at the 1.2 Mb default |
+|---|---|
+| chr20 (64.4 Mb) | 54 |
+| chr1 (249.0 Mb) | 208 |
+| whole genome (3.1 Gb) | ~2,584 |
+
+**Rule of thumb: keep partitions at roughly 2–4× your total core count.** If you run
+chr20 on 128 cores with the default, ~74 cores have nothing to do — which looks like
+"the tool doesn't scale" but is purely a partitioning artefact.
+
+```bash
+# chr1 on a 128-core cluster: 600 kb -> 415 partitions (~3x cores)
+hvantk hgc gvcf-combine -g /path/to/chr1_gvcfs -o cohort.vds \
+    --import-interval-size 600000
+
+# The same knob on the recommended end-to-end pipeline
+hvantk hgc pipeline -i /path/to/chr1_gvcfs -o /path/to/out \
+    --import-interval-size 600000
+```
+
+Related tuning options (available on both `gvcf-combine` and `pipeline`):
+
+| Option | Meaning | Hail default |
+|---|---|---|
+| `--import-interval-size` | Interval size (bp); **one partition per interval** | 1.2 Mb (genome) |
+| `--use-exome-default-intervals` | Use Hail's exome interval size | 60 Mb |
+| `--gvcf-batch-size` | gVCFs merged per tree-merge batch | 50 |
+| `--branch-factor` | Branch factor of the hierarchical merge | 100 |
+
+`--import-interval-size` and `--use-exome-default-intervals` are mutually exclusive.
+
 #### Individual Component Commands
 
 For advanced users who need fine-grained control, HGC provides individual commands:

--- a/hvantk/algorithms/hgc/combiners.py
+++ b/hvantk/algorithms/hgc/combiners.py
@@ -33,8 +33,19 @@ def combine_gvcfs(
         save_path (str): Path to save the combiner plan.
         vdses (List[str]): List of VDS paths to be combined.
         kwargs (dict): Additional keyword arguments to pass to the new_combiner hail function.
-                      Can include 'intervals', 'use_genome_default_intervals', or
-                      'use_exome_default_intervals' (mutually exclusive).
+                      GVCF partitioning is chosen by exactly one of 'intervals',
+                      'import_interval_size', 'use_genome_default_intervals', or
+                      'use_exome_default_intervals' (mutually exclusive). If none is given,
+                      'use_genome_default_intervals' is applied (Hail's 1.2 Mb genome default).
+                      Other keys (e.g. 'gvcf_batch_size', 'branch_factor', 'target_records')
+                      are forwarded to Hail unchanged.
+
+                      Partitioning note: Hail derives one partition per interval, so the
+                      combiner's effective parallelism is capped by the interval count. With
+                      the 1.2 Mb genome default a single chromosome yields relatively few
+                      partitions (e.g. chr20 -> 54), and cores beyond that sit idle. Set
+                      'import_interval_size' so that partitions comfortably exceed the number
+                      of available cores (~2-4x is a good target).
         reference_genome (str): Reference genome to use (default: GRCh38).
 
     Returns:
@@ -66,18 +77,26 @@ def combine_gvcfs(
 
         # Handle interval-related parameters from kwargs
         intervals = kwargs.pop("intervals", None)
+        import_interval_size = kwargs.pop("import_interval_size", None)
         use_genome_default = kwargs.pop("use_genome_default_intervals", False)
         use_exome_default = kwargs.pop("use_exome_default_intervals", False)
 
-        # Validate that only one interval method is specified
+        # Validate that only one interval method is specified. Hail warns (and silently
+        # picks one) when several collide, so we fail loudly here instead.
         interval_params_set = sum(
-            [intervals is not None, use_genome_default, use_exome_default]
+            [
+                intervals is not None,
+                import_interval_size is not None,
+                use_genome_default,
+                use_exome_default,
+            ]
         )
 
         if interval_params_set > 1:
             raise ValueError(
-                "Only one of 'intervals', 'use_genome_default_intervals', or "
-                "'use_exome_default_intervals' can be specified."
+                "Only one of 'intervals', 'import_interval_size', "
+                "'use_genome_default_intervals', or 'use_exome_default_intervals' "
+                "can be specified."
             )
 
         # Set default to genome intervals if none specified
@@ -95,6 +114,9 @@ def combine_gvcfs(
         logging.info(f"  - Reference genome: {reference_genome}")
         logging.info(f"  - Use genome intervals: {use_genome_default}")
         logging.info(f"  - Use exome intervals: {use_exome_default}")
+        logging.info(f"  - Import interval size: {import_interval_size}")
+        if intervals is not None:
+            logging.info(f"  - Explicit intervals: {len(intervals)}")
         if validated_gvcfs:
             logging.info(f"  - First GVCF: {validated_gvcfs[0]}")
 
@@ -107,6 +129,7 @@ def combine_gvcfs(
                 save_path=save_path,
                 vds_paths=validated_vdses,
                 intervals=intervals,
+                import_interval_size=import_interval_size,
                 use_genome_default_intervals=use_genome_default,
                 use_exome_default_intervals=use_exome_default,
                 reference_genome=reference_genome,

--- a/hvantk/algorithms/hgc/combiners.py
+++ b/hvantk/algorithms/hgc/combiners.py
@@ -62,6 +62,12 @@ def combine_gvcfs(
         if not (gvcf_dir or vdses):
             raise ValueError("Either GVCF files or VDS files must be provided.")
 
+        # Work on a copy: the interval keys below are consumed with .pop(), and mutating
+        # the caller's dict would silently strip the settings from any subsequent call
+        # that reuses it (e.g. combining several chromosomes in a loop), falling back to
+        # the genome default without warning.
+        kwargs = dict(kwargs or {})
+
         validated_gvcfs: List[str] = []
         validated_vdses: List[str] = []
 
@@ -77,6 +83,11 @@ def combine_gvcfs(
 
         # Handle interval-related parameters from kwargs
         intervals = kwargs.pop("intervals", None)
+        if intervals is not None:
+            # Callers may naturally supply any iterable (e.g. a generator comprehension
+            # over contigs). Materialise it once so that logging/len cannot raise and so
+            # Hail receives a list it can traverse more than once.
+            intervals = list(intervals)
         import_interval_size = kwargs.pop("import_interval_size", None)
         use_genome_default = kwargs.pop("use_genome_default_intervals", False)
         use_exome_default = kwargs.pop("use_exome_default_intervals", False)
@@ -97,6 +108,13 @@ def combine_gvcfs(
                 "Only one of 'intervals', 'import_interval_size', "
                 "'use_genome_default_intervals', or 'use_exome_default_intervals' "
                 "can be specified."
+            )
+
+        # Fail fast on values Hail would only reject deep inside the combiner, where the
+        # error is wrapped in generic "check your Spark version / GVCF files" guidance.
+        if import_interval_size is not None and import_interval_size < 1:
+            raise ValueError(
+                f"'import_interval_size' must be at least 1 bp, got {import_interval_size}."
             )
 
         # Set default to genome intervals if none specified

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -64,6 +64,15 @@ class PipelineConfig:
     overwrite: bool = False
     output_prefix: str = "cohort"
 
+    # GVCF-combiner tuning (stage 1). Hail derives ONE PARTITION PER INTERVAL, so the
+    # interval size caps how many cores can do useful work in the combine stage: with
+    # Hail's 1.2 Mb genome default a single chromosome yields few partitions
+    # (chr20 -> 54, chr1 -> 208) and any cores beyond that idle.
+    import_interval_size: Optional[int] = None
+    use_exome_default_intervals: bool = False
+    gvcf_batch_size: Optional[int] = None
+    branch_factor: Optional[int] = None
+
     # Stage skip flags
     skip_combine_gvcfs: bool = False
     skip_vds_to_mt: bool = False
@@ -118,7 +127,41 @@ class PipelineConfig:
         if not 0 <= self.min_variant_call_rate <= 1:
             errors.append("min_variant_call_rate must be between 0 and 1")
 
+        # Validate GVCF-combiner tuning. Hail rejects these too, but only once the
+        # combiner is constructed - well after Hail init and gVCF validation - and the
+        # error is then wrapped in generic "check your Spark/GVCFs" guidance.
+        if self.import_interval_size is not None and self.import_interval_size < 1:
+            errors.append("import_interval_size must be at least 1 bp")
+
+        if self.import_interval_size is not None and self.use_exome_default_intervals:
+            errors.append(
+                "import_interval_size and use_exome_default_intervals are mutually exclusive"
+            )
+
+        if self.gvcf_batch_size is not None and self.gvcf_batch_size < 1:
+            errors.append("gvcf_batch_size must be at least 1")
+
+        if self.branch_factor is not None and self.branch_factor < 2:
+            errors.append("branch_factor must be at least 2")
+
         return errors
+
+    def combiner_kwargs(self) -> Dict[str, Any]:
+        """Build the kwargs forwarded to ``combine_gvcfs`` for stage 1.
+
+        Only keys the user actually set are included; an empty dict preserves Hail's
+        default partitioning (``use_genome_default_intervals``, 1.2 Mb).
+        """
+        kwargs: Dict[str, Any] = {}
+        if self.import_interval_size is not None:
+            kwargs["import_interval_size"] = self.import_interval_size
+        if self.use_exome_default_intervals:
+            kwargs["use_exome_default_intervals"] = True
+        if self.gvcf_batch_size is not None:
+            kwargs["gvcf_batch_size"] = self.gvcf_batch_size
+        if self.branch_factor is not None:
+            kwargs["branch_factor"] = self.branch_factor
+        return kwargs
 
 
 @dataclass
@@ -279,6 +322,9 @@ class PipelineRunner:
         print(f"  Reference genome: {self.config.reference_genome}")
         print(f"  Partitions:       {self.config.n_partitions or 'auto'}")
         print(f"  Overwrite:        {self.config.overwrite}")
+        print(
+            f"  Combiner options: {self.config.combiner_kwargs() or 'defaults (genome 1.2 Mb intervals)'}"
+        )
 
         print("\n📊 Stages to execute:")
         stage_num = 1
@@ -436,13 +482,17 @@ class PipelineRunner:
         """Stage 1: Combine gVCFs into VDS."""
         self.logger.info("🔄 [1/5] Combining gVCF files into VDS...")
 
+        combiner_kwargs = self.config.combiner_kwargs()
+        if combiner_kwargs:
+            self.logger.info(f"   Combiner options: {combiner_kwargs}")
+
         combine_gvcfs(
             gvcf_dir=self.config.input_dir,
             vds_output_path=self.paths["vds"],
             tmp_path=self.config.tmp_dir or tempfile.mkdtemp(),
             save_path=f"{self.paths['vds']}.plan",
             vdses=[],
-            kwargs={},
+            kwargs=combiner_kwargs,
             reference_genome=self.config.reference_genome,
         )
 

--- a/hvantk/tests/hgc/test_cli_combine.py
+++ b/hvantk/tests/hgc/test_cli_combine.py
@@ -85,6 +85,162 @@ def test_gvcf_combine_cli_with_vds_paths():
             assert call_kwargs["vdses"] == ["/vds1.vds", "/vds2.vds"]
 
 
+def test_gvcf_combine_cli_default_forwards_empty_kwargs():
+    """Default invocation must forward no combiner kwargs (Hail's genome default applies).
+
+    Regression guard: previously ``kwargs={}`` was hardcoded, so the partitioning was
+    unreachable. Exposing the knobs must not change the default behaviour.
+    """
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.combine_cli.combine_gvcfs") as mock_combine:
+        with patch(
+            "hvantk.tools.hgc.combine_cli.validate_output_path"
+        ) as mock_validate:
+            mock_validate.return_value = True
+
+            result = runner.invoke(
+                gvcf_combine,
+                ["--gvcf-dir", "/gvcfs", "--output", "/out.vds"],
+            )
+
+            assert result.exit_code == 0
+            assert mock_combine.call_args[1]["kwargs"] == {}
+
+
+def test_gvcf_combine_cli_import_interval_size():
+    """--import-interval-size is forwarded to the combiner (the parallelism knob)."""
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.combine_cli.combine_gvcfs") as mock_combine:
+        with patch(
+            "hvantk.tools.hgc.combine_cli.validate_output_path"
+        ) as mock_validate:
+            mock_validate.return_value = True
+
+            result = runner.invoke(
+                gvcf_combine,
+                [
+                    "--gvcf-dir",
+                    "/gvcfs",
+                    "--output",
+                    "/out.vds",
+                    "--import-interval-size",
+                    "600000",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert mock_combine.call_args[1]["kwargs"] == {
+                "import_interval_size": 600000
+            }
+
+
+def test_gvcf_combine_cli_tree_merge_options():
+    """--gvcf-batch-size and --branch-factor are forwarded to the combiner."""
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.combine_cli.combine_gvcfs") as mock_combine:
+        with patch(
+            "hvantk.tools.hgc.combine_cli.validate_output_path"
+        ) as mock_validate:
+            mock_validate.return_value = True
+
+            result = runner.invoke(
+                gvcf_combine,
+                [
+                    "--gvcf-dir",
+                    "/gvcfs",
+                    "--output",
+                    "/out.vds",
+                    "--gvcf-batch-size",
+                    "100",
+                    "--branch-factor",
+                    "50",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert mock_combine.call_args[1]["kwargs"] == {
+                "gvcf_batch_size": 100,
+                "branch_factor": 50,
+            }
+
+
+def test_gvcf_combine_cli_exome_default_intervals():
+    """--use-exome-default-intervals is forwarded (previously unreachable from the CLI)."""
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.combine_cli.combine_gvcfs") as mock_combine:
+        with patch(
+            "hvantk.tools.hgc.combine_cli.validate_output_path"
+        ) as mock_validate:
+            mock_validate.return_value = True
+
+            result = runner.invoke(
+                gvcf_combine,
+                [
+                    "--gvcf-dir",
+                    "/gvcfs",
+                    "--output",
+                    "/out.vds",
+                    "--use-exome-default-intervals",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert mock_combine.call_args[1]["kwargs"] == {
+                "use_exome_default_intervals": True
+            }
+
+
+def test_gvcf_combine_cli_partitioning_options_mutually_exclusive():
+    """Colliding partitioning options must fail loudly.
+
+    Hail itself only emits a warning and silently picks one, which is easy to miss in a
+    long combiner log, so the CLI rejects the combination up front.
+    """
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.combine_cli.validate_output_path") as mock_validate:
+        mock_validate.return_value = True
+
+        result = runner.invoke(
+            gvcf_combine,
+            [
+                "--gvcf-dir",
+                "/gvcfs",
+                "--output",
+                "/out.vds",
+                "--import-interval-size",
+                "600000",
+                "--use-genome-default-intervals",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output
+
+
+def test_gvcf_combine_cli_dry_run_shows_combiner_options():
+    """Dry-run surfaces the combiner options that would be used."""
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.combine_cli.validate_output_path") as mock_validate:
+        mock_validate.return_value = True
+
+        result = runner.invoke(
+            gvcf_combine,
+            [
+                "--gvcf-dir",
+                "/gvcfs",
+                "--output",
+                "/out.vds",
+                "--import-interval-size",
+                "300000",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "import_interval_size" in result.output
+        assert "300000" in result.output
+
+
 def test_vds_combine_cli_basic():
     """Test vds-combine command with basic options."""
     runner = CliRunner()

--- a/hvantk/tests/hgc/test_combiners_partitioning.py
+++ b/hvantk/tests/hgc/test_combiners_partitioning.py
@@ -1,0 +1,116 @@
+"""Unit tests for `combine_gvcfs` partitioning handling.
+
+These exercise the algorithm directly (not through the CLI), because the CLI does not
+expose ``intervals`` and therefore cannot reach some of these branches at all.
+Hail is stubbed out: every assertion here is about what `combine_gvcfs` decides *before*
+it hands off to ``hl.vds.new_combiner``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hvantk.algorithms.hgc.combiners import combine_gvcfs
+
+
+def _run(kwargs, gvcfs=("/gvcfs/a.g.vcf.gz",)):
+    """Call combine_gvcfs with Hail + path validation stubbed; return the new_combiner mock."""
+    with patch(
+        "hvantk.algorithms.hgc.combiners.validate_vcfs_paths", return_value=list(gvcfs)
+    ):
+        with patch("hvantk.algorithms.hgc.combiners.hl") as mock_hl:
+            mock_hl.vds.new_combiner.return_value = MagicMock()
+            combine_gvcfs(
+                gvcf_dir="/gvcfs",
+                vds_output_path="/out.vds",
+                tmp_path="/tmp",
+                save_path=None,
+                vdses=[],
+                kwargs=kwargs,
+            )
+            return mock_hl.vds.new_combiner
+
+
+def test_no_partitioning_option_defaults_to_genome_intervals():
+    """With no options, Hail's genome default is applied (unchanged legacy behaviour)."""
+    nc = _run({})
+    call = nc.call_args[1]
+    assert call["use_genome_default_intervals"] is True
+    assert call["import_interval_size"] is None
+    assert call["intervals"] is None
+
+
+def test_import_interval_size_is_forwarded_and_suppresses_genome_default():
+    """import_interval_size must NOT also trigger use_genome_default_intervals.
+
+    Hail only *warns* about colliding partition arguments and silently picks one, so a
+    regression here would quietly ignore the user's requested interval size.
+    """
+    nc = _run({"import_interval_size": 600_000})
+    call = nc.call_args[1]
+    assert call["import_interval_size"] == 600_000
+    assert call["use_genome_default_intervals"] is False
+    assert call["use_exome_default_intervals"] is False
+
+
+def test_explicit_intervals_suppress_genome_default():
+    nc = _run({"intervals": ["iv1", "iv2"]})
+    call = nc.call_args[1]
+    assert call["intervals"] == ["iv1", "iv2"]
+    assert call["use_genome_default_intervals"] is False
+
+
+def test_intervals_may_be_any_iterable():
+    """A generator must not blow up (len() is used for logging)."""
+    nc = _run({"intervals": (f"iv{i}" for i in range(3))})
+    assert nc.call_args[1]["intervals"] == ["iv0", "iv1", "iv2"]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"import_interval_size": 600_000, "use_genome_default_intervals": True},
+        {"import_interval_size": 600_000, "use_exome_default_intervals": True},
+        {"intervals": ["iv"], "import_interval_size": 600_000},
+        {"use_genome_default_intervals": True, "use_exome_default_intervals": True},
+    ],
+)
+def test_colliding_partitioning_options_raise(kwargs):
+    """Colliding options must fail loudly rather than let Hail silently pick one."""
+    with pytest.raises(ValueError, match="Only one of"):
+        _run(kwargs)
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_non_positive_import_interval_size_raises(bad):
+    """0 would reach Hail as ceil(contig_length / 0) -> ZeroDivisionError."""
+    with pytest.raises(ValueError, match="at least 1"):
+        _run({"import_interval_size": bad})
+
+
+def test_caller_kwargs_dict_is_not_mutated():
+    """combine_gvcfs must not consume the caller's dict.
+
+    Regression guard: the interval keys are read with .pop(). If they were popped from
+    the caller's own dict, a natural pattern like
+
+        opts = {"import_interval_size": 600_000}
+        for contig in contigs:
+            combine_gvcfs(..., kwargs=opts)
+
+    would silently lose the setting after the first iteration and fall back to the
+    genome default -- exactly the parallelism ceiling these options exist to avoid.
+    """
+    opts = {"import_interval_size": 600_000, "gvcf_batch_size": 100}
+    nc = _run(opts)
+
+    assert opts == {"import_interval_size": 600_000, "gvcf_batch_size": 100}
+    # ...and the setting really did reach Hail on this call
+    assert nc.call_args[1]["import_interval_size"] == 600_000
+
+
+def test_tree_merge_options_are_forwarded_unchanged():
+    nc = _run({"gvcf_batch_size": 100, "branch_factor": 50})
+    call = nc.call_args[1]
+    assert call["gvcf_batch_size"] == 100
+    assert call["branch_factor"] == 50

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -1,0 +1,71 @@
+"""The HGC pipeline must be able to tune gVCF-combiner partitioning.
+
+`hvantk hgc pipeline` is the documented, recommended entry point, but it previously
+passed ``kwargs={}`` to ``combine_gvcfs`` unconditionally -- so a pipeline user was stuck
+with Hail's 1.2 Mb genome default and had no way to raise the partition count above their
+core count. These tests pin the wiring so that cannot silently regress.
+"""
+
+import pytest
+
+from hvantk.algorithms.hgc.pipeline import PipelineConfig
+
+
+def _cfg(tmp_path, **overrides):
+    return PipelineConfig(
+        input_dir=str(tmp_path), output_dir=str(tmp_path / "out"), **overrides
+    )
+
+
+def test_combiner_kwargs_empty_by_default(tmp_path):
+    """No tuning options -> empty kwargs -> Hail's genome default (legacy behaviour)."""
+    assert _cfg(tmp_path).combiner_kwargs() == {}
+
+
+def test_combiner_kwargs_carries_import_interval_size(tmp_path):
+    cfg = _cfg(tmp_path, import_interval_size=600_000)
+    assert cfg.combiner_kwargs() == {"import_interval_size": 600_000}
+
+
+def test_combiner_kwargs_carries_tree_merge_options(tmp_path):
+    cfg = _cfg(tmp_path, gvcf_batch_size=100, branch_factor=50)
+    assert cfg.combiner_kwargs() == {"gvcf_batch_size": 100, "branch_factor": 50}
+
+
+def test_combiner_kwargs_carries_exome_default(tmp_path):
+    cfg = _cfg(tmp_path, use_exome_default_intervals=True)
+    assert cfg.combiner_kwargs() == {"use_exome_default_intervals": True}
+
+
+@pytest.mark.parametrize(
+    "overrides, expected",
+    [
+        ({"import_interval_size": 0}, "at least 1 bp"),
+        ({"import_interval_size": -5}, "at least 1 bp"),
+        ({"gvcf_batch_size": 0}, "at least 1"),
+        ({"branch_factor": 1}, "at least 2"),
+        (
+            {"import_interval_size": 600_000, "use_exome_default_intervals": True},
+            "mutually exclusive",
+        ),
+    ],
+)
+def test_invalid_combiner_tuning_is_rejected_by_validate(tmp_path, overrides, expected):
+    """Bad values must be caught by config validation, not deep inside Hail.
+
+    Hail does reject these, but only after init + gVCF validation, and the error is then
+    wrapped in generic "check your Spark version / GVCF files" guidance that points the
+    user at the wrong cause entirely.
+    """
+    errors = _cfg(tmp_path, **overrides).validate()
+    assert any(expected in e for e in errors), errors
+
+
+def test_valid_combiner_tuning_passes_validate(tmp_path):
+    errors = _cfg(
+        tmp_path, import_interval_size=600_000, gvcf_batch_size=50, branch_factor=100
+    ).validate()
+    combiner_errors = [
+        e for e in errors if "interval" in e or "batch" in e or "branch" in e
+    ]
+    assert combiner_errors == []

--- a/hvantk/tools/hgc/combine_cli.py
+++ b/hvantk/tools/hgc/combine_cli.py
@@ -34,19 +34,76 @@ def register_combine_commands(group):
 )
 @click.option("--save-path", "-s", help="Path to save the combiner plan")
 @click.option(
+    "--import-interval-size",
+    type=int,
+    default=None,
+    help=(
+        "Size (bp) of the even genomic intervals used to partition GVCF import. "
+        "Hail derives ONE PARTITION PER INTERVAL, so this caps the combiner's "
+        "parallelism. Default (Hail's genome default) is 1.2 Mb. Lower it so that "
+        "partitions comfortably exceed your core count (~2-4x is a good target). "
+        "Mutually exclusive with --use-genome-default-intervals / "
+        "--use-exome-default-intervals."
+    ),
+)
+@click.option(
+    "--use-genome-default-intervals",
+    is_flag=True,
+    default=False,
+    help="Partition with Hail's genome default interval size (1.2 Mb). This is the default behaviour.",
+)
+@click.option(
+    "--use-exome-default-intervals",
+    is_flag=True,
+    default=False,
+    help="Partition with Hail's exome default interval size (60 Mb).",
+)
+@click.option(
+    "--gvcf-batch-size",
+    type=int,
+    default=None,
+    help="Number of GVCFs to combine per tree-merge batch (Hail default: 50).",
+)
+@click.option(
+    "--branch-factor",
+    type=int,
+    default=None,
+    help="Branch factor of the combiner's hierarchical merge (Hail default: 100).",
+)
+@click.option(
     "--dry-run", is_flag=True, help="Show what would be done without executing"
 )
 @click.pass_context
-def gvcf_combine(ctx, gvcf_dir, vds_paths, output, temp_dir, save_path, dry_run):
+def gvcf_combine(
+    ctx,
+    gvcf_dir,
+    vds_paths,
+    output,
+    temp_dir,
+    save_path,
+    import_interval_size,
+    use_genome_default_intervals,
+    use_exome_default_intervals,
+    gvcf_batch_size,
+    branch_factor,
+    dry_run,
+):
     """
     Combine GVCF files for joint genotyping.
 
     This command takes GVCF files from a directory and/or existing VDS datasets
     and combines them into a single joint-called variant dataset using Hail's optimized combiner.
 
+    Tuning parallelism: the combiner creates one partition per genomic interval, so the
+    interval size sets the ceiling on how many cores can do useful work. With the 1.2 Mb
+    genome default, a single chromosome yields relatively few partitions (chr20 -> 54,
+    chr1 -> 208) and any cores beyond that idle. Use --import-interval-size to raise the
+    partition count above your core count.
+
     Examples:
         hvantk hgc gvcf-combine -g /path/to/gvcfs -o combined.vds
         hvantk hgc gvcf-combine -g /path/to/gvcfs -v existing.vds -o combined.vds
+        hvantk hgc gvcf-combine -g /path/to/gvcfs -o combined.vds --import-interval-size 600000
     """
     try:
         logger.info("Starting GVCF combination workflow")
@@ -60,12 +117,42 @@ def gvcf_combine(ctx, gvcf_dir, vds_paths, output, temp_dir, save_path, dry_run)
             click.echo("❌ Invalid output path", err=True)
             ctx.exit(1)
 
+        # Exactly one partitioning strategy may be chosen (Hail only warns and silently
+        # picks one when they collide, so reject it here).
+        partition_opts = [
+            import_interval_size is not None,
+            use_genome_default_intervals,
+            use_exome_default_intervals,
+        ]
+        if sum(partition_opts) > 1:
+            click.echo(
+                "❌ --import-interval-size, --use-genome-default-intervals and "
+                "--use-exome-default-intervals are mutually exclusive",
+                err=True,
+            )
+            ctx.exit(1)
+
+        # Only forward keys the user actually set; an empty dict preserves the previous
+        # behaviour (Hail's 1.2 Mb genome default).
+        combiner_kwargs = {}
+        if import_interval_size is not None:
+            combiner_kwargs["import_interval_size"] = import_interval_size
+        if use_genome_default_intervals:
+            combiner_kwargs["use_genome_default_intervals"] = True
+        if use_exome_default_intervals:
+            combiner_kwargs["use_exome_default_intervals"] = True
+        if gvcf_batch_size is not None:
+            combiner_kwargs["gvcf_batch_size"] = gvcf_batch_size
+        if branch_factor is not None:
+            combiner_kwargs["branch_factor"] = branch_factor
+
         if dry_run:
             click.echo("🔍 Dry run mode - would execute GVCF combination with:")
             click.echo(f"   • GVCF directory: {gvcf_dir or 'None'}")
             click.echo(f"   • VDS paths: {list(vds_paths) if vds_paths else 'None'}")
             click.echo(f"   • Output: {output}")
             click.echo(f"   • Temp directory: {temp_dir}")
+            click.echo(f"   • Combiner options: {combiner_kwargs or 'defaults'}")
             return
 
         # Execute combination
@@ -76,7 +163,7 @@ def gvcf_combine(ctx, gvcf_dir, vds_paths, output, temp_dir, save_path, dry_run)
             tmp_path=temp_dir,
             save_path=save_path or f"{output}.plan",
             vdses=list(vds_paths) if vds_paths else [],
-            kwargs={},
+            kwargs=combiner_kwargs,
         )
 
         click.echo(f"✅ Successfully combined GVCFs to {output}")

--- a/hvantk/tools/hgc/combine_cli.py
+++ b/hvantk/tools/hgc/combine_cli.py
@@ -35,7 +35,7 @@ def register_combine_commands(group):
 @click.option("--save-path", "-s", help="Path to save the combiner plan")
 @click.option(
     "--import-interval-size",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help=(
         "Size (bp) of the even genomic intervals used to partition GVCF import. "
@@ -60,13 +60,13 @@ def register_combine_commands(group):
 )
 @click.option(
     "--gvcf-batch-size",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="Number of GVCFs to combine per tree-merge batch (Hail default: 50).",
 )
 @click.option(
     "--branch-factor",
-    type=int,
+    type=click.IntRange(min=2),
     default=None,
     help="Branch factor of the combiner's hierarchical merge (Hail default: 100).",
 )

--- a/hvantk/tools/hgc/pipeline_cli.py
+++ b/hvantk/tools/hgc/pipeline_cli.py
@@ -32,6 +32,38 @@ def register_pipeline_command(group):
 )
 # Stage control flags
 @click.option(
+    "--import-interval-size",
+    type=click.IntRange(min=1),
+    default=None,
+    help=(
+        "Size (bp) of the even genomic intervals used to partition gVCF import in "
+        "stage 1. Hail derives ONE PARTITION PER INTERVAL, so this caps the combine "
+        "stage's parallelism. Default (Hail's genome default) is 1.2 Mb, which yields "
+        "few partitions for a single chromosome (chr20 -> 54, chr1 -> 208), leaving "
+        "extra cores idle. Lower it so partitions comfortably exceed your core count "
+        "(~2-4x is a good target). Mutually exclusive with "
+        "--use-exome-default-intervals."
+    ),
+)
+@click.option(
+    "--use-exome-default-intervals",
+    is_flag=True,
+    default=False,
+    help="Partition gVCF import with Hail's exome default interval size (60 Mb).",
+)
+@click.option(
+    "--gvcf-batch-size",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Number of gVCFs to combine per tree-merge batch (Hail default: 50).",
+)
+@click.option(
+    "--branch-factor",
+    type=click.IntRange(min=2),
+    default=None,
+    help="Branch factor of the combiner's hierarchical merge (Hail default: 100).",
+)
+@click.option(
     "--skip-combine-gvcfs",
     is_flag=True,
     default=False,
@@ -142,6 +174,10 @@ def pipeline(
     ctx,
     input_dir,
     output_dir,
+    import_interval_size,
+    use_exome_default_intervals,
+    gvcf_batch_size,
+    branch_factor,
     skip_combine_gvcfs,
     skip_vds_to_mt,
     skip_compute_sample_qc,
@@ -202,6 +238,10 @@ def pipeline(
             n_partitions=n_partitions,
             overwrite=overwrite,
             output_prefix=output_prefix,
+            import_interval_size=import_interval_size,
+            use_exome_default_intervals=use_exome_default_intervals,
+            gvcf_batch_size=gvcf_batch_size,
+            branch_factor=branch_factor,
             skip_combine_gvcfs=skip_combine_gvcfs,
             skip_vds_to_mt=skip_vds_to_mt,
             skip_compute_sample_qc=skip_compute_sample_qc,


### PR DESCRIPTION
## Problem

`hvantk hgc gvcf-combine` hardcoded `kwargs={}`, so Hail's combiner partitioning was **unreachable from the CLI** and always fell back to `use_genome_default_intervals` (1.2 Mb).

Hail derives **one partition per genomic interval**, so that default silently caps the combiner's parallelism:

| region | partitions @ 1.2 Mb default |
|---|---|
| chr20 (64.4 Mb) | **54** |
| chr1 (249.0 Mb) | **208** |
| whole genome | ~2,584 |

Cores beyond the partition count sit idle. This is invisible in the logs and is easy to misread as *"the tool doesn't scale"* — especially for region-restricted runs, where the genome default both under-partitions the region of interest and creates thousands of empty intervals elsewhere.

## Changes

- **CLI (`gvcf-combine`)** — new options: `--import-interval-size`, `--use-genome-default-intervals`, `--use-exome-default-intervals`, `--gvcf-batch-size`, `--branch-factor`. Colliding partitioning flags are **rejected up front**; Hail itself only emits a warning and silently picks one, which is easy to miss in a long combiner log.
- **`combine_gvcfs`** — recognises `import_interval_size` as a partitioning strategy so it participates in the mutual-exclusion check and is forwarded to `new_combiner`. Previously, passing it *also* triggered the genome default, producing Hail's "colliding arguments" warning.
- **Help text** documents the partitions-vs-cores relationship (aim for ~2–4× partitions per core).

## Backwards compatibility

With no new flags the CLI still forwards an empty `kwargs`, preserving Hail's genome default. This is guarded by an explicit regression test (`test_gvcf_combine_cli_default_forwards_empty_kwargs`).

## Testing

- 6 new CLI tests: option forwarding, mutual exclusion, dry-run output, and the empty-default regression guard.
- Full suite on a compute node (Java 11): **0 failures**. The only errors are pre-existing `ModuleNotFoundError: requests_mock` collection errors in `skills/*/tests/test_drift_probe.py`, which are present on `dev` and unrelated to this change.
- `flake8` (E9,F63,F7,F82) and `black --check` clean.

## Provenance

Motivated by measurement, not speculation: verified end-to-end on the CHD-1000WGS cohort, where `--import-interval-size 600000` yields **415 chr1 partitions** through hvantk's own code path (vs 208 at the default), comfortably above the core counts used in our scaling runs.