### PR TITLE
feat(annotate): P2a — the 'hvantk annotate prepare' framework + gnomAD constraint reference source

### DIFF
--- a/hvantk/algorithms/annotation/mapping.py
+++ b/hvantk/algorithms/annotation/mapping.py
@@ -88,6 +88,19 @@ class GeneIdMapper:
         mapping = {i: self._keep_if_on_spine(to_ensembl.get(i)) for i in ids}
         return mapping, self._report(source, "hgnc_id", mapping)
 
+    def from_gene_ids(
+        self, gene_ids: Iterable[str], *, source: str
+    ) -> tuple[dict[str, Optional[str]], MappingReport]:
+        """Resolve source rows already keyed on Ensembl ``gene_id``.
+
+        No HGNC lookup: the identifiers are already in the spine's key space. A
+        ``gene_id`` the spine does not contain (a different Ensembl release, or a
+        non-protein-coding gene) counts as unmapped, exactly as for the other key types.
+        """
+        ids = list(gene_ids)
+        mapping = {g: self._keep_if_on_spine(g) for g in ids}
+        return mapping, self._report(source, "gene_id", mapping)
+
     def from_symbols(
         self, symbols: Iterable[str], *, source: str
     ) -> tuple[dict[str, Optional[str]], MappingReport]:

--- a/hvantk/algorithms/annotation/prepare.py
+++ b/hvantk/algorithms/annotation/prepare.py
@@ -1,0 +1,61 @@
+"""Prepare a single annotation source into a per-gene, gene_id-keyed artifact.
+
+`prepare` is Stage 1 of the annotation build (design §3): it reads one already-built
+source, maps its key onto the spine's ``gene_id``, keeps only the columns a spec entry
+declares, restricts to rows that land on the spine, and returns the prepared table plus a
+:class:`MappingReport`. Stage 2 (compose, P3) left-joins every prepared artifact to the
+spine. P2a supports ``gene_id``-keyed sources only; other key types raise until P2c.
+
+Layering: this module reads sources as Hail Tables handed in by the caller (the CLI loads
+them by path). It must never import a ``hvantk.skills`` module -- the source is data, not
+code.
+"""
+from __future__ import annotations
+
+import logging
+
+from hvantk.algorithms.annotation.mapping import GeneIdMapper, MappingReport
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_source(source_ht, spine_gene_ids, entry, *, hgnc=None):
+    """Map ``source_ht`` onto the spine and select ``entry.columns``.
+
+    Parameters
+    ----------
+    source_ht : hail.Table
+        The built source, keyed on ``entry.key``.
+    spine_gene_ids : Iterable[str]
+        The spine's ``gene_id`` values.
+    entry : hvantk.algorithms.annotation.spec.SourceEntry
+    hgnc : optional
+        An ``HGNCGeneCatalogStreamer``; required only for non-``gene_id`` keys (P2c).
+
+    Returns
+    -------
+    (hail.Table, MappingReport)
+        A ``gene_id``-keyed table with exactly ``entry.columns``, restricted to the spine,
+        and the mapping report for the source.
+    """
+    import hail as hl
+
+    if entry.key != "gene_id":
+        raise ValueError(
+            f"prepare_source (P2a) supports only gene_id-keyed sources; entry "
+            f"{entry.source!r} declares key {entry.key!r}"
+        )
+
+    spine = set(spine_gene_ids)
+    mapper = GeneIdMapper(hgnc, spine)
+
+    source_ids = source_ht.gene_id.collect()
+    mapping, report = mapper.from_gene_ids(source_ids, source=entry.source)
+
+    # Keep only rows whose gene_id is on the spine, then narrow to the declared columns.
+    mapped_ids = hl.literal({g for g, v in mapping.items() if v is not None})
+    prepared = source_ht.filter(mapped_ids.contains(source_ht.gene_id))
+    prepared = prepared.select(*entry.columns)
+
+    logger.info(report.summary())
+    return prepared, report

