### PR TITLE
feat(annotate): P2b — GTF-canonical gene table + simplified spine (reproduces P1 exactly)

### DIFF
--- a/hvantk/algorithms/annotation/spine.py
+++ b/hvantk/algorithms/annotation/spine.py
@@ -42,6 +42,11 @@ def build_spine(gene_table_ht, hgnc_ht, *, biotype: str = "protein_coding"):
         ``hgnc:lookup``, keyed on ``hgnc_id``, carrying ``ensembl_gene_id``.
     biotype : str
         Gene biotype to keep. Pass ``None`` to keep every biotype.
+
+    Returns
+    -------
+    hail.Table
+        Keyed on ``gene_id``, one row per gene, fields as in ``SPINE_FIELDS``.
     """
     import hail as hl
 

--- a/hvantk/algorithms/annotation/spine.py
+++ b/hvantk/algorithms/annotation/spine.py
@@ -30,29 +30,22 @@ SPINE_FIELDS = [
 ]
 
 
-def build_spine(genes_ht, structure_ht, hgnc_ht, *, biotype: str = "protein_coding"):
-    """Join Ensembl genes, GTF structure and HGNC into the gene spine.
+def build_spine(gene_table_ht, hgnc_ht, *, biotype: str = "protein_coding"):
+    """Join the canonical Ensembl gene table to HGNC into the gene spine.
 
     Parameters
     ----------
-    genes_ht : hail.Table
-        ``ensembl-gene:genes``, keyed on ``gene_id``.
-    structure_ht : hail.Table
-        ``ensembl-gene:structure``, keyed on ``gene_id``.
+    gene_table_ht : hail.Table
+        ``ensembl-gene:structure`` (the canonical gene table: location, name, biotype,
+        and structural summary), keyed on ``gene_id``.
     hgnc_ht : hail.Table
         ``hgnc:lookup``, keyed on ``hgnc_id``, carrying ``ensembl_gene_id``.
     biotype : str
         Gene biotype to keep. Pass ``None`` to keep every biotype.
-
-    Returns
-    -------
-    hail.Table
-        Keyed on ``gene_id``, one row per gene, fields as in ``SPINE_FIELDS``.
     """
     import hail as hl
 
-    ht = genes_ht.join(structure_ht, how="inner")
-
+    ht = gene_table_ht
     if biotype is not None:
         ht = ht.filter(ht.gene_biotype == biotype)
 
@@ -100,7 +93,6 @@ def build_spine(genes_ht, structure_ht, hgnc_ht, *, biotype: str = "protein_codi
         )
 
     ht = ht.select(*SPINE_FIELDS)
-
     logger.info("Spine: %d genes (biotype=%s)", after, biotype)
     return ht
 

--- a/hvantk/skills/ensembl_gene/structure/SKILL.md
+++ b/hvantk/skills/ensembl_gene/structure/SKILL.md
@@ -1,12 +1,16 @@
 # ensembl-gene:structure
 
-Per-gene structural summary parsed from the pinned Ensembl GTF.
+The canonical per-gene Ensembl table (location, name, biotype, and structure) parsed from the pinned GTF.
 
 **Key:** `gene_id` (Ensembl, version suffix stripped)
 
 | Column | Type | Meaning |
 |---|---|---|
 | `gene_id` | str | Ensembl gene ID, unversioned |
+| `gene_name` | str | HGNC/Ensembl gene symbol |
+| `chromosome` | str | Sequence name (e.g. `1`, `X`) |
+| `gene_start` | int | Gene start (1-based) |
+| `gene_end` | int | Gene end (1-based, inclusive) |
 | `gene_biotype` | str | e.g. `protein_coding`, `lncRNA` |
 | `mane_select` | str | MANE Select transcript ID, `""` if the gene has none |
 | `cds_transcript` | str | Representative coding transcript: MANE if present, else longest CDS |

--- a/hvantk/skills/ensembl_gene/structure/builder.py
+++ b/hvantk/skills/ensembl_gene/structure/builder.py
@@ -1,10 +1,12 @@
-"""Builder for ``ensembl-gene:structure`` -- per-gene structural summary from the GTF.
+"""Builder for ``ensembl-gene:structure`` -- the canonical per-gene Ensembl table from the GTF.
 
