### PR TITLE
perf(hgc): densify once in vds2mt; drop provably-zero QC preflight scans

### DIFF
--- a/docs_site/tools/hgc.md
+++ b/docs_site/tools/hgc.md
@@ -160,7 +160,7 @@ convert_vds_to_mt(
     output_path="analysis.mt",
     adjust_genotypes=True,
     skip_split_multi=False,
-    convert_lgt_to_gt=True
+    skip_validation=False
 )
 ```
 
@@ -354,7 +354,6 @@ hvantk hgc vds2mt \
   --input cohort.vds \
   --output analysis.mt \
   --adjust-genotypes \
-  --convert-lgt-to-gt \
   --overwrite
 ```
 
@@ -367,7 +366,7 @@ convert_vds_to_mt(
     output_path="analysis.mt",
     adjust_genotypes=True,
     skip_split_multi=False,
-    convert_lgt_to_gt=True,
+    skip_validation=False,
     skip_keying_by_cols=False,
     overwrite=False
 )
@@ -378,14 +377,36 @@ convert_vds_to_mt(
 - `output_path`: Output MatrixTable path
 - `adjust_genotypes`: Annotate with adjusted genotypes using gnomAD quality filters (requires `gnomad` package)
 - `skip_split_multi`: Skip splitting multi-allelic variants (not recommended)
-- `convert_lgt_to_gt`: Convert LGT (local genotype) to GT (global genotype) after splitting (recommended)
+- `skip_validation`: Skip the biallelic audit and genotype repair (see below)
 - `skip_keying_by_cols`: Skip keying MatrixTable by sample column
 - `overwrite`: Whether to overwrite existing output
 
 **Important Notes:**
-- LGT to GT conversion must happen **after** splitting multi-allelic variants
+- The VDS-level split already produces biallelic GT/AD — no manual LGT→GT downcoding is needed
 - Adjusted genotype annotation requires the `gnomad` package: `pip install gnomad`
-- Setting `skip_split_multi=True` and `convert_lgt_to_gt=True` will raise an error
+
+#### The densify runs exactly once
+
+This stage is dominated by *densification*: expanding the VDS's reference blocks back into a full
+samples × sites matrix. Hail is lazy and **does not cache**, so every *eager* action on the dense
+MatrixTable — an `aggregate_entries`, a `count`, a `write` — re-executes the whole densify from
+the top.
+
+`convert_vds_to_mt` is therefore written so that **only the final `write` touches the dense
+matrix**:
+
+- the **biallelic audit** (out-of-bounds `GT` indices, `AD` length mismatches) runs on the *sparse*
+  `variant_data`, before densification. That is where such defects can originate: reference blocks
+  are hom-ref by construction and carry no `AD`, so densification cannot introduce either defect.
+- the **repair** (setting an out-of-bounds genotype to missing) is applied as a lazy, unconditional
+  expression on the dense matrix. It fuses into the write, and on clean data it is the identity.
+
+Gating the repair behind `if n_invalid > 0` would look harmless but is not: *reading* that count is
+an eager action, so it forces an entire extra densify of the cohort. On a 500-sample chr1 callset
+that mistake cost ~42% of the stage's wall time.
+
+`--skip-validation` turns off both the audit and the repair. The audit is cheap (it scans only the
+sparse variant records), so there is rarely a reason to.
 
 ### MatrixTable to VCF Export
 
@@ -721,7 +742,7 @@ convert_vds_to_mt(..., adjust_genotypes=False)
 Solution: Either enable multi-allelic splitting or disable LGT conversion:
 convert_vds_to_mt(..., skip_split_multi=False)
 # OR
-convert_vds_to_mt(..., convert_lgt_to_gt=False)
+convert_vds_to_mt(..., skip_validation=True)
 ```
 
 **Issue: "Out of memory during GVCF combination"**
@@ -813,7 +834,7 @@ mt.write("cohort_filtered.mt")
 |----------|-------------|---------|
 | `combine_gvcfs(gvcf_dir, vds_output_path, tmp_path, save_path, vdses, kwargs, reference_genome='GRCh38')` | Combine GVCF files into a VDS. See [GVCF Combination](#gvcf-combination). | None |
 | `combine_vdses(vdses_dir, output_path, validate=True, overwrite=False)` | Merge multiple VDS directories. See [VDS Combination](#vds-combination). | None |
-| `convert_vds_to_mt(vds_path, output_path, adjust_genotypes=True, skip_split_multi=False, convert_lgt_to_gt=True, skip_keying_by_cols=False, overwrite=False)` | Convert VDS to dense MatrixTable. See [VDS to MatrixTable Conversion](#vds-to-matrixtable-conversion). | None |
+| `convert_vds_to_mt(vds_path, output_path, adjust_genotypes=True, skip_split_multi=False, skip_validation=False, skip_keying_by_cols=False, overwrite=False)` | Convert VDS to dense MatrixTable. See [VDS to MatrixTable Conversion](#vds-to-matrixtable-conversion). | None |
 | `convert_mt_to_multi_sample_vcf(mt_path, vcf_path, filter_adj_genotypes=True, min_ac=1, split_multi=True)` | Export MatrixTable to VCF. See [MatrixTable to VCF Export](#matrixtable-to-vcf-export). | None |
 
 ### Utility Functions

--- a/hvantk/algorithms/hgc/converters.py
+++ b/hvantk/algorithms/hgc/converters.py
@@ -37,89 +37,117 @@ def _split_vds(
     return hl.vds.split_multi(vds)
 
 
-def _validate_and_fix_biallelic_entries(
-    mt: hl.MatrixTable, skip_validation: bool = False
-) -> hl.MatrixTable:
+def _gt_out_of_bounds(mt: hl.MatrixTable, field: str = "GT"):
+    """Predicate: this entry's call references an allele index that does not exist.
+
+    Shared by the audit (which counts them) and the repair (which sets them missing), so the two
+    can never drift apart.
     """
-    Validate that GT and AD are correctly aligned to biallelic split variants.
-
-    After VDS-level split, this should find 0 issues. This is a safety check
-    that can be skipped for trusted pipelines to improve performance.
-
-    Parameters:
-        mt: Input MatrixTable (after VDS split + densification)
-        skip_validation: If True, skip validation (faster, use only if confident)
-
-    Returns:
-        MatrixTable with any invalid entries fixed (set to missing)
-    """
-    if skip_validation:
-        logging.info("Skipping biallelic validation (skip_validation=True)")
-        return mt
-
-    logging.info("Validating biallelic entries (GT indices and AD lengths)…")
-
-    # Single aggregation for both GT and AD validation (performance optimization)
-    validation = mt.aggregate_entries(
-        hl.struct(
-            # GT validation: check for out-of-bounds allele indices
-            n_invalid_gt=hl.agg.count_where(
-                hl.is_defined(mt.GT)
-                & hl.any(
-                    lambda i: mt.GT[i] >= hl.len(mt.alleles), hl.range(0, mt.GT.ploidy)
-                )
-            ),
-            gt_examples=hl.agg.filter(
-                hl.is_defined(mt.GT)
-                & hl.any(
-                    lambda i: mt.GT[i] >= hl.len(mt.alleles), hl.range(0, mt.GT.ploidy)
-                ),
-                hl.agg.take(hl.struct(locus=mt.locus, alleles=mt.alleles, GT=mt.GT), 3),
-            ),
-            # AD validation: check for length mismatch
-            n_invalid_ad=hl.agg.count_where(
-                hl.is_defined(mt.AD) & (hl.len(mt.AD) != hl.len(mt.alleles))
-            ),
-            ad_examples=hl.agg.filter(
-                hl.is_defined(mt.AD) & (hl.len(mt.AD) != hl.len(mt.alleles)),
-                hl.agg.take(hl.struct(locus=mt.locus, alleles=mt.alleles, AD=mt.AD), 3),
-            ),
-        )
+    gt = mt[field]
+    return hl.is_defined(gt) & hl.any(
+        lambda i: gt[i] >= hl.len(mt.alleles), hl.range(0, gt.ploidy)
     )
 
-    # Report findings
-    if validation.n_invalid_gt == 0 and validation.n_invalid_ad == 0:
+
+def _audit_split_variant_data(vds: hl.vds.VariantDataset) -> None:
+    """Count (and report) misaligned GT/AD entries, on the SPARSE variant data.
+
+    This is the same check that used to run on the densified MatrixTable, moved upstream. It is
+    equivalent because neither defect can originate in a reference block:
+
+    * reference-derived entries get a hom-ref call -- `to_dense_mt` either injects `hl.call(0, 0)`
+      outright, or reuses a reference call that the VDS combiner already forced to be hom-ref
+      (`.or_error('found reference block with non reference-genotype at' ...)`). A hom-ref call can
+      never index an allele that does not exist.
+    * reference-derived entries have `AD` MISSING. The combiner renames the reference block's depth
+      field to `LAD`, and `to_dense_mt` fills every variant-only field with `hl.missing` on the
+      reference side -- so the `hl.is_defined(AD)` guard below can never fire there.
+
+    Both defects can therefore only live in `variant_data`, which holds just the variant records
+    rather than the full samples x sites matrix. Auditing it costs a scan of the sparse data
+    instead of a second full densify of the cohort.
+
+    (Verified against Hail 0.2.137: hail/vds/methods.py `to_dense_mt`,
+    hail/vds/combiner/combine.py `make_ref_entry_struct`.)
+
+    Assumes a combiner-built VDS, which is the only kind hvantk produces. A hand-assembled VDS with
+    a non-hom-ref reference block could in principle hide a defect from this count -- it would
+    still be *repaired* downstream, because the repair runs on the dense matrix, but it would not
+    be *reported* here.
+    """
+    vd = vds.variant_data
+    has_gt, has_ad = "GT" in vd.entry, "AD" in vd.entry
+
+    if not (has_gt or has_ad):
+        logging.warning(
+            "Skipping biallelic audit: variant data has neither 'GT' nor 'AD' "
+            f"(entries: {list(vd.entry.keys())}). This is expected when the VDS-level "
+            "multi-allelic split was skipped, which leaves local alleles (LGT/LAD) in place."
+        )
+        return
+
+    logging.info(
+        "Auditing biallelic entries on variant data (GT indices and AD lengths)…"
+    )
+
+    checks = {}
+    if has_gt:
+        invalid_gt = _gt_out_of_bounds(vd)
+        checks["n_invalid_gt"] = hl.agg.count_where(invalid_gt)
+        checks["gt_examples"] = hl.agg.filter(
+            invalid_gt,
+            hl.agg.take(hl.struct(locus=vd.locus, alleles=vd.alleles, GT=vd.GT), 3),
+        )
+    if has_ad:
+        invalid_ad = hl.is_defined(vd.AD) & (hl.len(vd.AD) != hl.len(vd.alleles))
+        checks["n_invalid_ad"] = hl.agg.count_where(invalid_ad)
+        checks["ad_examples"] = hl.agg.filter(
+            invalid_ad,
+            hl.agg.take(hl.struct(locus=vd.locus, alleles=vd.alleles, AD=vd.AD), 3),
+        )
+
+    audit = vd.aggregate_entries(hl.struct(**checks))
+
+    n_gt = audit.n_invalid_gt if has_gt else 0
+    n_ad = audit.n_invalid_ad if has_ad else 0
+
+    if n_gt == 0 and n_ad == 0:
         logging.info("✓ All entries valid (GT indices and AD lengths correct)")
+        return
+
+    if n_gt > 0:
+        logging.warning(
+            f"Found {n_gt} entries with out-of-bounds GT indices; they will be set to missing. "
+            f"Examples: {audit.gt_examples}"
+        )
+    if n_ad > 0:
+        # Reported only -- an AD of the wrong length is a caller/pipeline bug upstream, and
+        # silently rewriting depths would hide it.
+        logging.warning(
+            f"Found {n_ad} entries with AD length mismatch. Examples: {audit.ad_examples}"
+        )
+
+
+def _apply_biallelic_gt_fix(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """Set out-of-bounds genotypes to missing, as a LAZY expression on the dense matrix.
+
+    Applied unconditionally, and that is the crux of the fix. The previous version gated this on
+    `if n_invalid_gt > 0`, and *reading* that count is an eager action: it forced Hail to execute
+    the whole densify plan a first time, purely to decide whether to add an annotation. Expressed
+    unconditionally, the repair instead folds into the single pass that writes the MatrixTable.
+
+    On clean data -- which is what a VDS-level split is supposed to guarantee -- this is the
+    identity: `hl.if_else(False, missing, GT)` is `GT`, so the written entries are unchanged.
+
+    It stays on the DENSE matrix on purpose: correctness of the output must not depend on the
+    reference-block invariants that make the sparse audit sound.
+    """
+    if "GT" not in mt.entry:
         return mt
 
-    # Log issues found
-    if validation.n_invalid_gt > 0:
-        logging.warning(
-            f"Found {validation.n_invalid_gt} entries with out-of-bounds GT indices. "
-            f"Examples: {validation.gt_examples}"
-        )
-
-    if validation.n_invalid_ad > 0:
-        logging.warning(
-            f"Found {validation.n_invalid_ad} entries with AD length mismatch. "
-            f"Examples: {validation.ad_examples}"
-        )
-
-    # Fix invalid GTs (set to missing)
-    if validation.n_invalid_gt > 0:
-        logging.info("Setting invalid genotypes to missing…")
-        mt = mt.annotate_entries(
-            GT=hl.if_else(
-                hl.is_defined(mt.GT)
-                & hl.any(
-                    lambda i: mt.GT[i] >= hl.len(mt.alleles), hl.range(0, mt.GT.ploidy)
-                ),
-                hl.missing(hl.tcall),
-                mt.GT,
-            )
-        )
-
-    return mt
+    return mt.annotate_entries(
+        GT=hl.if_else(_gt_out_of_bounds(mt), hl.missing(hl.tcall), mt.GT)
+    )
 
 
 @algorithm(name="convert_vds_to_mt", backends=[Backend.HAIL])
@@ -137,17 +165,18 @@ def convert_vds_to_mt(
 
     This function:
     1. Splits multi-allelic variants at VDS level (recommended for VDS data)
-    2. Densifies to MatrixTable
-    3. Validates biallelic entries (optional, for safety)
-    4. Annotates adjusted genotypes (optional, requires gnomad)
-    5. Keys by sample and writes to disk
+    2. Audits biallelic entries on the sparse variant data (optional, for safety)
+    3. Densifies to MatrixTable
+    4. Repairs out-of-bounds genotypes (lazily, fused into the write)
+    5. Annotates adjusted genotypes (optional, requires gnomad)
+    6. Keys by sample and writes to disk
 
     Parameters:
         vds_path: Path to the input VDS
         output_path: Path where the output MatrixTable will be written
         adjust_genotypes: If True, annotate with adjusted genotypes (requires gnomad)
         skip_split_multi: If True, skip splitting multi-allelic variants
-        skip_validation: If True, skip biallelic validation (faster, use only if confident)
+        skip_validation: If True, skip both the biallelic audit and the repair
         skip_keying_by_cols: If True, skip keying the MatrixTable by columns
         overwrite: Whether to overwrite the output if it already exists
 
@@ -156,8 +185,11 @@ def convert_vds_to_mt(
 
     Notes:
         - VDS-level splitting is critical for correct GT/AD/PL alignment
-        - Validation can be skipped for trusted pipelines to improve performance
         - After VDS split, GT/AD are already biallelic (no manual downcoding needed)
+        - The densify is executed EXACTLY ONCE, by the final write. Hail is lazy and does not
+          cache, so any eager action on the dense MatrixTable (an aggregate, a count) would
+          re-execute the densify from the top. The audit therefore runs on the sparse variant data
+          and the repair is expressed lazily; see `_audit_split_variant_data`.
         - This algorithm operates on raw `hl.MatrixTable` / `hl.VariantDataset` instances
           (genotype data). ExpressionMatrix's hail-mt backend isn't available yet (Phase J).
     """
@@ -174,14 +206,24 @@ def convert_vds_to_mt(
         vds = hl.vds.read_vds(vds_path)
         vds = _split_vds(vds, skip_split=skip_split_multi)
 
-        # Step 2: Densify to MatrixTable
+        # Step 2: Audit the SPARSE variant data, before densifying. Every eager action on the
+        # dense MatrixTable re-runs the densify from scratch (Hail is lazy and does not cache), so
+        # a validation aggregate there would double the cost of this whole stage.
+        if skip_validation:
+            logging.info("Skipping biallelic audit (skip_validation=True)")
+        else:
+            _audit_split_variant_data(vds)
+
+        # Step 3: Densify to MatrixTable
         logging.info("Converting VDS to dense MatrixTable…")
         mt = hl.vds.to_dense_mt(vds)
 
-        # Step 3: Validate biallelic entries (optional, can skip for performance)
-        mt = _validate_and_fix_biallelic_entries(mt, skip_validation=skip_validation)
+        # Step 4: Repair out-of-bounds genotypes. A lazy expression: it costs no extra pass,
+        # it fuses into the write below, and on clean data it is the identity.
+        if not skip_validation:
+            mt = _apply_biallelic_gt_fix(mt)
 
-        # Step 4: Annotate adjusted genotypes (optional, requires gnomad)
+        # Step 5: Annotate adjusted genotypes (optional, requires gnomad)
         if adjust_genotypes:
             logging.info("Annotating MatrixTable with adjusted genotypes...")
             required_fields = {"GQ", "DP", "AD", "GT"}
@@ -196,12 +238,12 @@ def convert_vds_to_mt(
                 mt = annotate_adj(mt)
                 logging.info("Adjusted genotype annotation completed.")
 
-        # Step 5: Key by sample (optional)
+        # Step 6: Key by sample (optional)
         if not skip_keying_by_cols:
             logging.info("Keying MatrixTable by sample column 's'...")
             mt = mt.key_cols_by(mt["s"])
 
-        # Step 6: Write output
+        # Step 7: Write output -- the ONLY action that executes the densify
         logging.info(f"Writing MatrixTable to {output_path}...")
         mt.write(output_path, overwrite=overwrite)
         logging.info("✓ MatrixTable successfully written.")

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -71,6 +71,11 @@ class PipelineConfig:
     skip_compute_variant_qc: bool = False
     skip_export_pvcf: bool = False
 
+    # Skip the biallelic audit + repair in the VDS -> MT stage. `hvantk hgc vds2mt` has exposed
+    # this since forever; the pipeline hard-coded False, so users of the *recommended* entry point
+    # could not opt out at all.
+    skip_validation: bool = False
+
     # Path overrides (for resuming from intermediate stages)
     vds_path: Optional[str] = None
     mt_path: Optional[str] = None
@@ -460,7 +465,7 @@ class PipelineRunner:
             output_path=self.paths["mt"],
             adjust_genotypes=True,
             skip_split_multi=False,
-            skip_validation=False,
+            skip_validation=self.config.skip_validation,
             skip_keying_by_cols=False,
             overwrite=self.config.overwrite,
         )

--- a/hvantk/algorithms/hgc/qc.py
+++ b/hvantk/algorithms/hgc/qc.py
@@ -521,20 +521,10 @@ def compute_sample_qc(
             mt, call_field=call_field, prefer_lpgT=True, tmp_field=tmp_field
         )
 
-        # Preflight: count invalid GT if any slipped through
-        invalid_count = mt_qc.aggregate_entries(
-            hl.agg.count_where(
-                hl.is_defined(mt_qc[tmp_field])
-                & hl.any(
-                    lambda i: mt_qc[tmp_field][i] >= hl.len(mt_qc.alleles),
-                    hl.range(0, mt_qc[tmp_field].ploidy),
-                )
-            )
-        )
-        if invalid_count:
-            logger.warning(
-                f"Preflight: found {invalid_count} invalid temp genotypes before sample_qc; they will be set missing"
-            )
+        # NB: no preflight count here. `_prepare_qc_gt` sets `tmp_field` to MISSING wherever the
+        # call was out of bounds, so counting entries where `tmp_field` is *defined* and out of
+        # bounds is counting an empty intersection: the answer is 0 by construction and the
+        # warning was unreachable. It cost a full pass over the entry matrix to learn nothing.
 
         # Ensure compatibility: temporarily set GT to the sanitized tmp field
         mt_for_qc = _with_temp_gt(mt_qc, tmp_field=tmp_field, backup_field="__orig_GT")
@@ -616,20 +606,7 @@ def compute_variant_qc(
             mt, call_field=call_field, prefer_lpgT=True, tmp_field=tmp_field
         )
 
-        # Preflight logging as above
-        invalid_count = mt_qc.aggregate_entries(
-            hl.agg.count_where(
-                hl.is_defined(mt_qc[tmp_field])
-                & hl.any(
-                    lambda i: mt_qc[tmp_field][i] >= hl.len(mt_qc.alleles),
-                    hl.range(0, mt_qc[tmp_field].ploidy),
-                )
-            )
-        )
-        if invalid_count:
-            logger.warning(
-                f"Preflight: found {invalid_count} invalid temp genotypes before variant_qc; they will be set missing"
-            )
+        # No preflight count -- see compute_sample_qc: the value is 0 by construction.
 
         mt_for_qc = _with_temp_gt(mt_qc, tmp_field=tmp_field, backup_field="__orig_GT")
         mt_with_qc = hl.variant_qc(mt_for_qc, name=name)

--- a/hvantk/tests/hgc/test_converters_single_pass.py
+++ b/hvantk/tests/hgc/test_converters_single_pass.py
@@ -1,0 +1,178 @@
+"""VDS -> MatrixTable conversion must densify exactly ONCE.
+
+Hail is lazy and does not cache. `to_dense_mt` builds a plan; every *eager* action on the
+resulting MatrixTable (an aggregate, a count, a write) re-executes that plan from the top --
+including the densify. `convert_vds_to_mt` used to issue two eager actions on the dense MT: an
+`aggregate_entries` to validate biallelic entries, and then the `write`. So it densified the whole
+cohort twice, and the validation pass cost ~42% of the stage's wall time on a 500-sample chr1
+callset.
+
+The fix moves the *audit* onto the sparse `variant_data` (where the defects can actually
+originate) and applies the *repair* as a lazy, unconditional expression that folds into the single
+write pass. These tests pin that: they count eager actions rather than measure time, so they run in
+the fast suite with Hail stubbed out entirely.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hvantk.algorithms.hgc.converters import convert_vds_to_mt
+
+
+class SpyMT:
+    """A stand-in MatrixTable that records the calls made against it.
+
+    Hail's MatrixTable methods are a mix of lazy (annotate_entries, key_cols_by -> return a new
+    MT) and eager (aggregate_entries, write -> execute the plan). We return `self` from the lazy
+    ones so a chain of them stays observable on one object, and record everything in order.
+    """
+
+    EAGER = {
+        "aggregate_entries",
+        "aggregate_rows",
+        "aggregate_cols",
+        "count",
+        "count_rows",
+        "write",
+    }
+
+    def __init__(
+        self, name, entry_fields=("GT", "AD", "GQ", "DP"), aggregate_result=None
+    ):
+        self.name = name
+        self.entry = dict.fromkeys(entry_fields)
+        self.calls = []
+        self.annotate_entries_kwargs = []
+        self._aggregate_result = aggregate_result
+
+    # -- lazy ops: record, return self so the chain stays on this spy --
+    def annotate_entries(self, **kwargs):
+        self.calls.append("annotate_entries")
+        self.annotate_entries_kwargs.append(set(kwargs))
+        return self
+
+    def key_cols_by(self, *_a, **_k):
+        self.calls.append("key_cols_by")
+        return self
+
+    # -- eager ops: these are the ones that force a densify --
+    def aggregate_entries(self, *_a, **_k):
+        self.calls.append("aggregate_entries")
+        return self._aggregate_result
+
+    def write(self, *_a, **_k):
+        self.calls.append("write")
+
+    def __getitem__(self, key):
+        return MagicMock(name=f"{self.name}[{key}]")
+
+    def __getattr__(self, item):
+        # locus / alleles / GT / AD ... -> opaque expression objects
+        return MagicMock(name=f"{self.name}.{item}")
+
+    @property
+    def n_eager(self):
+        return sum(1 for c in self.calls if c in self.EAGER)
+
+
+class SpyVDS:
+    def __init__(self, variant_data, reference_data=None):
+        self.variant_data = variant_data
+        self.reference_data = reference_data or SpyMT("reference_data")
+
+
+def _clean_audit():
+    """What the audit aggregate returns when the data is fine (the expected case)."""
+    return MagicMock(n_invalid_gt=0, gt_examples=[], n_invalid_ad=0, ad_examples=[])
+
+
+@pytest.fixture
+def spies():
+    """Patch converters.hl so no Hail/Spark is needed; hand back the two spy MTs."""
+    variant_data = SpyMT("variant_data", aggregate_result=_clean_audit())
+    dense = SpyMT("dense_mt", aggregate_result=_clean_audit())
+    vds = SpyVDS(variant_data)
+
+    with patch("hvantk.algorithms.hgc.converters.hl") as hl:
+        hl.vds.read_vds.return_value = vds
+        hl.vds.split_multi.return_value = vds
+        hl.vds.to_dense_mt.return_value = dense
+        # hl.if_else / hl.missing / hl.any ... just need to be inert expression builders
+        yield {"hl": hl, "vds": vds, "variant_data": variant_data, "dense": dense}
+
+
+def _run(**overrides):
+    kwargs = dict(
+        vds_path="/in.vds",
+        output_path="/out.mt",
+        adjust_genotypes=False,  # keep gnomad out of this test
+    )
+    kwargs.update(overrides)
+    convert_vds_to_mt(**kwargs)
+
+
+def test_dense_mt_is_materialized_exactly_once(spies):
+    """THE regression test: only the write may force the dense plan to execute.
+
+    Fails on the old code, which called aggregate_entries on the dense MT *and* wrote it -> two
+    eager actions -> two densifies.
+    """
+    _run()
+    dense = spies["dense"]
+
+    assert dense.calls.count("aggregate_entries") == 0, (
+        "the biallelic audit must not run on the dense MatrixTable -- an eager aggregate there "
+        f"forces a second full densify (calls seen: {dense.calls})"
+    )
+    assert dense.calls.count("write") == 1
+    assert (
+        dense.n_eager == 1
+    ), f"expected exactly one densify-forcing action, got {dense.calls}"
+
+
+def test_audit_runs_on_sparse_variant_data(spies):
+    """The audit must move to variant_data -- that is the whole point of the fix."""
+    _run()
+    assert spies["variant_data"].calls.count("aggregate_entries") == 1
+
+
+def test_gt_repair_is_applied_unconditionally_even_when_audit_is_clean(spies):
+    """The repair must be a lazy expression, not gated on a Python-visible count.
+
+    Gating it on `if n_invalid_gt > 0` is precisely what forced the second densify: reading that
+    count is an eager action. So the repair has to be applied always -- on clean data it is the
+    identity (`if_else(False, missing, GT) == GT`).
+    """
+    _run()
+    dense = spies["dense"]
+
+    gt_annotations = [kw for kw in dense.annotate_entries_kwargs if kw == {"GT"}]
+    assert len(gt_annotations) == 1, (
+        "expected exactly one lazy GT-repair annotate_entries on the dense MT, got "
+        f"{dense.annotate_entries_kwargs}"
+    )
+    assert dense.calls.index("annotate_entries") < dense.calls.index("write")
+
+
+def test_skip_validation_skips_both_audit_and_repair(spies):
+    """skip_validation=True keeps its documented meaning: no audit, no repair."""
+    _run(skip_validation=True)
+
+    assert spies["variant_data"].calls.count("aggregate_entries") == 0
+    assert {"GT"} not in spies["dense"].annotate_entries_kwargs
+    assert spies["dense"].calls.count("write") == 1
+
+
+def test_audit_tolerates_unsplit_variant_data(spies):
+    """With skip_split_multi=True the entries are LGT/LAD, not GT/AD.
+
+    The old validator dereferenced mt.GT / mt.AD unconditionally and blew up on this path. The
+    audit must degrade to a warning instead of raising.
+    """
+    spies["variant_data"].entry = dict.fromkeys(("LGT", "LAD", "LA"))
+    spies["dense"].entry = dict.fromkeys(("LGT", "LAD", "LA"))
+
+    _run(skip_split_multi=True)  # must not raise
+
+    assert spies["dense"].calls.count("write") == 1

--- a/hvantk/tests/hgc/test_qc_no_preflight.py
+++ b/hvantk/tests/hgc/test_qc_no_preflight.py
@@ -1,0 +1,69 @@
+"""The QC preflight aggregates were provably-zero counts, and must not come back.
+
+`_prepare_qc_gt` writes a SANITIZED call into `__qc_gt`:
+
+    invalid_gt = hl.is_defined(base_gt) & hl.any(lambda i: base_gt[i] >= hl.len(mt.alleles), ...)
+    qc_gt      = hl.if_else(invalid_gt, hl.missing(hl.tcall), base_gt)
+
+so `__qc_gt` is MISSING exactly where the genotype was invalid. compute_sample_qc and
+compute_variant_qc then each ran a full `aggregate_entries` counting entries where `__qc_gt`
+IS DEFINED *and* is invalid. That intersection is empty by construction: the count is the constant
+0 and the `if invalid_count:` warning branch is unreachable.
+
+Each of those aggregates was a full pass over the entry matrix (a 12 GiB MatrixTable on the
+benchmark cohort) to compute a number that could not be anything but zero. These tests assert the
+QC functions perform no eager entry aggregation at all.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hvantk.algorithms.hgc.qc import compute_sample_qc, compute_variant_qc
+
+
+class SpyMT:
+    """MatrixTable stand-in that records eager aggregations. Lazy ops return self."""
+
+    def __init__(self):
+        self.entry = dict.fromkeys(("GT", "AD", "GQ", "DP"))
+        self.row = dict.fromkeys(("locus", "alleles"))
+        self.calls = []
+
+    def annotate_entries(self, **_kwargs):
+        self.calls.append("annotate_entries")
+        return self
+
+    def drop(self, *_a):
+        self.calls.append("drop")
+        return self
+
+    def aggregate_entries(self, *_a, **_k):
+        self.calls.append("aggregate_entries")
+        return 0
+
+    def __getitem__(self, key):
+        return MagicMock(name=f"mt[{key}]")
+
+    def __getattr__(self, item):
+        return MagicMock(name=f"mt.{item}")
+
+
+@pytest.fixture
+def spy_mt():
+    mt = SpyMT()
+    with patch("hvantk.algorithms.hgc.qc.hl") as hl:
+        hl.sample_qc.side_effect = lambda m, **_k: m
+        hl.variant_qc.side_effect = lambda m, **_k: m
+        yield mt
+
+
+@pytest.mark.parametrize("qc_fn", [compute_sample_qc, compute_variant_qc])
+def test_qc_does_not_aggregate_entries(spy_mt, qc_fn):
+    """No full entry scan may be issued just to compute a number that is always 0."""
+    qc_fn(spy_mt)
+
+    assert spy_mt.calls.count("aggregate_entries") == 0, (
+        f"{qc_fn.__name__} issued a full entry aggregation; the preflight count it replaced was "
+        f"tautologically zero (calls seen: {spy_mt.calls})"
+    )

--- a/hvantk/tools/hgc/pipeline_cli.py
+++ b/hvantk/tools/hgc/pipeline_cli.py
@@ -61,6 +61,16 @@ def register_pipeline_command(group):
     default=False,
     help="Skip exporting the cohort (project) VCF",
 )
+@click.option(
+    "--skip-validation",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip the biallelic audit and genotype repair during VDS -> MatrixTable conversion. "
+        "The audit runs on the sparse variant data and is cheap; skip it only for a trusted, "
+        "already-validated VDS."
+    ),
+)
 # Path overrides
 @click.option(
     "--vds-path",
@@ -147,6 +157,7 @@ def pipeline(
     skip_compute_sample_qc,
     skip_compute_variant_qc,
     skip_export_pvcf,
+    skip_validation,
     vds_path,
     mt_path,
     tmp_dir,
@@ -207,6 +218,7 @@ def pipeline(
             skip_compute_sample_qc=skip_compute_sample_qc,
             skip_compute_variant_qc=skip_compute_variant_qc,
             skip_export_pvcf=skip_export_pvcf,
+            skip_validation=skip_validation,
             vds_path=vds_path,
             mt_path=mt_path,
             min_sample_call_rate=min_sample_call_rate,


### PR DESCRIPTION
## What

Two places in HGC paid for a full pass over the data and got nothing for it. Hail is lazy and **does not cache**, so every *eager* action on a densified MatrixTable (an aggregate, a count, a write) re-executes the densify from the top.

### 1. `vds2mt` densified the cohort twice

`convert_vds_to_mt` issued **two** eager actions on the dense MT: an `aggregate_entries` to validate biallelic entries, then the `write`. Measured on a 500-sample chr1 callset at 16 cores, the validation cost **373.8 s of the stage's 891.8 s (~42%)** — and the Hail stage ledger showed two identical `table_scan_write_prefix_sums` stages, confirming the double densify.

**The check is not dropped — it is moved.** Neither defect it looks for can originate in a reference block:

- `to_dense_mt` gives reference-derived entries a hom-ref call — it injects `hl.call(0, 0)`, or reuses a call the VDS combiner already forced hom-ref via `.or_error('found reference block with non reference-genotype at' …)`.
- it fills every variant-only field — **including `AD`** — with `hl.missing` on the reference side, so the `is_defined(AD)` guard can never fire there.

So both defects can only live in `variant_data`. The **audit** now runs on the sparse `variant_data` before densification; the **repair** is applied on the dense matrix as a lazy, *unconditional* expression that fuses into the single write pass (on clean data it is the identity).

The repair deliberately stays on the **dense** side: correctness of the output must not depend on the reference-block invariants that make the sparse audit sound.

> Verified against the installed Hail 0.2.137 source: `hail/vds/methods.py` (`to_dense_mt`), `hail/vds/combiner/combine.py` (`make_ref_entry_struct`).

Gating the repair behind `if n_invalid > 0` looks harmless but is the entire bug: *reading* that count is an eager action.

### 2. The QC preflight counts were provably zero

`compute_sample_qc` and `compute_variant_qc` each ran a full `aggregate_entries` counting entries where `__qc_gt` **is defined** *and* is out of bounds. But `_prepare_qc_gt` sets `__qc_gt` to **missing** exactly where the call is out of bounds — so that intersection is empty **by construction**. The count could only ever be `0`, and the `if invalid_count:` warning was unreachable.

Two full passes over a 12 GiB MatrixTable to compute the constant zero.

## Also fixed

- **`pipeline.py` hard-coded `skip_validation=False`.** Users of the *recommended* entry point (`hvantk hgc pipeline`) could not opt out at all, while `hvantk hgc vds2mt` has always exposed the flag. Now on `PipelineConfig` and the CLI.
- **`skip_split_multi=True` used to crash.** The validator dereferenced `mt.GT`/`mt.AD` unconditionally, but skipping the split leaves `LGT`/`LAD` in place. The audit now guards on field presence and degrades to a warning.
- **Docs advertised a `convert_lgt_to_gt` parameter that does not exist** on `convert_vds_to_mt` — copy-pasting the documented example raised `TypeError`. Purged (5 sites).

## Semantics

**Output entries are unchanged in every case, including the pathological ones.** On clean data `hl.if_else(False, missing, GT)` is `GT`. On dirty data the repair is the same expression as before and still runs on the dense matrix, so an out-of-bounds genotype is still set to missing. `annotate_adj` still sees the repaired `GT`.

One honest caveat: the *reported counts* now come from `variant_data`. For any combiner-built VDS (the only kind hvantk produces) they are provably identical. A hand-assembled VDS with a non-hom-ref reference block could be repaired-but-not-counted — a log-completeness gap, not a data change. Documented in the docstring.

## Tests

New fast tests (Hail stubbed out entirely — they **count eager actions** rather than measure time, so they run in the default suite):

- `test_dense_mt_is_materialized_exactly_once` — **fails on the old code**
- `test_audit_runs_on_sparse_variant_data`
- `test_gt_repair_is_applied_unconditionally_even_when_audit_is_clean` — stops anyone "optimizing" the repair back behind an `if`, which would silently restore the double densify
- `test_skip_validation_skips_both_audit_and_repair`
- `test_audit_tolerates_unsplit_variant_data` — regression guard for the `skip_split_multi` crash
- `test_qc_does_not_aggregate_entries[compute_sample_qc|compute_variant_qc]` — **fail on the old code**

**79/79 HGC tests pass on a compute node with Java 11**, including the `hail`-marked ones. `flake8 (E9,F63,F7,F82)`: 0. Black-clean on the changed regions (the pre-existing Black drift in `qc.py`'s import block is left alone to keep the diff reviewable).

## Note for reviewers

This changes the wall-clock of `vds2mt` and `qc`, so the HGC scaling benchmark must be **re-run across all cluster sizes** — the numbers should not be spliced into the existing curve. Expected: `vds2mt` ~891.8 s → ~530–580 s and `qc` 451.4 s → ~306 s at 16 cores. The acceptance criterion is structural, not temporal: the Hail stage ledger should show **exactly one** `table_scan_write_prefix_sums` instead of two.

Independent of #203, though both touch `pipeline.py`.