--- a/hvantk/algorithms/annotation/prepare.py
+++ b/hvantk/algorithms/annotation/prepare.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 
-from hvantk.algorithms.annotation.mapping import GeneIdMapper, MappingReport
+from hvantk.algorithms.annotation.mapping import GeneIdMapper
 
 logger = logging.getLogger(__name__)
 

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -1,0 +1,74 @@
+"""Feature-spec parsing and validation.
+
+A feature spec declares, per source, which columns become gene-level features and how the
+source's key maps onto the spine's ``gene_id``. P2a supports only ``gene_id``-keyed
+entries (direct); P2c widens the key types and adds aggregation transforms. Parsing is
+pure Python -- no Hail -- so specs validate in the fast test suite.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "resources"
+    / "schemas"
+    / "feature_spec.schema.json"
+)
+
+
+def _schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text())
+
+
+@dataclass(frozen=True)
+class SourceEntry:
+    axis: str
+    source: str
+    key: str
+    columns: tuple[str, ...]
+    min_mapping_rate: float = 0.9
+    origin: str | None = None
+    ablate_separately: bool = False
+
+
+@dataclass(frozen=True)
+class FeatureSpec:
+    name: str
+    layer1: tuple[SourceEntry, ...] = field(default_factory=tuple)
+
+    def entry(self, axis: str) -> SourceEntry:
+        for e in self.layer1:
+            if e.axis == axis:
+                return e
+        raise KeyError(f"no layer1 entry for axis {axis!r}")
+
+
+def load_spec(path: str | Path) -> FeatureSpec:
+    """Read a feature-spec YAML, validate it against the schema, and return a FeatureSpec.
+
+    Raises
+    ------
+    jsonschema.ValidationError
+        If the document does not conform to feature_spec.schema.json.
+    """
+    doc = yaml.safe_load(Path(path).read_text())
+    jsonschema.validate(doc, _schema())  # raises ValidationError on failure
+    entries = tuple(
+        SourceEntry(
+            axis=e["axis"],
+            source=e["source"],
+            key=e["key"],
+            columns=tuple(e["columns"]),
+            min_mapping_rate=e.get("min_mapping_rate", 0.9),
+            origin=e.get("origin"),
+            ablate_separately=e.get("ablate_separately", False),
+        )
+        for e in doc["layer1"]
+    )
+    return FeatureSpec(name=doc["name"], layer1=entries)

--- a/hvantk/resources/schemas/feature_spec.schema.json
+++ b/hvantk/resources/schemas/feature_spec.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "hvantk feature spec",
+  "description": "Declares the per-source feature entries composed into a per-gene matrix.",
+  "type": "object",
+  "required": ["name", "layer1"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {"type": "string", "minLength": 1},
+    "spine": {"type": "object"},
+    "layer1": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/sourceEntry"}
+    },
+    "exclude": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "reason"],
+        "properties": {
+          "source": {"type": "string"},
+          "reason": {"type": "string"}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sourceEntry": {
+      "type": "object",
+      "required": ["axis", "source", "key", "columns"],
+      "additionalProperties": false,
+      "properties": {
+        "axis": {"type": "string", "minLength": 1},
+        "source": {"type": "string", "minLength": 1},
+        "key": {"type": "string", "enum": ["gene_id"]},
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "min_mapping_rate": {"type": "number", "minimum": 0, "maximum": 1},
+        "origin": {"type": "string"},
+        "ablate_separately": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/hvantk/tests/annotation/test_mapping.py
+++ b/hvantk/tests/annotation/test_mapping.py
@@ -52,7 +52,7 @@ def test_symbols_map_through_alias_resolution():
     mapping, report = mapper.from_symbols(["MYL7", "OLD1"], source="test")
 
     assert mapping["MYL7"] == "ENSG00000106631"
-    assert mapping["OLD1"] == "ENSG00000000001"   # OLD1 -> NEW1 -> HGNC -> ENSG
+    assert mapping["OLD1"] == "ENSG00000000001"  # OLD1 -> NEW1 -> HGNC -> ENSG
     assert report.n_mapped == 2
     assert report.rate == 1.0
 
@@ -99,7 +99,9 @@ def test_enforce_rate_raises_below_threshold_and_names_examples():
 
 
 def test_gene_ids_pass_through_when_on_the_spine():
-    mapper = GeneIdMapper(FakeHGNC(), SPINE)  # SPINE = {"ENSG00000106631","ENSG00000000001"}
+    mapper = GeneIdMapper(
+        FakeHGNC(), SPINE
+    )  # SPINE = {"ENSG00000106631","ENSG00000000001"}
     mapping, report = mapper.from_gene_ids(
         ["ENSG00000106631", "ENSG00000000001"], source="test"
     )
@@ -122,11 +124,14 @@ def test_gene_ids_off_the_spine_count_as_unmapped():
 
 def test_from_gene_ids_does_not_touch_hgnc():
     """A gene_id source must not consult HGNC at all -- it is already in spine key space."""
+
     class ExplodingHGNC:
         def resolve_to_canonical(self, s):
             raise AssertionError("HGNC must not be called for gene_id keying")
+
         def map_to_hgnc(self, *a, **k):
             raise AssertionError("HGNC must not be called for gene_id keying")
+
         def map_from_hgnc(self, *a, **k):
             raise AssertionError("HGNC must not be called for gene_id keying")
 

--- a/hvantk/tests/annotation/test_mapping.py
+++ b/hvantk/tests/annotation/test_mapping.py
@@ -96,3 +96,40 @@ def test_enforce_rate_raises_below_threshold_and_names_examples():
     assert "cardoso" in message
     assert "0.50" in message
     assert "A" in message
+
+
+def test_gene_ids_pass_through_when_on_the_spine():
+    mapper = GeneIdMapper(FakeHGNC(), SPINE)  # SPINE = {"ENSG00000106631","ENSG00000000001"}
+    mapping, report = mapper.from_gene_ids(
+        ["ENSG00000106631", "ENSG00000000001"], source="test"
+    )
+    assert mapping["ENSG00000106631"] == "ENSG00000106631"
+    assert mapping["ENSG00000000001"] == "ENSG00000000001"
+    assert report.key_type == "gene_id"
+    assert report.rate == 1.0
+
+
+def test_gene_ids_off_the_spine_count_as_unmapped():
+    mapper = GeneIdMapper(FakeHGNC(), SPINE)
+    mapping, report = mapper.from_gene_ids(
+        ["ENSG00000106631", "ENSG_NOT_ON_SPINE"], source="src"
+    )
+    assert mapping["ENSG_NOT_ON_SPINE"] is None
+    assert report.n_unmapped == 1
+    assert "ENSG_NOT_ON_SPINE" in report.unmapped
+    assert report.rate == 0.5
+
+
+def test_from_gene_ids_does_not_touch_hgnc():
+    """A gene_id source must not consult HGNC at all -- it is already in spine key space."""
+    class ExplodingHGNC:
+        def resolve_to_canonical(self, s):
+            raise AssertionError("HGNC must not be called for gene_id keying")
+        def map_to_hgnc(self, *a, **k):
+            raise AssertionError("HGNC must not be called for gene_id keying")
+        def map_from_hgnc(self, *a, **k):
+            raise AssertionError("HGNC must not be called for gene_id keying")
+
+    mapper = GeneIdMapper(ExplodingHGNC(), SPINE)
+    mapping, report = mapper.from_gene_ids(["ENSG00000106631"], source="s")
+    assert mapping["ENSG00000106631"] == "ENSG00000106631"

--- a/hvantk/tests/annotation/test_prepare.py
+++ b/hvantk/tests/annotation/test_prepare.py
@@ -1,0 +1,68 @@
+"""prepare_source: map a built source onto the spine's gene_id and select columns."""
+from __future__ import annotations
+
+import pytest
+
+from hvantk.algorithms.annotation.spec import SourceEntry
+
+
+def _source_ht():
+    import hail as hl
+
+    # 3 source genes: ENSG1/ENSG2 on the spine, ENSG_OFF not on it.
+    return hl.Table.parallelize(
+        [
+            {"gene_id": "ENSG1", "mis_z": 2.5, "pLI": 0.99, "extra": "drop-me"},
+            {"gene_id": "ENSG2", "mis_z": -1.0, "pLI": 0.01, "extra": "drop-me"},
+            {"gene_id": "ENSG_OFF", "mis_z": 9.9, "pLI": 0.5, "extra": "drop-me"},
+        ],
+        hl.tstruct(gene_id=hl.tstr, mis_z=hl.tfloat64, pLI=hl.tfloat64, extra=hl.tstr),
+        key=["gene_id"],
+    )
+
+
+ENTRY = SourceEntry(
+    axis="constraint",
+    source="gnomad-metrics:metrics",
+    key="gene_id",
+    columns=("mis_z", "pLI"),
+    min_mapping_rate=0.5,
+)
+
+
+@pytest.mark.hail
+def test_prepared_table_is_gene_id_keyed_with_only_declared_columns(hail_session):
+    from hvantk.algorithms.annotation.prepare import prepare_source
+
+    prepared, report = prepare_source(_source_ht(), {"ENSG1", "ENSG2"}, ENTRY)
+    assert list(prepared.key) == ["gene_id"]
+    assert set(prepared.row) == {"gene_id", "mis_z", "pLI"}  # "extra" dropped
+
+
+@pytest.mark.hail
+def test_rows_off_the_spine_are_dropped(hail_session):
+    from hvantk.algorithms.annotation.prepare import prepare_source
+
+    prepared, report = prepare_source(_source_ht(), {"ENSG1", "ENSG2"}, ENTRY)
+    assert sorted(prepared.gene_id.collect()) == ["ENSG1", "ENSG2"]  # ENSG_OFF gone
+
+
+@pytest.mark.hail
+def test_mapping_report_counts_the_off_spine_row_as_unmapped(hail_session):
+    from hvantk.algorithms.annotation.prepare import prepare_source
+
+    prepared, report = prepare_source(_source_ht(), {"ENSG1", "ENSG2"}, ENTRY)
+    assert report.n_in == 3
+    assert report.n_mapped == 2
+    assert report.n_unmapped == 1
+    assert "ENSG_OFF" in report.unmapped
+    assert report.rate == pytest.approx(2 / 3)
+
+
+@pytest.mark.hail
+def test_a_non_gene_id_key_is_rejected_in_p2a(hail_session):
+    from hvantk.algorithms.annotation.prepare import prepare_source
+
+    bad = SourceEntry("x", "s:d", "hgnc_id", ("mis_z",))
+    with pytest.raises(ValueError, match="gene_id"):
+        prepare_source(_source_ht(), {"ENSG1"}, bad)

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -36,5 +36,8 @@ def test_schema_accepts_a_gene_id_entry_and_rejects_a_bad_one():
     }
     assert validator.is_valid(good), list(validator.iter_errors(good))
 