-``ensembl-gene:genes`` (the BioMart dataset) carries only coordinates, name and biotype.
-This dataset adds the structural covariates that downstream annotation depends on:
-CDS length (needed to normalise PTM site counts), coding-exon count, transcript count and
-the MANE Select transcript. Gene length is also a mechanical confounder of rare-variant
-burden counts, so it must be available as a nuisance covariate rather than omitted.
+Parsed from the pinned release GTF, this is the single gene table the spine is built on: it
+carries location and name (chromosome, gene_start, gene_end, gene_name), biotype, and the
+structural covariates downstream annotation depends on -- CDS length (needed to normalise PTM
+site counts), coding-exon count, transcript count, and the MANE Select transcript. Gene length
+is also a mechanical confounder of rare-variant burden counts, so it must be available as a
+nuisance covariate rather than omitted. (``ensembl-gene:genes`` is a separate BioMart-sourced
+dataset, no longer used by the spine.)
 """
 from __future__ import annotations
 

--- a/hvantk/skills/ensembl_gene/structure/parse.py
+++ b/hvantk/skills/ensembl_gene/structure/parse.py
@@ -23,10 +23,15 @@ logger = logging.getLogger(__name__)
 _RE_GENE_ID = re.compile(r'gene_id "([^"]+)"')
 _RE_TX_ID = re.compile(r'transcript_id "([^"]+)"')
 _RE_BIOTYPE = re.compile(r'gene_biotype "([^"]+)"')
+_RE_GENE_NAME = re.compile(r'gene_name "([^"]+)"')
 
 COLUMNS = [
     "gene_id",
     "gene_biotype",
+    "gene_name",
+    "chromosome",
+    "gene_start",
+    "gene_end",
     "mane_select",
     "cds_transcript",
     "cds_length",
@@ -53,6 +58,8 @@ def parse_gtf_structure(gtf_path: str) -> pd.DataFrame:
     cds_n: dict[str, int] = defaultdict(int)
     mane_of_gene: dict[str, str] = {}
     biotype_of_gene: dict[str, str] = {}
+    coords_of_gene: dict[str, tuple[str, int, int]] = {}
+    name_of_gene: dict[str, str] = {}
 
     opener = gzip.open if gtf_path.endswith(".gz") else open
     with opener(gtf_path, "rt") as fh:
@@ -63,7 +70,21 @@ def parse_gtf_structure(gtf_path: str) -> pd.DataFrame:
             if len(fields) < 9:
                 continue
             feature, attrs = fields[2], fields[8]
-            if feature != "transcript" and feature != "CDS":
+            if feature not in ("gene", "transcript", "CDS"):
+                continue
+
+            if feature == "gene":
+                m_gene = _RE_GENE_ID.search(attrs)
+                if not m_gene:
+                    continue
+                gid = m_gene.group(1).split(".")[0]
+                coords_of_gene[gid] = (fields[0], int(fields[3]), int(fields[4]))
+                m_name = _RE_GENE_NAME.search(attrs)
+                name_of_gene[gid] = m_name.group(1) if m_name else ""
+                if gid not in biotype_of_gene:
+                    m_bt = _RE_BIOTYPE.search(attrs)
+                    if m_bt:
+                        biotype_of_gene[gid] = m_bt.group(1)
                 continue
 
             m_gene = _RE_GENE_ID.search(attrs)
@@ -86,7 +107,8 @@ def parse_gtf_structure(gtf_path: str) -> pd.DataFrame:
                 cds_n[tx_id] += 1
 
     rows = []
-    for gene_id, transcripts in tx_of_gene.items():
+    for gene_id in sorted(set(tx_of_gene) | set(coords_of_gene)):
+        transcripts = tx_of_gene.get(gene_id, set())
         coding = [t for t in transcripts if cds_bp[t] > 0]
         representative = mane_of_gene.get(gene_id)
         if representative is None or representative not in coding:
@@ -97,10 +119,15 @@ def parse_gtf_structure(gtf_path: str) -> pd.DataFrame:
             representative = (
                 max(coding, key=lambda t: (cds_bp[t], t)) if coding else None
             )
+        chrom, gstart, gend = coords_of_gene.get(gene_id, ("", 0, 0))
         rows.append(
             {
                 "gene_id": gene_id,
                 "gene_biotype": biotype_of_gene.get(gene_id, ""),
+                "gene_name": name_of_gene.get(gene_id, ""),
+                "chromosome": chrom,
+                "gene_start": gstart,
+                "gene_end": gend,
                 "mane_select": mane_of_gene.get(gene_id, ""),
                 "cds_transcript": representative or "",
                 "cds_length": cds_bp[representative] if representative else 0,

--- a/hvantk/skills/ensembl_gene/structure/tests/snapshots/sample_rows.json
+++ b/hvantk/skills/ensembl_gene/structure/tests/snapshots/sample_rows.json
@@ -6,7 +6,11 @@
     "row": {
       "cds_length": 300,
       "cds_transcript": "ENST00000000001",
+      "chromosome": "1",
       "gene_biotype": "protein_coding",
+      "gene_end": 6000,
+      "gene_name": "GENE1",
+      "gene_start": 1000,
       "mane_select": "ENST00000000001",
       "n_coding_exons": 2,
       "n_transcripts": 2
@@ -19,7 +23,11 @@
     "row": {
       "cds_length": 300,
       "cds_transcript": "ENST00000000004",
+      "chromosome": "2",
       "gene_biotype": "protein_coding",
+      "gene_end": 5000,
+      "gene_name": "GENE2",
+      "gene_start": 1000,
       "mane_select": "",
       "n_coding_exons": 1,
       "n_transcripts": 2
@@ -32,7 +40,11 @@
     "row": {
       "cds_length": 0,
       "cds_transcript": "",
+      "chromosome": "3",
       "gene_biotype": "lncRNA",
+      "gene_end": 5000,
+      "gene_name": "LNC3",
+      "gene_start": 1000,
       "mane_select": "",
       "n_coding_exons": 0,
       "n_transcripts": 1

--- a/hvantk/skills/ensembl_gene/structure/tests/snapshots/schema.json
+++ b/hvantk/skills/ensembl_gene/structure/tests/snapshots/schema.json
@@ -5,8 +5,12 @@
   "row": {
     "cds_length": "int32",
     "cds_transcript": "str",
+    "chromosome": "str",
     "gene_biotype": "str",
+    "gene_end": "int32",
     "gene_id": "str",
+    "gene_name": "str",
+    "gene_start": "int32",
     "mane_select": "str",
     "n_coding_exons": "int32",
     "n_transcripts": "int32"

--- a/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
+++ b/hvantk/skills/ensembl_gene/structure/tests/test_parse.py
@@ -131,3 +131,19 @@ print(df.iloc[0]["cds_transcript"])
     # Verify the winner is the larger transcript ID (the expected tie-break result).
     expected_winner = "ENST00000000011"
     assert winners[0] == expected_winner
+
+
+def test_gene_coordinates_and_name_are_captured(df):
+    row = df[df.gene_id == "ENSG00000000001"].iloc[0]
+    assert row.chromosome == "1"
+    assert row.gene_start == 1000
+    assert row.gene_end == 6000
+    assert row.gene_name == "GENE1"
+
+
+def test_coordinates_present_for_the_non_coding_gene_too(df):
+    row = df[df.gene_id == "ENSG00000000003"].iloc[0]
+    assert row.chromosome == "3"
+    assert row.gene_name == "LNC3"
+    assert row.gene_start == 1000
+    assert row.gene_end == 5000

--- a/hvantk/skills/ensembl_gene/structure/tests/testdata/raw/ensembl-structure/mini.gtf
+++ b/hvantk/skills/ensembl_gene/structure/tests/testdata/raw/ensembl-structure/mini.gtf
@@ -1,11 +1,14 @@
 #!genome-build GRCh38
+1	ensembl	gene	1000	6000	.	+	.	gene_id "ENSG00000000001"; gene_name "GENE1"; gene_biotype "protein_coding";
 1	ensembl	transcript	1000	5000	.	+	.	gene_id "ENSG00000000001"; transcript_id "ENST00000000001"; gene_biotype "protein_coding"; tag "MANE_Select";
 1	ensembl	CDS	1000	1099	.	+	0	gene_id "ENSG00000000001"; transcript_id "ENST00000000001";
 1	ensembl	CDS	2000	2199	.	+	0	gene_id "ENSG00000000001"; transcript_id "ENST00000000001";
 1	ensembl	transcript	1000	6000	.	+	.	gene_id "ENSG00000000001"; transcript_id "ENST00000000002"; gene_biotype "protein_coding";
 1	ensembl	CDS	1000	1999	.	+	0	gene_id "ENSG00000000001"; transcript_id "ENST00000000002";
+2	ensembl	gene	1000	5000	.	-	.	gene_id "ENSG00000000002"; gene_name "GENE2"; gene_biotype "protein_coding";
 2	ensembl	transcript	1000	5000	.	-	.	gene_id "ENSG00000000002"; transcript_id "ENST00000000003"; gene_biotype "protein_coding";
 2	ensembl	CDS	1000	1049	.	-	0	gene_id "ENSG00000000002"; transcript_id "ENST00000000003";
 2	ensembl	transcript	1000	5000	.	-	.	gene_id "ENSG00000000002"; transcript_id "ENST00000000004"; gene_biotype "protein_coding";
 2	ensembl	CDS	1000	1299	.	-	0	gene_id "ENSG00000000002"; transcript_id "ENST00000000004";
+3	ensembl	gene	1000	5000	.	+	.	gene_id "ENSG00000000003"; gene_name "LNC3"; gene_biotype "lncRNA";
 3	ensembl	transcript	1000	5000	.	+	.	gene_id "ENSG00000000003"; transcript_id "ENST00000000005"; gene_biotype "lncRNA";

--- a/hvantk/tests/annotation/test_spine.py
+++ b/hvantk/tests/annotation/test_spine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 
 
-def _genes_ht():
+def _gene_table_ht():
     import hail as hl
 
     return hl.Table.parallelize(
@@ -15,40 +15,6 @@ def _genes_ht():
                 "chromosome": "7",
                 "gene_start": 100,
                 "gene_end": 200,
-            },
-            {
-                "gene_id": "ENSG2",
-                "gene_name": "LNC1",
-                "chromosome": "2",
-                "gene_start": 300,
-                "gene_end": 400,
-            },
-            {
-                "gene_id": "ENSG3",
-                "gene_name": "ORPH",
-                "chromosome": "3",
-                "gene_start": 500,
-                "gene_end": 600,
-            },
-        ],
-        hl.tstruct(
-            gene_id=hl.tstr,
-            gene_name=hl.tstr,
-            chromosome=hl.tstr,
-            gene_start=hl.tint32,
-            gene_end=hl.tint32,
-        ),
-        key=["gene_id"],
-    )
-
-
-def _structure_ht():
-    import hail as hl
-
-    return hl.Table.parallelize(
-        [
-            {
-                "gene_id": "ENSG1",
                 "gene_biotype": "protein_coding",
                 "mane_select": "ENST1",
                 "cds_length": 300,
@@ -57,6 +23,10 @@ def _structure_ht():
             },
             {
                 "gene_id": "ENSG2",
+                "gene_name": "LNC1",
+                "chromosome": "2",
+                "gene_start": 300,
+                "gene_end": 400,
                 "gene_biotype": "lncRNA",
                 "mane_select": "",
                 "cds_length": 0,
@@ -65,6 +35,10 @@ def _structure_ht():
             },
             {
                 "gene_id": "ENSG3",
+                "gene_name": "ORPH",
+                "chromosome": "3",
+                "gene_start": 500,
+                "gene_end": 600,
                 "gene_biotype": "protein_coding",
                 "mane_select": "",
                 "cds_length": 150,
@@ -74,6 +48,10 @@ def _structure_ht():
         ],
         hl.tstruct(
             gene_id=hl.tstr,
+            gene_name=hl.tstr,
+            chromosome=hl.tstr,
+            gene_start=hl.tint32,
+            gene_end=hl.tint32,
             gene_biotype=hl.tstr,
             mane_select=hl.tstr,
             cds_length=hl.tint32,
@@ -123,7 +101,7 @@ def _hgnc_ht():
 def test_spine_keeps_only_protein_coding(hail_session):
     from hvantk.algorithms.annotation.spine import build_spine
 
-    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    spine = build_spine(_gene_table_ht(), _hgnc_ht())
     assert sorted(spine.gene_id.collect()) == ["ENSG1", "ENSG3"]
 
 
@@ -131,7 +109,7 @@ def test_spine_keeps_only_protein_coding(hail_session):
 def test_gene_id_is_the_key_and_is_unique(hail_session):
     from hvantk.algorithms.annotation.spine import build_spine
 
-    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    spine = build_spine(_gene_table_ht(), _hgnc_ht())
     assert list(spine.key) == ["gene_id"]
     assert spine.count() == spine.distinct().count()
 
@@ -140,7 +118,7 @@ def test_gene_id_is_the_key_and_is_unique(hail_session):
 def test_structure_and_hgnc_fields_are_carried(hail_session):
     from hvantk.algorithms.annotation.spine import build_spine
 
-    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    spine = build_spine(_gene_table_ht(), _hgnc_ht())
     row = spine.filter(spine.gene_id == "ENSG1").collect()[0]
 
     assert row.cds_length == 300
@@ -155,7 +133,7 @@ def test_a_gene_without_an_hgnc_record_is_kept_with_a_missing_hgnc_id(hail_sessi
     """The join must not silently drop genes HGNC does not cover."""
     from hvantk.algorithms.annotation.spine import build_spine
 
-    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    spine = build_spine(_gene_table_ht(), _hgnc_ht())
     row = spine.filter(spine.gene_id == "ENSG3").collect()[0]
 
     assert row.hgnc_id is None
@@ -166,7 +144,7 @@ def test_a_gene_without_an_hgnc_record_is_kept_with_a_missing_hgnc_id(hail_sessi
 def test_hgnc_mapping_rate_is_reported(hail_session):
     from hvantk.algorithms.annotation.spine import build_spine, spine_mapping_rate
 
-    spine = build_spine(_genes_ht(), _structure_ht(), _hgnc_ht())
+    spine = build_spine(_gene_table_ht(), _hgnc_ht())
     assert spine_mapping_rate(spine) == pytest.approx(0.5)  # 1 of 2 kept genes
 
 
@@ -206,7 +184,7 @@ def test_two_hgnc_records_for_one_gene_do_not_duplicate_the_row(hail_session):
         key=["hgnc_id"],
     )
 
-    spine = build_spine(_genes_ht(), _structure_ht(), dup_hgnc)
+    spine = build_spine(_gene_table_ht(), dup_hgnc)
 
     assert spine.count() == 2  # ENSG1 + ENSG3, not 3
     assert spine.count() == spine.distinct().count()

--- a/hvantk/tools/annotation/annotate_cli.py
+++ b/hvantk/tools/annotation/annotate_cli.py
@@ -1,6 +1,6 @@
 """CLI for building annotation artifacts.
 
