### PR TITLE
feat(annotate): P1 foundation — Ensembl release pin, gene structure dataset, identifier mapper, gene spine

### DIFF
--- a/hvantk/algorithms/annotation/mapping.py
+++ b/hvantk/algorithms/annotation/mapping.py
@@ -1,0 +1,128 @@
+"""Identifier reconciliation onto the gene spine.
+
+Every annotation source arrives keyed on something other than the spine's ``gene_id``:
+HGNC IDs (ClinGen, GenCC), gene symbols (expression atlases), or genomic coordinates.
+Reconciliation happens here and nowhere else, and it always produces a
+:class:`MappingReport` so loss is measured rather than silent.
+
+The failure this exists to prevent: the previous per-gene matrix merged on raw symbols
+with no alias resolution, so every previous-symbol or alias mismatch dropped a gene and
+nothing reported it.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_NAMED_UNMAPPED = 20
+
+
+class MappingRateError(Exception):
+    """A source mapped below its declared minimum rate."""
+
+
+@dataclass(frozen=True)
+class MappingReport:
+    """How much of a source reached the spine, and what did not."""
+
+    source: str
+    key_type: str
+    n_in: int
+    n_mapped: int
+    n_unmapped: int
+    n_ambiguous: int
+    unmapped: tuple[str, ...]
+
+    @property
+    def rate(self) -> float:
+        """Mapped fraction. An empty input maps completely, vacuously."""
+        return self.n_mapped / self.n_in if self.n_in else 1.0
+
+    def summary(self) -> str:
+        return (
+            f"{self.source} [{self.key_type}]: {self.n_mapped}/{self.n_in} mapped "
+            f"({self.rate:.2%}), {self.n_unmapped} unmapped, "
+            f"{self.n_ambiguous} ambiguous"
+        )
+
+
+def enforce_rate(report: MappingReport, min_rate: float) -> None:
+    """Raise if ``report`` fell below ``min_rate``.
+
+    A source that maps poorly must fail loudly. Contributing a column of NaNs instead is
+    how mapping bugs become invisible model degradation.
+    """
+    if report.rate < min_rate:
+        examples = ", ".join(report.unmapped[:10])
+        raise MappingRateError(
+            f"{report.source} mapped {report.rate:.2f} of its identifiers, below the "
+            f"required {min_rate:.2f}. Unmapped examples: {examples}"
+        )
+
+
+class GeneIdMapper:
+    """Map source identifiers onto spine ``gene_id`` values.
+
+    Parameters
+    ----------
+    hgnc : HGNCGeneCatalogStreamer
+        Built from the ``hgnc:lookup`` artifact.
+    spine_gene_ids : set of str
+        The spine's ``gene_id`` values. An identifier that resolves to an Ensembl ID
+        outside the spine counts as unmapped, not mapped -- otherwise a join would
+        silently drop it later, which is the loss this class exists to surface.
+    """
+
+    def __init__(self, hgnc, spine_gene_ids: Iterable[str]) -> None:
+        self._hgnc = hgnc
+        self._spine = set(spine_gene_ids)
+
+    def from_hgnc_ids(
+        self, hgnc_ids: Iterable[str], *, source: str
+    ) -> tuple[dict[str, Optional[str]], MappingReport]:
+        ids = list(hgnc_ids)
+        to_ensembl = self._hgnc.map_from_hgnc(ids, "ensembl_gene_id")
+        mapping = {i: self._keep_if_on_spine(to_ensembl.get(i)) for i in ids}
+        return mapping, self._report(source, "hgnc_id", mapping)
+
+    def from_symbols(
+        self, symbols: Iterable[str], *, source: str
+    ) -> tuple[dict[str, Optional[str]], MappingReport]:
+        syms = list(symbols)
+        canonical = {s: self._hgnc.resolve_to_canonical(s) for s in syms}
+        to_hgnc = self._hgnc.map_to_hgnc(
+            sorted({c for c in canonical.values() if c}), "gene_symbol"
+        )
+        hgnc_ids = sorted({h for h in to_hgnc.values() if h})
+        to_ensembl = self._hgnc.map_from_hgnc(hgnc_ids, "ensembl_gene_id")
+
+        mapping: dict[str, Optional[str]] = {}
+        for sym in syms:
+            hgnc_id = to_hgnc.get(canonical.get(sym))
+            gene_id = to_ensembl.get(hgnc_id) if hgnc_id else None
+            mapping[sym] = self._keep_if_on_spine(gene_id)
+        return mapping, self._report(source, "symbol", mapping)
+
+    def _keep_if_on_spine(self, gene_id: Optional[str]) -> Optional[str]:
+        return gene_id if gene_id in self._spine else None
+
+    def _report(
+        self, source: str, key_type: str, mapping: dict[str, Optional[str]]
+    ) -> MappingReport:
+        unmapped = tuple(sorted(k for k, v in mapping.items() if v is None))
+        targets = [v for v in mapping.values() if v is not None]
+        n_ambiguous = len(targets) - len(set(targets))
+        report = MappingReport(
+            source=source,
+            key_type=key_type,
+            n_in=len(mapping),
+            n_mapped=len(targets),
+            n_unmapped=len(unmapped),
+            n_ambiguous=n_ambiguous,
+            unmapped=unmapped[:MAX_NAMED_UNMAPPED],
+        )
+        logger.info(report.summary())
+        return report

--- a/hvantk/algorithms/annotation/spine.py
+++ b/hvantk/algorithms/annotation/spine.py
@@ -1,0 +1,116 @@
+"""The gene spine -- the single table every annotation joins onto.
+
+One row per protein-coding gene, keyed on Ensembl ``gene_id``, carrying the identifiers
+and structural covariates that later stages need. Identifier reconciliation happens here
+and nowhere else, so a downstream source only ever has to map onto ``gene_id``.
+
+``hgnc_id`` is a LEFT join on purpose: a protein-coding Ensembl gene with no HGNC record
+must stay in the spine with a missing ``hgnc_id``, not vanish. Dropping it would make the
+universe depend on HGNC's coverage, which is the class of silent loss this rebuild exists
+to remove.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+SPINE_FIELDS = [
+    "gene_name",
+    "chromosome",
+    "gene_start",
+    "gene_end",
+    "gene_biotype",
+    "cds_length",
+    "n_coding_exons",
+    "n_transcripts",
+    "mane_select",
+    "hgnc_id",
+    "gene_group",
+]
+
+
+def build_spine(genes_ht, structure_ht, hgnc_ht, *, biotype: str = "protein_coding"):
+    """Join Ensembl genes, GTF structure and HGNC into the gene spine.
+
+    Parameters
+    ----------
+    genes_ht : hail.Table
+        ``ensembl-gene:genes``, keyed on ``gene_id``.
+    structure_ht : hail.Table
+        ``ensembl-gene:structure``, keyed on ``gene_id``.
+    hgnc_ht : hail.Table
+        ``hgnc:lookup``, keyed on ``hgnc_id``, carrying ``ensembl_gene_id``.
+    biotype : str
+        Gene biotype to keep. Pass ``None`` to keep every biotype.
+
+    Returns
+    -------
+    hail.Table
+        Keyed on ``gene_id``, one row per gene, fields as in ``SPINE_FIELDS``.
+    """
+    import hail as hl
+
+    ht = genes_ht.join(structure_ht, how="inner")
+
+    if biotype is not None:
+        ht = ht.filter(ht.gene_biotype == biotype)
+
+    # Re-key HGNC by its Ensembl ID so the spine can left-join on gene_id. Rows with no
+    # Ensembl ID cannot participate and are dropped from the lookup, not from the spine.
+    hgnc_by_gene = hgnc_ht.filter(
+        hl.is_defined(hgnc_ht.ensembl_gene_id) & (hgnc_ht.ensembl_gene_id != "")
+    )
+
+    # HGNC can carry more than one record for the same Ensembl gene. Left-joining a
+    # non-unique right side would MULTIPLY spine rows -- and every feature joined on
+    # afterwards with them -- so collapse to one record per gene first. The lowest
+    # hgnc_id wins, which makes the pick deterministic across rebuilds rather than
+    # whichever row the engine happened to emit first.
+    hgnc_by_gene = hgnc_by_gene.group_by(
+        gene_id=hgnc_by_gene.ensembl_gene_id
+    ).aggregate(
+        _records=hl.sorted(
+            hl.agg.collect(
+                hl.struct(
+                    hgnc_id=hgnc_by_gene.hgnc_id,
+                    gene_group=hgnc_by_gene.gene_group,
+                )
+            ),
+            key=lambda r: r.hgnc_id,
+        )
+    )
+    hgnc_by_gene = hgnc_by_gene.select(
+        hgnc_id=hgnc_by_gene._records[0].hgnc_id,
+        gene_group=hgnc_by_gene._records[0].gene_group,
+    )
+
+    before = ht.count()
+    ht = ht.join(hgnc_by_gene, how="left")
+    after = ht.count()
+    if before != after:
+        raise ValueError(
+            f"HGNC join changed the row count ({before} -> {after}); the lookup is "
+            "not unique per gene_id"
+        )
+
+    ht = ht.select(*SPINE_FIELDS)
+
+    logger.info("Spine: %d genes (biotype=%s)", after, biotype)
+    return ht
+
+
+def spine_mapping_rate(spine_ht) -> float:
+    """Fraction of spine genes carrying an HGNC record.
+
+    Reported rather than enforced: a gene with no HGNC record is a real Ensembl gene, not
+    an error. The rate is a health signal for the identifier layer, and P2's per-source
+    gates are where mapping loss becomes fatal.
+    """
+    import hail as hl
+
+    total = spine_ht.count()
+    if total == 0:
+        return 1.0
+    mapped = spine_ht.aggregate(hl.agg.count_where(hl.is_defined(spine_ht.hgnc_id)))
+    return mapped / total

--- a/hvantk/algorithms/annotation/spine.py
+++ b/hvantk/algorithms/annotation/spine.py
@@ -80,6 +80,11 @@ def build_spine(genes_ht, structure_ht, hgnc_ht, *, biotype: str = "protein_codi
             key=lambda r: r.hgnc_id,
         )
     )