-    bad = {"name": "x", "layer1": [{"axis": "constraint"}]}  # missing source/key/columns
+    bad = {
+        "name": "x",
+        "layer1": [{"axis": "constraint"}],
+    }  # missing source/key/columns
     assert not validator.is_valid(bad)

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -7,20 +7,31 @@ from pathlib import Path
 SCHEMA = Path("hvantk/resources/schemas/feature_spec.schema.json")
 
 
-def test_feature_spec_schema_is_valid_draft_2020_12():
+# These tests validate through jsonschema's version-tolerant entry points
+# (``validator_for`` + ``validate``) rather than the 4.x-only ``Draft202012Validator``
+# class. CI's conda environment pins an older jsonschema (3.2.0) that has no
+# ``Draft202012Validator``, and the production loader (``spec.load_spec``) and every existing
+# plugin/tool loader already validate this way, so the tests must match that path. The
+# assertions here (required fields, enum, additionalProperties) are all draft-4+ features, so
+# they hold whether the schema is validated as 2020-12 or under an older draft's fallback.
+
+
+def test_feature_spec_schema_is_valid():
     import jsonschema
 
     schema = json.loads(SCHEMA.read_text())
     assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
-    # Must not raise: the schema itself is a well-formed schema.
-    jsonschema.Draft202012Validator.check_schema(schema)
+    # Must not raise: the schema is a well-formed schema for whatever draft this jsonschema
+    # resolves it to (validator_for picks 2020-12 on 4.x, an older fallback on 3.x).
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
 
 
 def test_schema_accepts_a_gene_id_entry_and_rejects_a_bad_one():
     import jsonschema