-    hvantk annotate spine --genes G.ht --structure S.ht --hgnc H.ht --output spine.ht
+    hvantk annotate spine --gene-table G.ht --hgnc H.ht --output spine.ht
 
 Later phases add ``prepare``, ``compose`` and ``cohort`` to this group.
 
@@ -22,9 +22,11 @@ def annotate_group():
 
 
 @annotate_group.command("spine")
-@click.option("--genes", required=True, help="Path to the ensembl-gene:genes table.")
 @click.option(
-    "--structure", required=True, help="Path to the ensembl-gene:structure table."
+    "--gene-table",
+    "gene_table",
+    required=True,
+    help="Path to the ensembl-gene:structure table (the canonical gene table).",
 )
 @click.option("--hgnc", required=True, help="Path to the hgnc:lookup table.")
 @click.option("--output", required=True, help="Output path for the spine table.")
@@ -34,7 +36,7 @@ def annotate_group():
     show_default=True,
     help="Gene biotype to keep; pass 'all' to keep every biotype.",
 )
-def spine_cmd(genes, structure, hgnc, output, biotype):
+def spine_cmd(gene_table, hgnc, output, biotype):
     """Build the gene spine every annotation joins onto."""
     import hail as hl
 
@@ -44,8 +46,7 @@ def spine_cmd(genes, structure, hgnc, output, biotype):
     init_hail()
 
     ht = build_spine(
-        hl.read_table(genes),
-        hl.read_table(structure),
+        hl.read_table(gene_table),
         hl.read_table(hgnc),
         biotype=None if biotype == "all" else biotype,
     )

