### PR TITLE
fix(ucsc-cellbrowser): build from raw dir so reprocess works end-to-end

### DIFF
--- a/hvantk/skills/ucsc_cellbrowser/builder.py
+++ b/hvantk/skills/ucsc_cellbrowser/builder.py
@@ -34,6 +34,53 @@ _SCHEMA_IDS: dict[str, str] = {
 }
 
 
+def _resolve_ucsc_inputs(parsed_input):
+    """Normalise the builder input into ``(expression_matrix_path, metadata_path)``.
+
+    Accepts either:
+
+    * a mapping with ``expression_matrix`` / ``metadata`` keys (direct Phase B callers), or
+    * a path to the raw download directory. This is the ``hvantk reprocess`` contract:
+      the dataset declares no ``lifecycle.parse`` stage, so reprocess passes the raw dir
+      to the builder ("no parse stage declared: the builder consumes the raw dir
+      directly", ``reprocess_cli``). The downloader writes files under a per-accession
+      subdirectory, so we search the given directory and one level of subdirectories.
+    """
+    if isinstance(parsed_input, dict):
+        return str(parsed_input["expression_matrix"]), str(parsed_input["metadata"])
+
+    from hvantk.skills.ucsc_cellbrowser.shared.constants import (
+        EXPRESSION_MATRIX_FILE_NAME,
+        METADATA_FILE_NAME,
+    )
+
+    root = str(parsed_input)
+    expr_names = (EXPRESSION_MATRIX_FILE_NAME, "expression_matrix.tsv")
+    meta_names = (METADATA_FILE_NAME, "metadata.tsv")
+    search_dirs = [root] + [
+        os.path.join(root, d)
+        for d in sorted(os.listdir(root))
+        if os.path.isdir(os.path.join(root, d))
+    ]
+
+    def _find(names):
+        for directory in search_dirs:
+            for name in names:
+                candidate = os.path.join(directory, name)
+                if os.path.exists(candidate):
+                    return candidate
+        return None
+
+    expr = _find(expr_names)
+    meta = _find(meta_names)
+    if expr is None or meta is None:
+        raise FileNotFoundError(
+            f"UCSC builder: could not locate an expression matrix {expr_names} and "
+            f"metadata {meta_names} under {root!r} (searched {search_dirs})"
+        )
+    return expr, meta
+
+
 def build_ucsc_cellbrowser(
     parsed_input,
     ctx,
@@ -49,7 +96,9 @@ def build_ucsc_cellbrowser(
 ):
     """Phase B builder — returns an ExpressionMatrix.
 
-    ``parsed_input`` must contain keys ``expression_matrix`` and ``metadata``.
+    ``parsed_input`` is either a mapping with ``expression_matrix`` / ``metadata``
+    keys, or a path to the raw download directory (the ``hvantk reprocess`` contract
+    for a parse-less dataset); see ``_resolve_ucsc_inputs``.
     The per-dataset ``schema_id`` is resolved from ``ctx.dataset`` via
     ``_SCHEMA_IDS`` so that all three datasets (default, adult-ctx, dev-ctx)
     share one builder function while each stamps the correct schema.
@@ -77,8 +126,7 @@ def build_ucsc_cellbrowser(
         load_ucsc_metadata,
     )
 
-    expression_matrix_path = str(parsed_input["expression_matrix"])
-    metadata_path = str(parsed_input["metadata"])
+    expression_matrix_path, metadata_path = _resolve_ucsc_inputs(parsed_input)
 
     logger.info("Loading UCSC metadata from %s", metadata_path)
     metadata_df = load_ucsc_metadata(metadata_path, sep=delimiter)

--- a/hvantk/skills/ucsc_cellbrowser/tests/test_builder_input_resolution.py
+++ b/hvantk/skills/ucsc_cellbrowser/tests/test_builder_input_resolution.py
@@ -1,0 +1,51 @@
+"""Regression tests for ``_resolve_ucsc_inputs``.
+
+The builder accepts EITHER a mapping with ``expression_matrix`` / ``metadata`` keys
+(direct Phase B callers) OR a path to the raw download directory -- the ``hvantk
+reprocess`` contract for a dataset with no ``lifecycle.parse`` stage, where reprocess
+passes the raw dir straight to the builder. Before the fix, ``ucsc-cellbrowser:default``
+crashed end-to-end because the builder assumed a dict. These are self-contained (no
+network, no snapshots) so they run without the plugin's snapshot-test harness.
+"""
+import pytest
+
+from hvantk.skills.ucsc_cellbrowser.builder import _resolve_ucsc_inputs
+from hvantk.skills.ucsc_cellbrowser.shared.constants import (
+    EXPRESSION_MATRIX_FILE_NAME,
+    METADATA_FILE_NAME,
+)
+
+
+def test_dict_input_passthrough():
+    """Direct callers keep working unchanged."""
+    out = _resolve_ucsc_inputs(
+        {"expression_matrix": "x/exprMatrix.tsv.gz", "metadata": "x/meta.tsv"}
+    )
+    assert out == ("x/exprMatrix.tsv.gz", "x/meta.tsv")
+
+
+def test_raw_dir_with_accession_subdir(tmp_path):
+    """reprocess passes raw_dir; the downloader nests files under <accession>/."""
+    acc = tmp_path / "some-accession"
+    acc.mkdir()
+    expr = acc / EXPRESSION_MATRIX_FILE_NAME
+    meta = acc / METADATA_FILE_NAME
+    expr.write_text("gene\tcell1\n")
+    meta.write_text("cell\ttype\n")
+    e, m = _resolve_ucsc_inputs(str(tmp_path))
+    assert e == str(expr)
+    assert m == str(meta)
+
+
+def test_raw_dir_flat(tmp_path):
+    """Files placed directly in the raw dir (e.g. test fixtures) also resolve."""
+    (tmp_path / "expression_matrix.tsv").write_text("gene\tcell1\n")
+    (tmp_path / "metadata.tsv").write_text("cell\ttype\n")
+    e, m = _resolve_ucsc_inputs(str(tmp_path))
+    assert e.endswith("expression_matrix.tsv")
+    assert m.endswith("metadata.tsv")
+
+
+def test_missing_files_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        _resolve_ucsc_inputs(str(tmp_path))


### PR DESCRIPTION
## Problem

`hvantk reprocess ucsc-cellbrowser:default --plugin-arg dataset=<accession>` was broken
end-to-end. The `default` dataset declares only `lifecycle.download` (no `parse`), so per
the reprocess contract — *"no parse stage declared: the builder consumes the raw dir
directly"* (`reprocess_cli.py`) — the builder is handed the **raw-dir path**. But
`build_ucsc_cellbrowser` assumed a dict `{expression_matrix, metadata}` and crashed:

```
File ".../ucsc_cellbrowser/builder.py", line 80, in build_ucsc_cellbrowser
    expression_matrix_path = str(parsed_input["expression_matrix"])
TypeError: string indices must be integers
```

So no repository dataset could be built through `reprocess`.

## Fix

`_resolve_ucsc_inputs` normalizes the builder input to
`(expression_matrix_path, metadata_path)`, accepting **either**:

- a mapping with `expression_matrix` / `metadata` keys (direct Phase B callers — unchanged), or
- the raw-dir path, locating the matrix + metadata under the per-accession subdirectory
  the downloader writes.

No `plugin.yaml` change; backward-compatible.

## Verification

- End-to-end: `hvantk reprocess ucsc-cellbrowser:default --plugin-arg dataset=adultPancreas`
  now runs download → build → drift, `rc=0` (82 MB artifact + provenance sidecar written).
- Also built `chi-10x-mouse-cardiomyocytes` (9,072 cells) the same way.
- New self-contained regression tests (`test_builder_input_resolution.py`) cover the dict,
  nested-subdir, flat, and missing-file cases (no network / snapshot harness needed).

## Follow-ups (found while testing; intentionally NOT fixed here)

1. **Nested-accession downloads 404.** `download_dataset` builds
   `https://cells.ucsc.edu/{accession}/exprMatrix.tsv.gz` directly, so only accessions that
   are valid *top-level* UCSC paths resolve; collection-nested accessions (e.g.
   `heart-cell-atlas`, `cardiogenesis-atac`) 404. Resolving them needs a UCSC collection-tree
   lookup — a feature-add, deferred.
2. **`source_fingerprint` is catalog-level, not per-accession.** The drift probe (zero-arg by
   manifest contract) fingerprints the UCSC *root catalog*, so two different datasets built at
   the same catalog state get identical `source_fingerprint`s — provenance can't distinguish
   which accession's content produced an artifact. Fixing this touches the drift-probe contract
   (platform-level), deferred.

## Note

The plugin's committed snapshot tests can't run in this environment (missing `requests_mock`;
a `--regenerate-snapshots` pytest option that isn't registering) — both pre-existing and
unrelated to this change. Validated behaviorally (end-to-end reprocess) and via the new unit
tests instead.