+    import pytest
 
     schema = json.loads(SCHEMA.read_text())
-    validator = jsonschema.Draft202012Validator(schema)
 
     good = {
         "name": "chd-v2",
@@ -34,13 +45,14 @@ def test_schema_accepts_a_gene_id_entry_and_rejects_a_bad_one():
             }
         ],
     }
-    assert validator.is_valid(good), list(validator.iter_errors(good))
+    jsonschema.validate(good, schema)  # must not raise
 
     bad = {
         "name": "x",
         "layer1": [{"axis": "constraint"}],
     }  # missing source/key/columns
-    assert not validator.is_valid(bad)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
 
 
 def test_schema_rejects_a_non_gene_id_key():
@@ -50,9 +62,9 @@ def test_schema_rejects_a_non_gene_id_key():
     when it does, this test is the deliberate tripwire it must update.
     """
     import jsonschema
+    import pytest
 
     schema = json.loads(SCHEMA.read_text())
-    validator = jsonschema.Draft202012Validator(schema)
     entry = {
         "name": "x",
         "layer1": [
@@ -64,7 +76,8 @@ def test_schema_rejects_a_non_gene_id_key():
             }
         ],
     }
-    assert not validator.is_valid(entry)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(entry, schema)
 
 
 def test_load_spec_parses_a_gene_id_entry(tmp_path):

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -43,6 +43,30 @@ def test_schema_accepts_a_gene_id_entry_and_rejects_a_bad_one():
     assert not validator.is_valid(bad)
 
 
+def test_schema_rejects_a_non_gene_id_key():
+    """P2a restricts key to gene_id; a well-formed hgnc_id entry must fail validation.
+
+    This is the schema half of the key-restriction defense-in-depth. P2c widens the enum;
+    when it does, this test is the deliberate tripwire it must update.
+    """
+    import jsonschema
+
+    schema = json.loads(SCHEMA.read_text())
+    validator = jsonschema.Draft202012Validator(schema)
+    entry = {
+        "name": "x",
+        "layer1": [
+            {
+                "axis": "gene-disease",
+                "source": "clingen:gene-disease",
+                "key": "hgnc_id",
+                "columns": ["classification"],
+            }
+        ],
+    }
+    assert not validator.is_valid(entry)
+
+
 def test_load_spec_parses_a_gene_id_entry(tmp_path):
     from hvantk.algorithms.annotation.spec import load_spec
 

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -1,0 +1,40 @@
+"""Feature-spec parsing and validation (P2a: gene_id-keyed entries only)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SCHEMA = Path("hvantk/resources/schemas/feature_spec.schema.json")
+
+
+def test_feature_spec_schema_is_valid_draft_2020_12():
+    import jsonschema
+
+    schema = json.loads(SCHEMA.read_text())
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    # Must not raise: the schema itself is a well-formed schema.
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_schema_accepts_a_gene_id_entry_and_rejects_a_bad_one():
+    import jsonschema
+
+    schema = json.loads(SCHEMA.read_text())
+    validator = jsonschema.Draft202012Validator(schema)
+
+    good = {
+        "name": "chd-v2",
+        "layer1": [
+            {
+                "axis": "constraint",
+                "source": "gnomad-metrics:metrics",
+                "key": "gene_id",
+                "columns": ["mis_z", "pLI"],
+                "min_mapping_rate": 0.9,
+            }
+        ],
+    }
+    assert validator.is_valid(good), list(validator.iter_errors(good))
+
+    bad = {"name": "x", "layer1": [{"axis": "constraint"}]}  # missing source/key/columns
+    assert not validator.is_valid(bad)

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -41,3 +41,73 @@ def test_schema_accepts_a_gene_id_entry_and_rejects_a_bad_one():
         "layer1": [{"axis": "constraint"}],
     }  # missing source/key/columns
     assert not validator.is_valid(bad)