--- a/hvantk/tools/annotation/annotate_cli.tool.yaml
+++ b/hvantk/tools/annotation/annotate_cli.tool.yaml
@@ -9,13 +9,13 @@ cli:
 purpose:
   short: Build the gene spine and the annotation matrices that join onto it.
   long: |
-    `hvantk annotate spine` joins ensembl-gene:genes, ensembl-gene:structure and
-    hgnc:lookup into one gene_id-keyed table that every annotation source maps onto.
+    `hvantk annotate spine` joins the canonical Ensembl gene table (ensembl-gene:structure)
+    and hgnc:lookup into one gene_id-keyed table that every annotation source maps onto.
     Later subcommands (`prepare`, `compose`, `cohort`) build the per-source annotations
     and compose them into a per-gene feature matrix.
 subcommands:
   - name: spine
-    description: Build the protein-coding gene spine keyed on Ensembl gene_id
+    description: Build the protein-coding gene spine from ensembl-gene:structure + hgnc:lookup
   - name: prepare
     description: Map one annotation source onto the spine's gene_id and select its columns
 requires:


### PR DESCRIPTION
## P2b — GTF-canonical gene table + simplified spine

Makes the gene spine **release-113-consistent** by sourcing gene coordinates + name from the
same 113 GTF that `ensembl-gene:structure` already parses, and simplifies `build_spine` to a
single gene-table input. Builds on P1 (spine) and P2a (prepare framework), both merged.