+    # Only hgnc_id and gene_group are pulled from HGNC. gene_group is array<str> upstream
+    # (a gene can be in several groups) and is carried through unreduced -- a downstream
+    # consumer sees the real shape rather than a lossy scalar. mane_select is taken from
+    # `structure` (a plain str), NOT from HGNC's own array<str> mane_select field, so this
+    # select must not start pulling HGNC's mane_select or it would collide with structure's.
     hgnc_by_gene = hgnc_by_gene.select(
         hgnc_id=hgnc_by_gene._records[0].hgnc_id,
         gene_group=hgnc_by_gene._records[0].gene_group,

--- a/hvantk/algorithms/ptm/constants.py
+++ b/hvantk/algorithms/ptm/constants.py
@@ -3,13 +3,13 @@
 Moved from hvantk/core/ptm_constants.py per issue #122 (clean-core principle).
 """
 
-# Ensembl GTF
-ENSEMBL_RELEASE = "113"
-ENSEMBL_GTF_URL = (
-    f"https://ftp.ensembl.org/pub/release-{ENSEMBL_RELEASE}"
-    f"/gtf/homo_sapiens/Homo_sapiens.GRCh38.{ENSEMBL_RELEASE}.gtf.gz"
+# Ensembl GTF -- release pinned once, in the ensembl-gene plugin. Re-exported here so
+# existing importers of hvantk.algorithms.ptm.constants keep working unchanged.
+from hvantk.resources.ensembl_release import (  # noqa: F401
+    ENSEMBL_GTF_FILENAME,
+    ENSEMBL_GTF_URL,
+    ENSEMBL_RELEASE,
 )
-ENSEMBL_GTF_FILENAME = f"Homo_sapiens.GRCh38.{ENSEMBL_RELEASE}.gtf.gz"
 
 # PTM type categories (UniProt MOD_RES description prefixes)
 PTM_TYPE_CATEGORIES = {

--- a/hvantk/hvantk.py
+++ b/hvantk/hvantk.py
@@ -20,6 +20,7 @@ from hvantk.tools.plugins.tools_cli import tools_group
 from hvantk.tools.plugins.drift_cli import drift_cmd
 from hvantk.tools.plugins.reprocess_cli import reprocess_cmd
 from hvantk.tools.rerank import rerank_cmd
+from hvantk.tools.annotation.annotate_cli import annotate_group
 
 # Main CLI entry point for the package (hvantk)
 
@@ -96,6 +97,7 @@ cli.add_command(tools_group)
 cli.add_command(drift_cmd)
 cli.add_command(reprocess_cmd)
 cli.add_command(rerank_cmd)
+cli.add_command(annotate_group)
 
 
 def main():

--- a/hvantk/resources/ensembl_release.py
+++ b/hvantk/resources/ensembl_release.py
@@ -1,0 +1,24 @@
+"""The single Ensembl release pin for the whole toolkit.
+
+Everything that reads Ensembl gene models -- the ``ensembl-gene`` plugin, the PTM
+coordinate mapper, and the gene spine -- imports the release from here. Two definitions
+that drift apart give different CDS lengths, different MANE Select assignments and
+different coordinates for the same gene, which is a silent correctness bug rather than a
+loud one.
+
+It lives in ``resources`` rather than in the plugin because the dependency rule is
+``tools -> skills -> algorithms -> core``, with ``resources`` as substrate alongside
+``core``. Both a skill (``ensembl_gene``) and an algorithm (``ptm``) consume this pin;
+putting it in the skill would make ``algorithms`` depend on ``skills`` and invert the
+rule.
+"""
+from __future__ import annotations
+
+ENSEMBL_RELEASE = "113"
+
+ENSEMBL_GTF_FILENAME = f"Homo_sapiens.GRCh38.{ENSEMBL_RELEASE}.gtf.gz"
+
+ENSEMBL_GTF_URL = (
+    f"https://ftp.ensembl.org/pub/release-{ENSEMBL_RELEASE}"
+    f"/gtf/homo_sapiens/{ENSEMBL_GTF_FILENAME}"
+)

--- a/hvantk/skills/ensembl_gene/catalog/datasets.json
+++ b/hvantk/skills/ensembl_gene/catalog/datasets.json
@@ -1,7 +1,7 @@
 [
   {
     "title": "Ensembl Gene Annotations",
-    "accession": "Ensembl_v110",
+    "accession": "Ensembl_v113",
     "description": "Comprehensive gene annotations from the Ensembl project including gene models, transcript isoforms, protein sequences, regulatory features, and comparative genomics data across species.",
     "pubmedid": "31691826",
     "data_source": "Ensembl",
@@ -27,14 +27,14 @@
     ],
     "files": [
       {
-        "path": "Homo_sapiens.GRCh38.110.gtf.gz",
+        "path": "Homo_sapiens.GRCh38.113.gtf.gz",
         "format": "gtf",
         "size_bytes": 800000000,
         "compression": "gzip",
         "description": "Complete gene annotations in GTF format"
       },
       {
-        "path": "Homo_sapiens.GRCh38.110.gff3.gz",
+        "path": "Homo_sapiens.GRCh38.113.gff3.gz",
         "format": "gff3",
         "size_bytes": 900000000,
         "compression": "gzip",

--- a/hvantk/skills/ensembl_gene/plugin.yaml
+++ b/hvantk/skills/ensembl_gene/plugin.yaml
@@ -32,3 +32,32 @@ datasets:
       schema_snapshot: tests/snapshots/schema.json
       row_snapshot: tests/snapshots/sample_rows.json
       drift_fingerprint: tests/drift_fingerprint.json
+
+  - name: structure
+    domain: mapping
+    backend: hail
+    artifact_type: AnnotationTable
+    schema_id: ensembl-gene-structure-v1
+    builder:
+      module: hvantk.skills.ensembl_gene.structure.builder
+      function: build_ensembl_gene_structure
+    drift_probe:
+      module: hvantk.skills.ensembl_gene.structure.drift_probe
+      function: fetch_fingerprint
+    lifecycle:
+      # No parse stage: the builder reads the downloaded GTF directly.
+      download:
+        module: hvantk.skills.ensembl_gene.structure.cli
+        function: download_dataset
+    skill: structure/SKILL.md
+    tests:
+      command: pytest hvantk/skills/ensembl_gene/structure/tests -m hail
+      fixture: structure/tests/testdata/raw/ensembl-structure
+      schema_snapshot: structure/tests/snapshots/schema.json
+      row_snapshot: structure/tests/snapshots/sample_rows.json
+      drift_fingerprint: structure/tests/drift_fingerprint.json
+
+cli:
+  - command: ensembl-structure-download
+    module: hvantk.skills.ensembl_gene.structure.cli
+    function: download_cmd

--- a/hvantk/skills/ensembl_gene/structure/SKILL.md
+++ b/hvantk/skills/ensembl_gene/structure/SKILL.md
@@ -1,0 +1,24 @@
+# ensembl-gene:structure
+
+Per-gene structural summary parsed from the pinned Ensembl GTF.
+
+**Key:** `gene_id` (Ensembl, version suffix stripped)
+
+| Column | Type | Meaning |
+|---|---|---|
+| `gene_id` | str | Ensembl gene ID, unversioned |
+| `gene_biotype` | str | e.g. `protein_coding`, `lncRNA` |
+| `mane_select` | str | MANE Select transcript ID, `""` if the gene has none |
+| `cds_transcript` | str | Representative coding transcript: MANE if present, else longest CDS |
+| `cds_length` | int | Summed CDS bp of `cds_transcript`; `0` for non-coding genes |
+| `n_coding_exons` | int | CDS feature count of `cds_transcript` |
+| `n_transcripts` | int | Distinct transcripts annotated for the gene |
+
+**Release pin:** `hvantk/resources/ensembl_release.py`. The same pin governs the
+PTM coordinate mapper, so both read one gene model.
+
+**Params:** `protein_coding_only` (bool, default `False`).
+
+**Why it exists:** `ensembl-gene:genes` carries coordinates only. CDS length is required
+to normalise PTM site density, and gene length mechanically confounds rare-variant burden
+counts, so it must be available as a nuisance covariate.

--- a/hvantk/skills/ensembl_gene/structure/builder.py
+++ b/hvantk/skills/ensembl_gene/structure/builder.py
@@ -9,10 +9,30 @@ burden counts, so it must be available as a nuisance covariate rather than omitt
 from __future__ import annotations
 
 import logging
+import os
+
+from hvantk.resources.ensembl_release import ENSEMBL_GTF_FILENAME
 
 logger = logging.getLogger(__name__)
 
 SCHEMA_ID = "ensembl-gene-structure-v1"
+
+
+def _resolve_gtf_path(parsed_input) -> str:
+    """Resolve the builder's input to the GTF file itself.
+
+    This dataset declares ``lifecycle.download`` but no ``lifecycle.parse``, so
+    ``hvantk reprocess`` hands the builder the raw *directory* (the download wrote the
+    GTF inside it), not the file. Sibling plugins survive this because ``hl.import_table``
+    tolerates a directory path; this builder reads the GTF with plain Python ``open()``,
+    which raises ``IsADirectoryError`` on a directory. So resolve a directory to the known
+    committed filename here. A path that already points at a file is returned unchanged,
+    which keeps the direct ``build(input_path=<file>)`` calls (tests, snapshots) working.
+    """
+    path = str(parsed_input)
+    if os.path.isdir(path):
+        return os.path.join(path, ENSEMBL_GTF_FILENAME)
+    return path
 
 
 def build_ensembl_gene_structure(parsed_input, ctx, **params):
@@ -37,7 +57,7 @@ def build_ensembl_gene_structure(parsed_input, ctx, **params):
     from hvantk.core.models import AnnotationTable
     from hvantk.skills.ensembl_gene.structure.parse import parse_gtf_structure
 
-    df = parse_gtf_structure(str(parsed_input))
+    df = parse_gtf_structure(_resolve_gtf_path(parsed_input))
 
     if params.get("protein_coding_only", False):
         df = df[df.gene_biotype == "protein_coding"].reset_index(drop=True)

--- a/hvantk/skills/ensembl_gene/structure/builder.py
+++ b/hvantk/skills/ensembl_gene/structure/builder.py
@@ -1,0 +1,48 @@
+"""Builder for ``ensembl-gene:structure`` -- per-gene structural summary from the GTF.
+
+``ensembl-gene:genes`` (the BioMart dataset) carries only coordinates, name and biotype.
+This dataset adds the structural covariates that downstream annotation depends on:
+CDS length (needed to normalise PTM site counts), coding-exon count, transcript count and
+the MANE Select transcript. Gene length is also a mechanical confounder of rare-variant
+burden counts, so it must be available as a nuisance covariate rather than omitted.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_ID = "ensembl-gene-structure-v1"
+
+
+def build_ensembl_gene_structure(parsed_input, ctx, **params):
+    """Phase B builder -- returns an AnnotationTable keyed on ``gene_id``.
+
+    Parameters
+    ----------
+    parsed_input : str | Path
+        Path to an Ensembl GTF (gzipped or plain).
+    ctx : hvantk.core.models.BuildContext
+        Platform-provided context; supplies provenance.
+    **params
+        protein_coding_only : bool, default False
+            Keep only ``gene_biotype == "protein_coding"`` rows.
+
+    Returns
+    -------
+    hvantk.core.models.AnnotationTable
+    """
+    import hail as hl
+
+    from hvantk.core.models import AnnotationTable
+    from hvantk.skills.ensembl_gene.structure.parse import parse_gtf_structure
+
+    df = parse_gtf_structure(str(parsed_input))
+
+    if params.get("protein_coding_only", False):
+        df = df[df.gene_biotype == "protein_coding"].reset_index(drop=True)
+        logger.info("Filtered to %d protein-coding genes", len(df))
+
+    ht = hl.Table.from_pandas(df, key=["gene_id"])
+
+    return AnnotationTable.from_hail(ht, provenance=ctx.provenance(schema_id=SCHEMA_ID))

--- a/hvantk/skills/ensembl_gene/structure/cli.py
+++ b/hvantk/skills/ensembl_gene/structure/cli.py
@@ -1,0 +1,38 @@
+"""Download lifecycle for ensembl-gene:structure -- fetches the pinned Ensembl GTF."""
+from __future__ import annotations
+
+import logging
+import os
+import urllib.request
+
+import click
+
+from hvantk.resources.ensembl_release import (
+    ENSEMBL_GTF_FILENAME,
+    ENSEMBL_GTF_URL,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def download_dataset(raw_dir: str, **params) -> str:
+    """Fetch the pinned Ensembl GTF into ``raw_dir`` and return its path."""
+    os.makedirs(raw_dir, exist_ok=True)
+    target = os.path.join(raw_dir, ENSEMBL_GTF_FILENAME)
+
+    if os.path.exists(target) and not params.get("overwrite", False):
+        logger.info("Using cached GTF: %s", target)
+        return target
+
+    logger.info("Downloading %s -> %s", ENSEMBL_GTF_URL, target)
+    urllib.request.urlretrieve(ENSEMBL_GTF_URL, target)
+    return target
+
+
+@click.command("ensembl-structure-download")
+@click.option("--raw-dir", required=True, help="Directory to download the GTF into.")
+@click.option("--overwrite", is_flag=True, help="Re-download even if cached.")
+def download_cmd(raw_dir, overwrite):
+    """Download the pinned Ensembl GTF."""
+    path = download_dataset(raw_dir, overwrite=overwrite)
+    click.echo(path)

--- a/hvantk/skills/ensembl_gene/structure/drift_probe.py
+++ b/hvantk/skills/ensembl_gene/structure/drift_probe.py
@@ -1,0 +1,20 @@
+"""Drift probe for ensembl-gene:structure.
+
+Unlike the BioMart ``genes`` dataset -- acquired manually, hence a stub probe -- the GTF
+has a stable, predictable release URL, so the pinned release is a real fingerprint. A
+release bump changes CDS lengths, MANE assignments and coordinates, which is exactly the
+kind of upstream movement drift detection exists to surface.
+"""
+from __future__ import annotations
+
+from hvantk.resources.ensembl_release import (
+    ENSEMBL_GTF_URL,
+    ENSEMBL_RELEASE,
+)
+
+
+def fetch_fingerprint() -> dict:
+    return {
+        "release": ENSEMBL_RELEASE,
+        "url": ENSEMBL_GTF_URL,
+    }

--- a/hvantk/skills/ensembl_gene/structure/parse.py
+++ b/hvantk/skills/ensembl_gene/structure/parse.py
@@ -90,7 +90,13 @@ def parse_gtf_structure(gtf_path: str) -> pd.DataFrame:
         coding = [t for t in transcripts if cds_bp[t] > 0]
         representative = mane_of_gene.get(gene_id)
         if representative is None or representative not in coding:
-            representative = max(coding, key=lambda t: cds_bp[t]) if coding else None
+            # Tie-break on transcript ID, not just length: `coding` derives from a set, so a
+            # bare max() on length alone resolves ties by set iteration order, which follows
+            # Python's per-process string-hash seed. That makes the output differ between runs
+            # on identical input.
+            representative = (
+                max(coding, key=lambda t: (cds_bp[t], t)) if coding else None
+            )
         rows.append(
             {
                 "gene_id": gene_id,

--- a/hvantk/skills/ensembl_gene/structure/parse.py
+++ b/hvantk/skills/ensembl_gene/structure/parse.py
@@ -1,0 +1,108 @@
+"""Single-pass Ensembl GTF -> per-gene structural summary.
+
+Deliberately separate from ``hvantk.algorithms.ptm.mapper.parse_ensembl_gtf``: that one
+keys MANE by gene SYMBOL and builds per-transcript exon lists for residue-to-genomic
+coordinate mapping. This one keys by ``gene_id`` and emits one row per gene. Pure Python
+and pandas -- no Hail -- so it stays in the fast test suite.
+
+The representative coding transcript is MANE Select when the gene has one, otherwise the
+transcript with the longest summed CDS. Length is preferred over "first seen" because GTF
+transcript order is not stable across releases.
+"""
+from __future__ import annotations
+
+import gzip
+import logging
+import re
+from collections import defaultdict
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_RE_GENE_ID = re.compile(r'gene_id "([^"]+)"')
+_RE_TX_ID = re.compile(r'transcript_id "([^"]+)"')
+_RE_BIOTYPE = re.compile(r'gene_biotype "([^"]+)"')
+
+COLUMNS = [
+    "gene_id",
+    "gene_biotype",
+    "mane_select",
+    "cds_transcript",
+    "cds_length",
+    "n_coding_exons",
+    "n_transcripts",
+]
+
+
+def parse_gtf_structure(gtf_path: str) -> pd.DataFrame:
+    """Summarise an Ensembl GTF to one row per gene.
+
+    Parameters
+    ----------
+    gtf_path : str
+        Path to an Ensembl GTF, gzipped or plain.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns as in ``COLUMNS``, sorted by ``gene_id`` with a reset index.
+    """
+    tx_of_gene: dict[str, set[str]] = defaultdict(set)
+    cds_bp: dict[str, int] = defaultdict(int)
+    cds_n: dict[str, int] = defaultdict(int)
+    mane_of_gene: dict[str, str] = {}
+    biotype_of_gene: dict[str, str] = {}
+
+    opener = gzip.open if gtf_path.endswith(".gz") else open
+    with opener(gtf_path, "rt") as fh:
+        for line in fh:
+            if not line or line.startswith("#"):
+                continue
+            fields = line.split("\t", 9)
+            if len(fields) < 9:
+                continue
+            feature, attrs = fields[2], fields[8]
+            if feature != "transcript" and feature != "CDS":
+                continue
+
+            m_gene = _RE_GENE_ID.search(attrs)
+            m_tx = _RE_TX_ID.search(attrs)
+            if not m_gene or not m_tx:
+                continue
+            gene_id = m_gene.group(1).split(".")[0]
+            tx_id = m_tx.group(1).split(".")[0]
+
+            if feature == "transcript":
+                tx_of_gene[gene_id].add(tx_id)
+                if gene_id not in biotype_of_gene:
+                    m_bt = _RE_BIOTYPE.search(attrs)
+                    if m_bt:
+                        biotype_of_gene[gene_id] = m_bt.group(1)
+                if 'tag "MANE_Select"' in attrs:
+                    mane_of_gene[gene_id] = tx_id
+            else:  # CDS -- GTF coordinates are 1-based inclusive on both ends
+                cds_bp[tx_id] += int(fields[4]) - int(fields[3]) + 1
+                cds_n[tx_id] += 1
+
+    rows = []
+    for gene_id, transcripts in tx_of_gene.items():
+        coding = [t for t in transcripts if cds_bp[t] > 0]
+        representative = mane_of_gene.get(gene_id)
+        if representative is None or representative not in coding:
+            representative = max(coding, key=lambda t: cds_bp[t]) if coding else None
+        rows.append(
+            {
+                "gene_id": gene_id,
+                "gene_biotype": biotype_of_gene.get(gene_id, ""),
+                "mane_select": mane_of_gene.get(gene_id, ""),
+                "cds_transcript": representative or "",
+                "cds_length": cds_bp[representative] if representative else 0,
+                "n_coding_exons": cds_n[representative] if representative else 0,
+                "n_transcripts": len(transcripts),
+            }
+        )
+
+    df = pd.DataFrame(rows, columns=COLUMNS)
+    logger.info("Parsed %d genes from %s", len(df), gtf_path)
+    return df.sort_values("gene_id").reset_index(drop=True)

--- a/hvantk/skills/ensembl_gene/structure/tests/conftest.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Local conftest for the Ensembl gene structure dataset tests.
+
+Re-exports the session-level fixtures (``hail_session``, ``regenerate_snapshots``)
+and the auto-marker hook from ``hvantk/tests/conftest.py``. Pytest's conftest
+discovery only walks ancestor directories, and ``hvantk/skills/`` is a sibling
+of ``hvantk/tests/`` -- without this shim, hail-marked tests in this folder
+would not receive the shared session fixture. The sibling
+``ensembl_gene/tests/conftest.py`` is not an ancestor of this ``structure/tests``
+folder, so it does not cover these tests either.
+
+``pytest_addoption`` is deliberately NOT re-exported here: it lives in the
+top-level test conftest and pytest only needs it registered once across the
+session. Re-exporting it would raise ``ValueError: option names already added``
+when both conftests load (e.g., when running the full suite).
+"""
+
+from hvantk.tests.conftest import (  # noqa: F401
+    hail_session,
+    pytest_collection_modifyitems,
+    regenerate_snapshots,
+)

--- a/hvantk/skills/ensembl_gene/structure/tests/drift_fingerprint.json
+++ b/hvantk/skills/ensembl_gene/structure/tests/drift_fingerprint.json
@@ -1,0 +1,4 @@
+{
+  "release": "113",
+  "url": "https://ftp.ensembl.org/pub/release-113/gtf/homo_sapiens/Homo_sapiens.GRCh38.113.gtf.gz"
+}

--- a/hvantk/skills/ensembl_gene/structure/tests/snapshots/sample_rows.json
+++ b/hvantk/skills/ensembl_gene/structure/tests/snapshots/sample_rows.json
@@ -1,0 +1,41 @@
+[
+  {
+    "key": {
+      "gene_id": "ENSG00000000001"
+    },
+    "row": {
+      "cds_length": 300,
+      "cds_transcript": "ENST00000000001",
+      "gene_biotype": "protein_coding",
+      "mane_select": "ENST00000000001",
+      "n_coding_exons": 2,
+      "n_transcripts": 2
+    }
+  },
+  {
+    "key": {
+      "gene_id": "ENSG00000000002"
+    },
+    "row": {
+      "cds_length": 300,
+      "cds_transcript": "ENST00000000004",
+      "gene_biotype": "protein_coding",
+      "mane_select": "",
+      "n_coding_exons": 1,
+      "n_transcripts": 2
+    }
+  },
+  {
+    "key": {
+      "gene_id": "ENSG00000000003"
+    },
+    "row": {
+      "cds_length": 0,
+      "cds_transcript": "",
+      "gene_biotype": "lncRNA",
+      "mane_select": "",
+      "n_coding_exons": 0,
+      "n_transcripts": 1
+    }
+  }
+]

--- a/hvantk/skills/ensembl_gene/structure/tests/snapshots/schema.json
+++ b/hvantk/skills/ensembl_gene/structure/tests/snapshots/schema.json
@@ -1,0 +1,14 @@
+{
+  "key": [
+    "gene_id"
+  ],
+  "row": {
+    "cds_length": "int32",
+    "cds_transcript": "str",
+    "gene_biotype": "str",
+    "gene_id": "str",
+    "mane_select": "str",
+    "n_coding_exons": "int32",
+    "n_transcripts": "int32"
+  }
+}

--- a/hvantk/skills/ensembl_gene/structure/tests/test_builder.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_builder.py
@@ -98,3 +98,40 @@ def test_protein_coding_only_param_filters(hail_session, tmp_path):
     ht = hl.read_table(output_path)
 
     assert ht.count() == 2  # the lncRNA gene is dropped
+
+
+@pytest.mark.hail
+def test_builder_accepts_a_raw_directory(hail_session, tmp_path):
+    """End-to-end guard for the reprocess path: `hvantk reprocess` hands the builder the
+    raw directory (no parse stage), not the GTF file. The build must succeed against a
+    directory containing the downloaded GTF, not crash with IsADirectoryError.
+
+    The downloaded artifact is gzipped (``...gtf.gz``), so the fixture is gzipped into the
+    committed filename here -- which also exercises the parser's gzip branch."""
+    import gzip
+
+    import hail as hl
+
+    from hvantk.resources.ensembl_release import ENSEMBL_GTF_FILENAME
+    from hvantk.skills.ensembl_gene.structure.builder import (
+        build_ensembl_gene_structure,
+    )
+
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    with open(FIXTURE, "rb") as src, gzip.open(
+        raw_dir / ENSEMBL_GTF_FILENAME, "wb"
+    ) as dst:
+        dst.write(src.read())  # what the downloader writes: a gzipped GTF
+
+    builder = phase_b_snapshot_adapter(
+        build_ensembl_gene_structure, "ensembl-gene:structure"
+    )
+    output_path = str(tmp_path / "structure_from_dir.ht")
+    builder(
+        input_path=str(raw_dir), output_path=output_path
+    )  # reprocess passes the dir
+    ht = hl.read_table(output_path)
+
+    assert ht.count() == 3
+    assert list(ht.key) == ["gene_id"]

--- a/hvantk/skills/ensembl_gene/structure/tests/test_builder.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_builder.py
@@ -1,0 +1,100 @@
+"""Snapshot round-trip for the ensembl-gene:structure builder.
+
+Regenerate after an intentional change:
+    pytest hvantk/skills/ensembl_gene/structure/tests/test_builder.py -m hail \
+        --regenerate-snapshots
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hvantk.tests._snapshot_utils import (
+    collect_sample_rows,
+    hail_schema_to_dict,
+    load_snapshot,
+    phase_b_snapshot_adapter,
+)
+from hvantk.tests._snapshot_utils import regenerate_snapshots as regenerate_snapshots_fn
+
+FIXTURE = (
+    "hvantk/skills/ensembl_gene/structure/tests/testdata/raw/"
+    "ensembl-structure/mini.gtf"
+)
+SNAPSHOT_DIR = Path("hvantk/skills/ensembl_gene/structure/tests/snapshots")
+
+SAMPLE_KEYS = [
+    {"gene_id": "ENSG00000000001"},
+    {"gene_id": "ENSG00000000002"},
+    {"gene_id": "ENSG00000000003"},
+]
+
+
+@pytest.mark.hail
+def test_structure_snapshot_round_trip(hail_session, tmp_path, regenerate_snapshots):
+    import hail as hl
+
+    from hvantk.skills.ensembl_gene.structure.builder import (
+        build_ensembl_gene_structure,
+    )
+
+    builder = phase_b_snapshot_adapter(
+        build_ensembl_gene_structure, "ensembl-gene:structure"
+    )
+
+    if regenerate_snapshots:
+        regenerate_snapshots_fn(
+            builder_fn=builder,
+            fixture_path=FIXTURE,
+            snapshot_dir=SNAPSHOT_DIR,
+            keys=SAMPLE_KEYS,
+        )
+        pytest.skip("Snapshots regenerated; rerun without the flag to assert.")
+
+    output_path = str(tmp_path / "structure.ht")
+    builder(input_path=FIXTURE, output_path=output_path)
+    ht = hl.read_table(output_path)
+
+    expected_schema = load_snapshot(SNAPSHOT_DIR / "schema.json")
+    assert hail_schema_to_dict(ht) == expected_schema, "structure schema drifted"
+
+    expected_rows = load_snapshot(SNAPSHOT_DIR / "sample_rows.json")
+    assert collect_sample_rows(ht, keys=SAMPLE_KEYS) == expected_rows
+
+
+@pytest.mark.hail
+def test_gene_id_is_the_key_and_is_unique(hail_session, tmp_path):
+    import hail as hl
+
+    from hvantk.skills.ensembl_gene.structure.builder import (
+        build_ensembl_gene_structure,
+    )
+
+    builder = phase_b_snapshot_adapter(
+        build_ensembl_gene_structure, "ensembl-gene:structure"
+    )
+    output_path = str(tmp_path / "structure.ht")
+    builder(input_path=FIXTURE, output_path=output_path)
+    ht = hl.read_table(output_path)
+
+    assert list(ht.key) == ["gene_id"]
+    assert ht.count() == ht.distinct().count()
+
+
+@pytest.mark.hail
+def test_protein_coding_only_param_filters(hail_session, tmp_path):
+    import hail as hl
+
+    from hvantk.skills.ensembl_gene.structure.builder import (
+        build_ensembl_gene_structure,
+    )
+
+    builder = phase_b_snapshot_adapter(
+        build_ensembl_gene_structure, "ensembl-gene:structure"
+    )
+    output_path = str(tmp_path / "structure_pc.ht")
+    builder(input_path=FIXTURE, output_path=output_path, protein_coding_only=True)
+    ht = hl.read_table(output_path)
+
+    assert ht.count() == 2  # the lncRNA gene is dropped

--- a/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
@@ -1,6 +1,9 @@
 """Per-gene structural summary parsed from an Ensembl GTF."""
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -69,11 +72,16 @@ def test_version_suffixes_are_stripped(tmp_path):
 
 
 def test_tie_break_deterministic_on_equal_cds_length(tmp_path):
-    """When two non-MANE transcripts have equal CDS length, pick the larger transcript ID.
+    """When two non-MANE transcripts have equal CDS length, output must be deterministic.
 
-    This tests the determinism fix: without transcript ID in the tie-break key, max()
-    would resolve ties by set iteration order (Python's per-process hash seed), causing
-    non-deterministic output across runs.
+    Without transcript ID in the tie-break key, max() would resolve ties by set iteration
+    order (Python's per-process hash seed), causing non-deterministic winners across runs.
+    This test verifies that output is identical across at least 8 subprocess runs with
+    different PYTHONHASHSEED values, proving the tuple-key (length, transcript_id) is
+    load-bearing for determinism.
+
+    The winner should be the transcript with the larger ID (lexicographically), since
+    (length, transcript_id) tuple comparison sorts on the second element to break ties.
     """
     gtf = tmp_path / "tie.gtf"
     gtf.write_text(
@@ -86,8 +94,36 @@ def test_tie_break_deterministic_on_equal_cds_length(tmp_path):
         '1\te\tCDS\t1\t9\t.\t+\t0\tgene_id "ENSG00000000010"; '
         'transcript_id "ENST00000000011";\n'
     )
-    out = parse_gtf_structure(str(gtf))
-    row = out.iloc[0]
-    # Both transcripts have 9 bp CDS; the one with larger ID (ENST00000000011) should win
-    assert row.cds_transcript == "ENST00000000011"
-    assert row.cds_length == 9
+
+    # Snippet to run in subprocess: parse the GTF and print the winner cds_transcript.
+    snippet = f"""
+import sys
+sys.path.insert(0, "/fs/dss/home/heto4575/projects/pyvatk")
+from hvantk.skills.ensembl_gene.structure.parse import parse_gtf_structure
+df = parse_gtf_structure({str(gtf)!r})
+print(df.iloc[0]["cds_transcript"])
+"""
+
+    # Run the parser 8 times, each with a different PYTHONHASHSEED.
+    winners = []
+    for seed in range(8):
+        env = {**os.environ, "PYTHONHASHSEED": str(seed)}
+        result = subprocess.run(
+            [sys.executable, "-c", snippet],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        winner = result.stdout.strip()
+        winners.append(winner)
+
+    # All runs must produce the identical winner; if they differ, the determinism is broken.
+    assert len(set(winners)) == 1, (
+        f"Determinism broken: got different winners across seeds: {winners}. "
+        "The tuple-key (cds_bp[t], t) is not being used."
+    )
+
+    # Verify the winner is the larger transcript ID (the expected tie-break result).
+    expected_winner = "ENST00000000011"
+    assert winners[0] == expected_winner

--- a/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
@@ -32,7 +32,7 @@ def test_mane_wins_over_a_longer_non_mane_transcript(df):
     row = df[df.gene_id == "ENSG00000000001"].iloc[0]
     assert row.mane_select == "ENST00000000001"
     assert row.cds_transcript == "ENST00000000001"
-    assert row.cds_length == 300          # (1099-1000+1) + (2199-2000+1)
+    assert row.cds_length == 300  # (1099-1000+1) + (2199-2000+1)
     assert row.n_coding_exons == 2
     assert row.n_transcripts == 2
 
@@ -42,7 +42,7 @@ def test_longest_cds_wins_when_there_is_no_mane(df):
     row = df[df.gene_id == "ENSG00000000002"].iloc[0]
     assert row.mane_select == ""
     assert row.cds_transcript == "ENST00000000004"
-    assert row.cds_length == 300          # 1299-1000+1
+    assert row.cds_length == 300  # 1299-1000+1
     assert row.n_coding_exons == 1
 
 
@@ -66,3 +66,28 @@ def test_version_suffixes_are_stripped(tmp_path):
     out = parse_gtf_structure(str(gtf))
     assert out.iloc[0].gene_id == "ENSG00000000009"
     assert out.iloc[0].cds_transcript == "ENST00000000009"
+
+
+def test_tie_break_deterministic_on_equal_cds_length(tmp_path):
+    """When two non-MANE transcripts have equal CDS length, pick the larger transcript ID.
+
+    This tests the determinism fix: without transcript ID in the tie-break key, max()
+    would resolve ties by set iteration order (Python's per-process hash seed), causing
+    non-deterministic output across runs.
+    """
+    gtf = tmp_path / "tie.gtf"
+    gtf.write_text(
+        '1\te\ttranscript\t1\t9\t.\t+\t.\tgene_id "ENSG00000000010"; '
+        'transcript_id "ENST00000000010"; gene_biotype "protein_coding";\n'
+        '1\te\tCDS\t1\t9\t.\t+\t0\tgene_id "ENSG00000000010"; '
+        'transcript_id "ENST00000000010";\n'
+        '1\te\ttranscript\t1\t9\t.\t+\t.\tgene_id "ENSG00000000010"; '
+        'transcript_id "ENST00000000011"; gene_biotype "protein_coding";\n'
+        '1\te\tCDS\t1\t9\t.\t+\t0\tgene_id "ENSG00000000010"; '
+        'transcript_id "ENST00000000011";\n'
+    )
+    out = parse_gtf_structure(str(gtf))
+    row = out.iloc[0]
+    # Both transcripts have 9 bp CDS; the one with larger ID (ENST00000000011) should win
+    assert row.cds_transcript == "ENST00000000011"
+    assert row.cds_length == 9

--- a/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
@@ -96,9 +96,13 @@ def test_tie_break_deterministic_on_equal_cds_length(tmp_path):
     )
 
     # Snippet to run in subprocess: parse the GTF and print the winner cds_transcript.
+    # The repo root is derived from this test file's location, not hardcoded -- a hardcoded
+    # absolute path would make the determinism guard itself non-portable, failing (or, worse,
+    # silently importing a different copy of hvantk) on any other checkout or on CI.
+    repo_root = Path(__file__).resolve().parents[5]
     snippet = f"""
 import sys
-sys.path.insert(0, "/fs/dss/home/heto4575/projects/pyvatk")
+sys.path.insert(0, {str(repo_root)!r})
 from hvantk.skills.ensembl_gene.structure.parse import parse_gtf_structure
 df = parse_gtf_structure({str(gtf)!r})
 print(df.iloc[0]["cds_transcript"])

--- a/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
@@ -1,0 +1,68 @@
+"""Per-gene structural summary parsed from an Ensembl GTF."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hvantk.skills.ensembl_gene.structure.parse import parse_gtf_structure
+
+FIXTURE = str(
+    Path("hvantk/skills/ensembl_gene/structure/tests/testdata/raw")
+    / "ensembl-structure"
+    / "mini.gtf"
+)
+
+
+@pytest.fixture(scope="module")
+def df():
+    return parse_gtf_structure(FIXTURE)
+
+
+def test_one_row_per_gene_sorted_by_gene_id(df):
+    assert list(df.gene_id) == [
+        "ENSG00000000001",
+        "ENSG00000000002",
+        "ENSG00000000003",
+    ]
+
+
+def test_mane_wins_over_a_longer_non_mane_transcript(df):
+    """ENST...001 is MANE with 300 bp CDS; ENST...002 is non-MANE with 1000 bp."""
+    row = df[df.gene_id == "ENSG00000000001"].iloc[0]
+    assert row.mane_select == "ENST00000000001"
+    assert row.cds_transcript == "ENST00000000001"
+    assert row.cds_length == 300          # (1099-1000+1) + (2199-2000+1)
+    assert row.n_coding_exons == 2
+    assert row.n_transcripts == 2
+
+
+def test_longest_cds_wins_when_there_is_no_mane(df):
+    """ENST...003 is 50 bp, ENST...004 is 300 bp, neither is MANE."""
+    row = df[df.gene_id == "ENSG00000000002"].iloc[0]
+    assert row.mane_select == ""
+    assert row.cds_transcript == "ENST00000000004"
+    assert row.cds_length == 300          # 1299-1000+1
+    assert row.n_coding_exons == 1
+
+
+def test_non_coding_gene_has_zero_cds(df):
+    row = df[df.gene_id == "ENSG00000000003"].iloc[0]
+    assert row.gene_biotype == "lncRNA"
+    assert row.cds_transcript == ""
+    assert row.cds_length == 0
+    assert row.n_coding_exons == 0
+    assert row.n_transcripts == 1
+
+
+def test_version_suffixes_are_stripped(tmp_path):
+    gtf = tmp_path / "v.gtf"
+    gtf.write_text(
+        '1\te\ttranscript\t1\t9\t.\t+\t.\tgene_id "ENSG00000000009.7"; '
+        'transcript_id "ENST00000000009.3"; gene_biotype "protein_coding";\n'
+        '1\te\tCDS\t1\t9\t.\t+\t0\tgene_id "ENSG00000000009.7"; '
+        'transcript_id "ENST00000000009.3";\n'
+    )
+    out = parse_gtf_structure(str(gtf))
+    assert out.iloc[0].gene_id == "ENSG00000000009"
+    assert out.iloc[0].cds_transcript == "ENST00000000009"

--- a/hvantk/skills/ensembl_gene/structure/tests/test_resolve_path.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_resolve_path.py
@@ -1,0 +1,40 @@
+"""The builder's raw-input resolution -- the reprocess directory path.
+
+``hvantk reprocess ensembl-gene:structure`` passes the builder the raw *directory* (no
+parse stage is declared), while the plain-Python GTF parser needs the file. These tests
+pin the resolver that bridges the two. Hail-free on purpose, so they run in the default
+suite rather than only on a Hail node.
+"""
+from __future__ import annotations
+
+from hvantk.resources.ensembl_release import ENSEMBL_GTF_FILENAME
+from hvantk.skills.ensembl_gene.structure.builder import _resolve_gtf_path
+
+
+def test_a_directory_resolves_to_the_committed_gtf_filename(tmp_path):
+    (tmp_path / ENSEMBL_GTF_FILENAME).write_text("dummy")
+    resolved = _resolve_gtf_path(tmp_path)
+    assert resolved == str(tmp_path / ENSEMBL_GTF_FILENAME)
+
+
+def test_a_file_path_is_returned_unchanged(tmp_path):
+    gtf = tmp_path / "mini.gtf"
+    gtf.write_text("dummy")
+    assert _resolve_gtf_path(gtf) == str(gtf)
+    assert _resolve_gtf_path(str(gtf)) == str(gtf)
+
+
+def test_reprocess_directory_convention_reaches_a_real_file(tmp_path):
+    """End-to-end path shape: reprocess hands over raw_dir; the resolver must land on the
+    file the downloader wrote there (raw_dir/ENSEMBL_GTF_FILENAME)."""
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    downloaded = raw_dir / ENSEMBL_GTF_FILENAME
+    downloaded.write_text("dummy")
+
+    resolved = _resolve_gtf_path(raw_dir)  # what reprocess passes: the directory
+
+    assert resolved == str(downloaded)
+    import os
+
+    assert os.path.isfile(resolved)

--- a/hvantk/skills/ensembl_gene/structure/tests/testdata/raw/ensembl-structure/mini.gtf
+++ b/hvantk/skills/ensembl_gene/structure/tests/testdata/raw/ensembl-structure/mini.gtf
@@ -1,0 +1,11 @@
+#!genome-build GRCh38
+1	ensembl	transcript	1000	5000	.	+	.	gene_id "ENSG00000000001"; transcript_id "ENST00000000001"; gene_biotype "protein_coding"; tag "MANE_Select";
+1	ensembl	CDS	1000	1099	.	+	0	gene_id "ENSG00000000001"; transcript_id "ENST00000000001";
+1	ensembl	CDS	2000	2199	.	+	0	gene_id "ENSG00000000001"; transcript_id "ENST00000000001";
+1	ensembl	transcript	1000	6000	.	+	.	gene_id "ENSG00000000001"; transcript_id "ENST00000000002"; gene_biotype "protein_coding";
+1	ensembl	CDS	1000	1999	.	+	0	gene_id "ENSG00000000001"; transcript_id "ENST00000000002";
+2	ensembl	transcript	1000	5000	.	-	.	gene_id "ENSG00000000002"; transcript_id "ENST00000000003"; gene_biotype "protein_coding";
+2	ensembl	CDS	1000	1049	.	-	0	gene_id "ENSG00000000002"; transcript_id "ENST00000000003";
+2	ensembl	transcript	1000	5000	.	-	.	gene_id "ENSG00000000002"; transcript_id "ENST00000000004"; gene_biotype "protein_coding";
+2	ensembl	CDS	1000	1299	.	-	0	gene_id "ENSG00000000002"; transcript_id "ENST00000000004";
+3	ensembl	transcript	1000	5000	.	+	.	gene_id "ENSG00000000003"; transcript_id "ENST00000000005"; gene_biotype "lncRNA";

--- a/hvantk/skills/ensembl_gene/tests/test_release_pin.py
+++ b/hvantk/skills/ensembl_gene/tests/test_release_pin.py
@@ -1,0 +1,39 @@
+"""The Ensembl release must be defined once and agree everywhere it is used."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hvantk.resources.ensembl_release import (
+    ENSEMBL_GTF_FILENAME,
+    ENSEMBL_GTF_URL,
+    ENSEMBL_RELEASE,
+)
+
+CATALOG = Path("hvantk/skills/ensembl_gene/catalog/datasets.json")
+
+
+def test_gtf_url_and_filename_carry_the_pinned_release():
+    assert ENSEMBL_RELEASE in ENSEMBL_GTF_URL
+    assert ENSEMBL_GTF_FILENAME == f"Homo_sapiens.GRCh38.{ENSEMBL_RELEASE}.gtf.gz"
+    assert ENSEMBL_GTF_URL.endswith(ENSEMBL_GTF_FILENAME)
+
+
+def test_ptm_constants_reuse_the_same_pin():
+    """The PTM algorithm must not define its own release."""
+    from hvantk.algorithms.ptm import constants
+
+    assert constants.ENSEMBL_RELEASE == ENSEMBL_RELEASE
+    assert constants.ENSEMBL_GTF_URL == ENSEMBL_GTF_URL
+    assert constants.ENSEMBL_GTF_FILENAME == ENSEMBL_GTF_FILENAME
+
+
+def test_catalog_declares_the_same_release():
+    entries = json.loads(CATALOG.read_text())
+    ensembl = [e for e in entries if e.get("data_source") == "Ensembl"]
+    assert ensembl, "no Ensembl entry in the catalog"
+    for entry in ensembl:
+        assert entry["accession"] == f"Ensembl_v{ENSEMBL_RELEASE}"
+        for f in entry.get("files", []):
+            if f["path"].endswith(".gtf.gz"):
+                assert f["path"] == ENSEMBL_GTF_FILENAME

--- a/hvantk/skills/ensembl_gene/tests/test_release_pin.py
+++ b/hvantk/skills/ensembl_gene/tests/test_release_pin.py
@@ -1,4 +1,10 @@
-"""The Ensembl release must be defined once and agree everywhere it is used."""
+"""The Ensembl release must be defined once and agree everywhere it is used.
+
+The cross-layer check -- that ``hvantk.algorithms.ptm.constants`` re-exports this pin --
+lives in ``hvantk/tests/test_ensembl_release_pin.py``, NOT here: a file under ``skills/``
+may not import from ``algorithms/`` (enforced by test_dependency_directions), and a
+skills-layer test importing the ptm algorithm would itself break that rule.
+"""
 from __future__ import annotations
 
 import json
@@ -17,15 +23,6 @@ def test_gtf_url_and_filename_carry_the_pinned_release():
     assert ENSEMBL_RELEASE in ENSEMBL_GTF_URL
     assert ENSEMBL_GTF_FILENAME == f"Homo_sapiens.GRCh38.{ENSEMBL_RELEASE}.gtf.gz"
     assert ENSEMBL_GTF_URL.endswith(ENSEMBL_GTF_FILENAME)
-
-
-def test_ptm_constants_reuse_the_same_pin():
-    """The PTM algorithm must not define its own release."""
-    from hvantk.algorithms.ptm import constants
-
-    assert constants.ENSEMBL_RELEASE == ENSEMBL_RELEASE
-    assert constants.ENSEMBL_GTF_URL == ENSEMBL_GTF_URL
-    assert constants.ENSEMBL_GTF_FILENAME == ENSEMBL_GTF_FILENAME
 
 
 def test_catalog_declares_the_same_release():

--- a/hvantk/tests/annotation/test_mapping.py
+++ b/hvantk/tests/annotation/test_mapping.py
@@ -1,0 +1,98 @@
+"""Identifier mapping onto the gene spine, with measurable loss."""
+from __future__ import annotations
+
+import pytest
+
+from hvantk.algorithms.annotation.mapping import (
+    GeneIdMapper,
+    MappingRateError,
+    MappingReport,
+    enforce_rate,
+)
+
+
+class FakeHGNC:
+    """Minimal stand-in for HGNCGeneCatalogStreamer.
+
+    Real HGNC tables need Hail; the mapper's own logic -- alias resolution, spine
+    membership, loss accounting -- does not, so it is tested against this fake and the
+    real streamer is exercised in Task 5's integration test.
+    """
+
+    _CANONICAL = {"MYL7": "MYL7", "OLD1": "NEW1", "NEW1": "NEW1"}
+    _TO_HGNC = {"MYL7": "HGNC:7592", "NEW1": "HGNC:00001"}
+    _TO_ENSEMBL = {"HGNC:7592": "ENSG00000106631", "HGNC:00001": "ENSG00000000001"}
+
+    def resolve_to_canonical(self, symbol):
+        return self._CANONICAL.get(symbol, symbol)
+
+    def map_to_hgnc(self, ids, source_type):
+        return {i: self._TO_HGNC.get(i) for i in ids}
+
+    def map_from_hgnc(self, hgnc_ids, target_type):
+        assert target_type == "ensembl_gene_id"
+        return {h: self._TO_ENSEMBL.get(h) for h in hgnc_ids}
+
+
+SPINE = {"ENSG00000106631", "ENSG00000000001"}
+
+
+def test_report_rate_is_mapped_over_input():
+    r = MappingReport("x", "symbol", 10, 8, 2, 0, ("A", "B"))
+    assert r.rate == 0.8
+
+
+def test_empty_input_reports_full_rate():
+    r = MappingReport("x", "symbol", 0, 0, 0, 0, ())
+    assert r.rate == 1.0
+
+
+def test_symbols_map_through_alias_resolution():
+    mapper = GeneIdMapper(FakeHGNC(), SPINE)
+    mapping, report = mapper.from_symbols(["MYL7", "OLD1"], source="test")
+
+    assert mapping["MYL7"] == "ENSG00000106631"
+    assert mapping["OLD1"] == "ENSG00000000001"   # OLD1 -> NEW1 -> HGNC -> ENSG
+    assert report.n_mapped == 2
+    assert report.rate == 1.0
+
+
+def test_unmapped_symbols_are_named_not_just_counted():
+    mapper = GeneIdMapper(FakeHGNC(), SPINE)
+    mapping, report = mapper.from_symbols(["MYL7", "NOTAGENE"], source="test")
+
+    assert mapping["NOTAGENE"] is None
+    assert report.n_unmapped == 1
+    assert "NOTAGENE" in report.unmapped
+
+
+def test_a_gene_absent_from_the_spine_counts_as_unmapped():
+    """Mapping to an Ensembl ID the spine does not contain is still a loss."""
+    mapper = GeneIdMapper(FakeHGNC(), spine_gene_ids={"ENSG00000106631"})
+    mapping, report = mapper.from_symbols(["MYL7", "NEW1"], source="test")
+
+    assert mapping["NEW1"] is None
+    assert report.n_unmapped == 1
+
+
+def test_hgnc_ids_map_directly():
+    mapper = GeneIdMapper(FakeHGNC(), SPINE)
+    mapping, report = mapper.from_hgnc_ids(["HGNC:7592"], source="test")
+
+    assert mapping["HGNC:7592"] == "ENSG00000106631"
+    assert report.key_type == "hgnc_id"
+
+
+def test_enforce_rate_passes_at_threshold():
+    enforce_rate(MappingReport("s", "symbol", 10, 9, 1, 0, ("X",)), min_rate=0.9)
+
+
+def test_enforce_rate_raises_below_threshold_and_names_examples():
+    report = MappingReport("cardoso", "symbol", 10, 5, 5, 0, ("A", "B", "C", "D", "E"))
+    with pytest.raises(MappingRateError) as exc:
+        enforce_rate(report, min_rate=0.9)
+
+    message = str(exc.value)
+    assert "cardoso" in message
+    assert "0.50" in message
+    assert "A" in message

--- a/hvantk/tests/annotation/test_spine.py
+++ b/hvantk/tests/annotation/test_spine.py
@@ -85,7 +85,13 @@ def _structure_ht():
 
 
 def _hgnc_ht():
-    """ENSG3 is deliberately absent -- a protein-coding gene with no HGNC record."""
+    """ENSG3 is deliberately absent -- a protein-coding gene with no HGNC record.
+
+    ``gene_group`` is ``array<str>`` to match the real ``hgnc:lookup`` schema (a gene can
+    belong to several HGNC gene groups): modelling it as a scalar here would assert a
+    contract production never produces. The spine carries the array through unchanged -- it
+    is deliberately not reduced to a scalar, so a P2 consumer sees the real shape.
+    """
     import hail as hl
 
     return hl.Table.parallelize(
@@ -94,17 +100,20 @@ def _hgnc_ht():
                 "hgnc_id": "HGNC:1",
                 "symbol": "MYL7",
                 "ensembl_gene_id": "ENSG1",
-                "gene_group": "Myosin light chains",
+                "gene_group": ["Myosin light chains"],
             },
             {
                 "hgnc_id": "HGNC:2",
                 "symbol": "LNC1",
                 "ensembl_gene_id": "ENSG2",
-                "gene_group": "",
+                "gene_group": [],
             },
         ],
         hl.tstruct(
-            hgnc_id=hl.tstr, symbol=hl.tstr, ensembl_gene_id=hl.tstr, gene_group=hl.tstr
+            hgnc_id=hl.tstr,
+            symbol=hl.tstr,
+            ensembl_gene_id=hl.tstr,
+            gene_group=hl.tarray(hl.tstr),
         ),
         key=["hgnc_id"],
     )
@@ -136,9 +145,9 @@ def test_structure_and_hgnc_fields_are_carried(hail_session):
 
     assert row.cds_length == 300
     assert row.n_coding_exons == 2
-    assert row.mane_select == "ENST1"
+    assert row.mane_select == "ENST1"  # from structure (str), not HGNC's array<str>
     assert row.hgnc_id == "HGNC:1"
-    assert row.gene_group == "Myosin light chains"
+    assert row.gene_group == ["Myosin light chains"]  # array<str>, carried unreduced
 
 
 @pytest.mark.hail
@@ -179,17 +188,20 @@ def test_two_hgnc_records_for_one_gene_do_not_duplicate_the_row(hail_session):
                 "hgnc_id": "HGNC:9",
                 "symbol": "MYL7B",
                 "ensembl_gene_id": "ENSG1",
-                "gene_group": "Z group",
+                "gene_group": ["Z group"],
             },
             {
                 "hgnc_id": "HGNC:1",
                 "symbol": "MYL7",
                 "ensembl_gene_id": "ENSG1",
-                "gene_group": "Myosin light chains",
+                "gene_group": ["Myosin light chains"],
             },
         ],
         hl.tstruct(
-            hgnc_id=hl.tstr, symbol=hl.tstr, ensembl_gene_id=hl.tstr, gene_group=hl.tstr
+            hgnc_id=hl.tstr,
+            symbol=hl.tstr,
+            ensembl_gene_id=hl.tstr,
+            gene_group=hl.tarray(hl.tstr),
         ),
         key=["hgnc_id"],
     )
@@ -199,5 +211,7 @@ def test_two_hgnc_records_for_one_gene_do_not_duplicate_the_row(hail_session):
     assert spine.count() == 2  # ENSG1 + ENSG3, not 3
     assert spine.count() == spine.distinct().count()
     row = spine.filter(spine.gene_id == "ENSG1").collect()[0]
-    assert row.hgnc_id == "HGNC:1"  # lowest hgnc_id wins, deterministically
-    assert row.gene_group == "Myosin light chains"
+    assert (
+        row.hgnc_id == "HGNC:1"
+    )  # lexicographically smallest hgnc_id wins, deterministically
+    assert row.gene_group == ["Myosin light chains"]  # the winning record's array

--- a/hvantk/tests/annotation/test_spine.py
+++ b/hvantk/tests/annotation/test_spine.py
@@ -1,0 +1,203 @@
+"""The gene spine: one row per protein-coding gene, keyed on Ensembl gene_id."""
+from __future__ import annotations
+
+import pytest
+
+
+def _genes_ht():
+    import hail as hl
+
+    return hl.Table.parallelize(
+        [
+            {
+                "gene_id": "ENSG1",
+                "gene_name": "MYL7",
+                "chromosome": "7",
+                "gene_start": 100,
+                "gene_end": 200,
+            },
+            {
+                "gene_id": "ENSG2",
+                "gene_name": "LNC1",
+                "chromosome": "2",
+                "gene_start": 300,
+                "gene_end": 400,
+            },
+            {
+                "gene_id": "ENSG3",
+                "gene_name": "ORPH",
+                "chromosome": "3",
+                "gene_start": 500,
+                "gene_end": 600,
+            },
+        ],
+        hl.tstruct(
+            gene_id=hl.tstr,
+            gene_name=hl.tstr,
+            chromosome=hl.tstr,
+            gene_start=hl.tint32,
+            gene_end=hl.tint32,
+        ),
+        key=["gene_id"],
+    )
+
+
+def _structure_ht():
+    import hail as hl
+
+    return hl.Table.parallelize(
+        [
+            {
+                "gene_id": "ENSG1",
+                "gene_biotype": "protein_coding",
+                "mane_select": "ENST1",
+                "cds_length": 300,
+                "n_coding_exons": 2,
+                "n_transcripts": 2,
+            },
+            {
+                "gene_id": "ENSG2",
+                "gene_biotype": "lncRNA",
+                "mane_select": "",
+                "cds_length": 0,
+                "n_coding_exons": 0,
+                "n_transcripts": 1,
+            },
+            {
+                "gene_id": "ENSG3",
+                "gene_biotype": "protein_coding",
+                "mane_select": "",
+                "cds_length": 150,
+                "n_coding_exons": 1,
+                "n_transcripts": 1,
+            },
+        ],
+        hl.tstruct(
+            gene_id=hl.tstr,
+            gene_biotype=hl.tstr,
+            mane_select=hl.tstr,
+            cds_length=hl.tint32,
+            n_coding_exons=hl.tint32,
+            n_transcripts=hl.tint32,
+        ),
+        key=["gene_id"],
+    )
+
+
+def _hgnc_ht():
+    """ENSG3 is deliberately absent -- a protein-coding gene with no HGNC record."""
+    import hail as hl
+
+    return hl.Table.parallelize(
+        [
+            {
+                "hgnc_id": "HGNC:1",
+                "symbol": "MYL7",
+                "ensembl_gene_id": "ENSG1",
+                "gene_group": "Myosin light chains",
+            },
+            {
+                "hgnc_id": "HGNC:2",
+                "symbol": "LNC1",
+                "ensembl_gene_id": "ENSG2",
+                "gene_group": "",
+            },
+        ],
+        hl.tstruct(
+            hgnc_id=hl.tstr, symbol=hl.tstr, ensembl_gene_id=hl.tstr, gene_group=hl.tstr
+        ),
+        key=["hgnc_id"],
+    )
+
+
+@pytest.mark.hail
+def test_spine_keeps_only_protein_coding(hail_session):
+    from hvantk.algorithms.annotation.spine import build_spine
+
+    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    assert sorted(spine.gene_id.collect()) == ["ENSG1", "ENSG3"]
+
+
+@pytest.mark.hail
+def test_gene_id_is_the_key_and_is_unique(hail_session):
+    from hvantk.algorithms.annotation.spine import build_spine
+
+    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    assert list(spine.key) == ["gene_id"]
+    assert spine.count() == spine.distinct().count()
+
+
+@pytest.mark.hail
+def test_structure_and_hgnc_fields_are_carried(hail_session):
+    from hvantk.algorithms.annotation.spine import build_spine
+
+    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    row = spine.filter(spine.gene_id == "ENSG1").collect()[0]
+
+    assert row.cds_length == 300
+    assert row.n_coding_exons == 2
+    assert row.mane_select == "ENST1"
+    assert row.hgnc_id == "HGNC:1"
+    assert row.gene_group == "Myosin light chains"
+
+
+@pytest.mark.hail
+def test_a_gene_without_an_hgnc_record_is_kept_with_a_missing_hgnc_id(hail_session):
+    """The join must not silently drop genes HGNC does not cover."""
+    from hvantk.algorithms.annotation.spine import build_spine
+
+    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    row = spine.filter(spine.gene_id == "ENSG3").collect()[0]
+
+    assert row.hgnc_id is None
+    assert row.cds_length == 150
+
+
+@pytest.mark.hail
+def test_hgnc_mapping_rate_is_reported(hail_session):
+    from hvantk.algorithms.annotation.spine import build_spine, spine_mapping_rate
+
+    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    assert spine_mapping_rate(spine) == pytest.approx(0.5)  # 1 of 2 kept genes
+
+
+@pytest.mark.hail
+def test_two_hgnc_records_for_one_gene_do_not_duplicate_the_row(hail_session):
+    """Join arity must be invariant: HGNC can map two hgnc_ids to one Ensembl gene.
+
+    A left join on a non-unique right side silently multiplies spine rows, which would
+    then multiply every feature joined on afterwards. The pick must also be
+    deterministic, so a rebuild does not change which hgnc_id a gene carries.
+    """
+    import hail as hl
+
+    from hvantk.algorithms.annotation.spine import build_spine
+
+    dup_hgnc = hl.Table.parallelize(
+        [
+            {
+                "hgnc_id": "HGNC:9",
+                "symbol": "MYL7B",
+                "ensembl_gene_id": "ENSG1",
+                "gene_group": "Z group",
+            },
+            {
+                "hgnc_id": "HGNC:1",
+                "symbol": "MYL7",
+                "ensembl_gene_id": "ENSG1",
+                "gene_group": "Myosin light chains",
+            },
+        ],
+        hl.tstruct(
+            hgnc_id=hl.tstr, symbol=hl.tstr, ensembl_gene_id=hl.tstr, gene_group=hl.tstr
+        ),
+        key=["hgnc_id"],
+    )
+
+    spine = build_spine(_genes_ht(), _structure_ht(), dup_hgnc)
+
+    assert spine.count() == 2  # ENSG1 + ENSG3, not 3
+    assert spine.count() == spine.distinct().count()
+    row = spine.filter(spine.gene_id == "ENSG1").collect()[0]
+    assert row.hgnc_id == "HGNC:1"  # lowest hgnc_id wins, deterministically
+    assert row.gene_group == "Myosin light chains"

--- a/hvantk/tests/test_ensembl_release_pin.py
+++ b/hvantk/tests/test_ensembl_release_pin.py
@@ -1,0 +1,23 @@
+"""The PTM algorithm must reuse the single Ensembl release pin, not define its own.
+
+This assertion lives at the top-level test layer rather than under
+``hvantk/skills/ensembl_gene/tests/`` because it imports ``hvantk.algorithms.ptm``, and a
+file under ``skills/`` may not import from ``algorithms/`` (test_dependency_directions).
+The pin itself lives in ``hvantk/resources/ensembl_release.py`` -- substrate that both the
+skill and the algorithm may depend on.
+"""
+from __future__ import annotations
+
+from hvantk.resources.ensembl_release import (
+    ENSEMBL_GTF_FILENAME,
+    ENSEMBL_GTF_URL,
+    ENSEMBL_RELEASE,
+)
+
+
+def test_ptm_constants_reuse_the_same_pin():
+    from hvantk.algorithms.ptm import constants
+
+    assert constants.ENSEMBL_RELEASE == ENSEMBL_RELEASE
+    assert constants.ENSEMBL_GTF_URL == ENSEMBL_GTF_URL
+    assert constants.ENSEMBL_GTF_FILENAME == ENSEMBL_GTF_FILENAME

--- a/hvantk/tests/test_plugin_smoke.py
+++ b/hvantk/tests/test_plugin_smoke.py
@@ -56,6 +56,7 @@ EXPECTED_DATASETS = {
     "cptac:phospho",
     "dbnsfp:variants",
     "ensembl-gene:genes",
+    "ensembl-gene:structure",
     "expression-atlas:dataset",
     "gencc:submissions",
     "gevir:metrics",

--- a/hvantk/tests/test_unified_registry_per_plugin.py
+++ b/hvantk/tests/test_unified_registry_per_plugin.py
@@ -44,11 +44,11 @@ def test_genomics_loaded_from_per_plugin_catalogs():
     reg = _fresh_registry()
     accs = {e.get("accession") for e in reg.list_genomics_datasets()}
     # The 10 genomics datasets now come from per-plugin catalogs. Two of them
-    # (Ensembl_v110, MSigDB_*) come from `mapping`-domain plugins routed into
+    # (Ensembl_v113, MSigDB_*) come from `mapping`-domain plugins routed into
     # the genomics bucket.
     expected = {
         "dbNSFP_v4.7", "ClinVar_latest", "gnomAD_v4.1", "INSIDER_v1.0",
-        "Ensembl_v110", "GeVIR_v1.0", "ClinGen_GeneDisease",
+        "Ensembl_v113", "GeVIR_v1.0", "ClinGen_GeneDisease",
         "GWAS_Catalog_v1.0_e115_r2026-04-27",
         "MSigDB_C2_CP_v2026.1.Hs.symbols", "GTEx_v11_eQTL_signif_pairs",
     }

--- a/hvantk/tools/annotation/annotate_cli.py
+++ b/hvantk/tools/annotation/annotate_cli.py
@@ -1,0 +1,56 @@
+"""CLI for building annotation artifacts.
+
+    hvantk annotate spine --genes G.ht --structure S.ht --hgnc H.ht --output spine.ht
+
+Later phases add ``prepare``, ``compose`` and ``cohort`` to this group.
+
+The command does its work in-process. Scheduling is deliberately external -- sbatch
+wrappers submit it -- so that hvantk never imports a scheduler.
+"""
+from __future__ import annotations
+
+import logging
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+@click.group("annotate")
+def annotate_group():
+    """Build gene- and cohort-level annotation artifacts."""
+
+
+@annotate_group.command("spine")
+@click.option("--genes", required=True, help="Path to the ensembl-gene:genes table.")
+@click.option(
+    "--structure", required=True, help="Path to the ensembl-gene:structure table."
+)
+@click.option("--hgnc", required=True, help="Path to the hgnc:lookup table.")
+@click.option("--output", required=True, help="Output path for the spine table.")
+@click.option(
+    "--biotype",
+    default="protein_coding",
+    show_default=True,
+    help="Gene biotype to keep; pass 'all' to keep every biotype.",
+)
+def spine_cmd(genes, structure, hgnc, output, biotype):
+    """Build the gene spine every annotation joins onto."""
+    import hail as hl
+
+    from hvantk.algorithms.annotation.spine import build_spine, spine_mapping_rate
+    from hvantk.core.utils.hail_context import init_hail
+
+    init_hail()
+
+    ht = build_spine(
+        hl.read_table(genes),
+        hl.read_table(structure),
+        hl.read_table(hgnc),
+        biotype=None if biotype == "all" else biotype,
+    )
+    ht.write(output, overwrite=True)
+
+    ht = hl.read_table(output)
+    click.echo(f"spine: {ht.count()} genes -> {output}")
+    click.echo(f"HGNC mapping rate: {spine_mapping_rate(ht):.2%}")

--- a/hvantk/tools/annotation/annotate_cli.tool.yaml
+++ b/hvantk/tools/annotation/annotate_cli.tool.yaml
@@ -1,0 +1,21 @@
+api_version: 1
+name: annotate
+domain: annotation
+type: command_group
+description: Build gene- and cohort-level annotation artifacts.
+cli:
+  module: hvantk.tools.annotation.annotate_cli
+  function: annotate_group
+purpose:
+  short: Build the gene spine and the annotation matrices that join onto it.
+  long: |
+    `hvantk annotate spine` joins ensembl-gene:genes, ensembl-gene:structure and
+    hgnc:lookup into one gene_id-keyed table that every annotation source maps onto.
+    Later subcommands (`prepare`, `compose`, `cohort`) build the per-source annotations
+    and compose them into a per-gene feature matrix.
+subcommands:
+  - name: spine
+    description: Build the protein-coding gene spine keyed on Ensembl gene_id
+requires:
+  hail: true
+  network: false


### PR DESCRIPTION
## P1 (Foundation) — gene-feature-matrix rebuild

First phase of rebuilding the per-gene feature matrix on a genome-wide, `gene_id`-keyed
protein-coding **spine** (design: `local/planning/2026-07-22-gene-feature-matrix-rebuild-design.md`).
This lays the identifier + structural foundation every later annotation source joins onto.

### What's in it (5 tasks)
1. **Single Ensembl release pin** (`hvantk/resources/ensembl_release.py`) — resolves a live
   **110-vs-113 divergence** between the PTM constants and the `ensembl-gene` catalog; the PTM
   algorithm now re-exports from the pin so one release governs every consumer.
2. **`parse_gtf_structure`** — pure-Python (no Hail) Ensembl GTF → per-gene structural summary
   (CDS length, coding-exon/transcript counts, MANE Select). Stays in the fast test suite.
3. **`ensembl-gene:structure`** — new dataset on the existing `ensembl-gene` provider: builder,
   **real** drift probe (not a stub), downloader, committed schema/row snapshots + drift baseline.
4. **`GeneIdMapper` / `MappingReport`** (`hvantk/algorithms/annotation/mapping.py`) — identifier
   reconciliation onto the spine that **measures** loss (an off-spine `gene_id` counts as
   unmapped) and can fail on a rate threshold. Dependency-injected HGNC (no `skills` import).
5. **`hvantk annotate spine`** + `build_spine` — joins `ensembl-gene:genes ⨝ ensembl-gene:structure
   ⨝ hgnc:lookup` into one `gene_id`-keyed table. HGNC is de-duped to one record per gene
   **before** a LEFT join, so join arity can't multiply rows; HGNC-less genes survive with a null
   `hgnc_id`. New `annotate` CLI group (was absent entirely).

### Review & bugs caught
Each task passed an individual review; the branch then had a final whole-branch review. Three
real defects were found and fixed that the happy-path tests didn't surface:
- **hash-seed non-determinism** in the CDS tie-break — the exact property this rebuild protects
  (now pinned by a `PYTHONHASHSEED` subprocess sweep);
- **`hvantk reprocess` crashed on a raw directory** (`IsADirectoryError`) — no parse stage means
  the builder gets the dir, not the file (fixed with a directory→filename resolver + tests);
- **`gene_group` type divergence** — it's `array<str>` in the real `hgnc:lookup`, but the spine
  fixtures asserted a scalar; a false contract that would have broken P2 (fixtures + carry now
  `array<str>`).

### Exit gate — validated on real genome-scale data (Hail-on-Slurm)
`hvantk reprocess ensembl-gene:structure` on the real release-113 GTF (78,932 genes) → build the
real spine → **all acceptance gates pass**:

| gate | observed |
|---|---|
| protein-coding gene count ∈ [19000, 20500] | **20,116** |
| gene_id unique | ✓ |
| HGNC mapping rate ≥ 0.95 | **0.9665** |
| cds_length > 0 | **100%** |
| mane_select present ≥ 90% | **95.57%** |
| gene_group is `array<str>` | ✓ |

Artifacts written to `$WORK/hvantk-datasets/{ensembl_structure_113.ht, gene_spine_113.ht}`.

### Notes for reviewers
- **Exit-gate genes input** is a release-consistent stand-in derived from the *same* 113 GTF, on
  purpose: live BioMart serves the current release (~116), which would reintroduce the very
  cross-release divergence Task 1 removed. Wiring the real BioMart-genes build at a **matched**
  release is a **P2 prerequisite**.
- Deferred to P2 (non-blocking, from reviews): exercise `GeneIdMapper.n_ambiguous`/unmapped-cap
  through the real path; `click.Path` types on the CLI options; a `spine_mapping_rate` empty-table test.
- **Pre-existing (not introduced here):** the sibling `ensembl-gene:genes` dataset declares
  `tests/drift_fingerprint.json` but never ships it, so `plugins validate --strict-artifacts`
  fails on `genes` (present on `dev`). The new `structure` dataset ships all three artifacts.

Fast tests: `pytest -q` on P1-touched areas green. Hail tests: green at fixture scale and on the
real-data exit gate (Slurm, Java 11).