+
+
+def test_load_spec_parses_a_gene_id_entry(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    p = tmp_path / "s.yaml"
+    p.write_text(
+        "name: chd-v2\n"
+        "layer1:\n"
+        "  - axis: constraint\n"
+        "    source: gnomad-metrics:metrics\n"
+        "    key: gene_id\n"
+        "    columns: [mis_z, pLI]\n"
+        "    min_mapping_rate: 0.9\n"
+    )
+    spec = load_spec(p)
+    assert spec.name == "chd-v2"
+    entry = spec.entry("constraint")
+    assert entry.source == "gnomad-metrics:metrics"
+    assert entry.key == "gene_id"
+    assert entry.columns == ("mis_z", "pLI")
+    assert entry.min_mapping_rate == 0.9
+
+
+def test_min_mapping_rate_defaults_to_0_9(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    p = tmp_path / "s.yaml"
+    p.write_text(
+        "name: x\n"
+        "layer1:\n"
+        "  - axis: constraint\n"
+        "    source: gnomad-metrics:metrics\n"
+        "    key: gene_id\n"
+        "    columns: [mis_z]\n"
+    )
+    assert load_spec(p).entry("constraint").min_mapping_rate == 0.9
+
+
+def test_load_spec_rejects_an_invalid_spec(tmp_path):
+    import jsonschema
+
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    p = tmp_path / "bad.yaml"
+    p.write_text(
+        "name: x\nlayer1:\n  - axis: constraint\n"
+    )  # missing source/key/columns
+    import pytest
+
+    with pytest.raises(jsonschema.ValidationError):
+        load_spec(p)
+
+
+def test_entry_raises_for_a_missing_axis(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    p = tmp_path / "s.yaml"
+    p.write_text(
+        "name: x\n"
+        "layer1:\n"
+        "  - axis: constraint\n"
+        "    source: gnomad-metrics:metrics\n"
+        "    key: gene_id\n"
+        "    columns: [mis_z]\n"
+    )
+    import pytest
+
+    with pytest.raises(KeyError):
+        load_spec(p).entry("expression")

--- a/hvantk/tools/annotation/annotate_cli.py
+++ b/hvantk/tools/annotation/annotate_cli.py
@@ -54,3 +54,38 @@ def spine_cmd(genes, structure, hgnc, output, biotype):
     ht = hl.read_table(output)
     click.echo(f"spine: {ht.count()} genes -> {output}")
     click.echo(f"HGNC mapping rate: {spine_mapping_rate(ht):.2%}")
+
+
+@annotate_group.command("prepare")
+@click.option("--spec", required=True, help="Path to the feature-spec YAML.")
+@click.option("--axis", required=True, help="Which layer1 axis entry to prepare.")
+@click.option(
+    "--input",
+    "input_path",
+    required=True,
+    help="Path to the built source AnnotationTable (.ht).",
+)
+@click.option("--spine", required=True, help="Path to the gene spine table (.ht).")
+@click.option(
+    "--output", required=True, help="Output path for the prepared table (.ht)."
+)
+def prepare_cmd(spec, axis, input_path, spine, output):
+    """Map one source onto the spine's gene_id and select its declared columns."""
+    import hail as hl
+
+    from hvantk.algorithms.annotation.mapping import enforce_rate
+    from hvantk.algorithms.annotation.prepare import prepare_source
+    from hvantk.algorithms.annotation.spec import load_spec
+    from hvantk.core.utils.hail_context import init_hail
+
+    init_hail()
+
+    entry = load_spec(spec).entry(axis)
+    source_ht = hl.read_table(input_path)
+    spine_ids = hl.read_table(spine).gene_id.collect()
+
+    prepared, report = prepare_source(source_ht, spine_ids, entry)
+    enforce_rate(report, entry.min_mapping_rate)  # raises MappingRateError if too low
+    prepared.write(output, overwrite=True)
+
+    click.echo(f"prepare {axis} ({entry.source}): {report.summary()} -> {output}")

--- a/hvantk/tools/annotation/annotate_cli.tool.yaml
+++ b/hvantk/tools/annotation/annotate_cli.tool.yaml
@@ -16,6 +16,8 @@ purpose:
 subcommands:
   - name: spine
     description: Build the protein-coding gene spine keyed on Ensembl gene_id
+  - name: prepare
+    description: Map one annotation source onto the spine's gene_id and select its columns
 requires:
   hail: true
   network: false


### PR DESCRIPTION
## P2a — the `hvantk annotate prepare` framework

First increment of the **Prepare** phase of the gene-feature-matrix rebuild
(design: `local/planning/2026-07-22-gene-feature-matrix-rebuild-design.md`, §14 P2a; builds on
P1's spine, merged in #214). It adds a declarative feature-spec + key-resolver + `prepare` CLI,
and drives one `gene_id`-keyed reference source (gnomAD constraint) through it end to end.

### What's in it
- **`GeneIdMapper.from_gene_ids`** — the direct-key resolver (a `gene_id` source is already in
  spine key space; an off-spine id counts as unmapped, uniform with the `hgnc_id`/`symbol`
  resolvers). Produces a `MappingReport`; never consults HGNC.
- **`feature_spec.schema.json`** — JSON Schema (draft 2020-12) for a feature spec. `key` enum is
  deliberately restricted to `gene_id` in P2a, so an unsupported key is a loud validation error.
- **`spec.py`** — `load_spec(path) → FeatureSpec`; frozen `FeatureSpec`/`SourceEntry` dataclasses;
  validate-before-construct (a bad spec raises `ValidationError`, never a downstream `KeyError`).
- **`prepare_source`** — maps a `gene_id`-keyed source onto the spine, restricts to spine genes,
  selects the declared columns, returns `(gene_id-keyed table, MappingReport)`. A non-`gene_id`
  key raises (defense-in-depth with the schema).
- **`hvantk annotate prepare`** — the CLI subcommand: load spec → read source + spine by path →
  `prepare_source` → `enforce_rate(min_mapping_rate)` **before** writing → echo the report.

### Exit gate — validated on real data (Hail-on-Slurm)
`hvantk annotate prepare` on the real gnomAD constraint source → the real 20,116-gene spine:

| check | observed |
|---|---|
| prepare Hail unit tests | 4/4 pass |
| mapping rate (source rows landing on spine) | **94.39%** (18,599 / 19,704) ≥ 0.90 gate |
| prepared artifact key | `gene_id` |
| prepared columns | the 9 declared constraint columns exactly |
| spine coverage (spine genes with constraint) | **0.9246** |

The design's §6 mapping-vs-coverage distinction is cleanly captured: **mapping rate** (gated) vs
**spine coverage** (reported, seeds P2c). Prepared artifact at `$WORK/hvantk-datasets/prep/constraint.ht`.

### Review
Six tasks, each per-task reviewed, plus a final whole-branch review. No Critical/Important
survived. The final review confirmed clean layering (`algorithms/` never imports `skills`/`tools`),
determinism (membership filter is set-order-independent; unmapped list is sorted), Hail correctness
vs the 0.2 docs, and that none of the four cross-cutting invariant tests
(`test_dependency_directions`, `test_unified_registry_per_plugin`, `test_plugin_smoke`,
`test_plugin_contract_artifacts`) are affected — P2a adds no new dataset/provider/tool-domain.

### Deferred to P2c (tracked, cannot fire for the gnomAD reference source)
- A source mapping **0** genes would hit `hl.literal(set())`'s empty-type-imputation before
  `enforce_rate` runs — guard it (`if not mapped: raise MappingRateError`) as P2c's first task, since
  P2c is where low-mapping sources arrive.
- Generalize the key handling to read the key field by `entry.key` name (P2a hard-codes `.gene_id`);
  widen the `key` enum (the new schema-reject test is the deliberate tripwire).

### Notes
- `transforms.py` and committed JSON snapshots are intentionally deferred to P2c (YAGNI — the
  reference source needs only column selection; inline fixture assertions cover P2a).
- Pre-existing, out of scope: `poetry.lock` pins jsonschema 3.2.0 while `pyproject.toml` says
  `>=4.0` — harmless (CI installs a modern jsonschema via `environment.yml`; the existing loaders
  already use draft-2020-12), worth a separate lock refresh.

Fast tests green; Hail tests green on Slurm. Pre-push checklist (dependency-directions,
unified-registry, plugin-smoke, plugin-contract-artifacts, tool-smoke) all pass.