### Why
The spine's `genes` input was a GTF-derived *stand-in* at the P1 and P2a exit gates: live BioMart
serves the *current* Ensembl release (~116), not the pinned 113, so joining it against the
113-GTF `structure` would reintroduce the cross-release divergence P1 eliminated. Investigation
found the **spine is the only consumer of `ensembl-gene:genes`**, using just four fields
(`gene_name`, `chromosome`, `gene_start`, `gene_end`) — all in the 113 GTF `structure` already
parses. So `structure` becomes the canonical Ensembl gene table and the spine drops its separate
genes input.

### What's in it
- **`ensembl-gene:structure` parser** also captures `chromosome/gene_start/gene_end/gene_name`
  from the GTF `gene` line — now the canonical per-gene Ensembl table (11 fields).
- **`build_spine(gene_table_ht, hgnc_ht)`** — the `genes ⨝ structure` inner join is dropped;
  the canonical table is biotype-filtered then left-joined to a de-duped HGNC. `SPINE_FIELDS`
  unchanged. The HGNC join-arity guard and `gene_group: array<str>` handling are preserved.
- **`hvantk annotate spine --gene-table … --hgnc …`** (drops `--genes`/`--structure`).
- Regenerated `structure` snapshots (11 fields).

### Exit gate — reproduced the P1 numbers *exactly* (Hail-on-Slurm)
The point of the refactor is to change *how* the spine is built, not *what* it produces:

| gate | P1 | P2b |
|---|---|---|
| structure genes (all biotypes) | 78,932 | **78,932** |
| spine protein-coding | 20,116 | **20,116** |
| gene_id unique | ✓ | ✓ |
| HGNC mapping rate | 0.9665 | **0.9665** |
| cds_length > 0 | 100% | **100%** |
| mane_select present | 95.57% | **95.57%** |
| gene_group | array<str> | **array<str>** |

Structure tests 4/4 and simplified-spine tests 6/6 passed on Slurm.

### Review
Five tasks, each per-task reviewed, plus a final whole-branch review. No Critical/Important. The
final review confirmed the equivalence is **structural** — both inputs were the same release-113
`gene_id`-keyed Ensembl view, so collapsing to one canonical table cannot change the protein-coding
set (the exact 20,116 match proves set identity). Determinism, int32 typing, layering, and the
full-suite invariants (`EXPECTED_DATASETS` unchanged; `structure` still ships a full contract) all
verified. Two branch-introduced doc-coherence nits were fixed (restored `build_spine` `Returns`;
reframed the structure builder docstring).

### Deferred (follow-up, reviewer-sanctioned)
`ensembl-gene:genes` (BioMart) is now spine-unused but stays registered. A separate cleanup can
retire or re-point it and update its provider SKILL wording; not this PR's scope.

Fast tests green; Hail tests green on Slurm. Pre-push checklist (dependency-directions,
unified-registry, plugin-smoke, plugin-contract-artifacts) all pass (22 passed, 3 deselected).
