### PR TITLE
feat(annotate): P2c-1 — prepare empty-set guard + GeVIR (2nd gene_id source)

### DIFF
--- a/hvantk/algorithms/annotation/prepare.py
+++ b/hvantk/algorithms/annotation/prepare.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 
-from hvantk.algorithms.annotation.mapping import GeneIdMapper
+from hvantk.algorithms.annotation.mapping import GeneIdMapper, MappingRateError
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,17 @@ def prepare_source(source_ht, spine_gene_ids, entry, *, hgnc=None):
     mapping, report = mapper.from_gene_ids(source_ids, source=entry.source)
 
     # Keep only rows whose gene_id is on the spine, then narrow to the declared columns.
-    mapped_ids = hl.literal({g for g, v in mapping.items() if v is not None})
+    mapped = {g for g, v in mapping.items() if v is not None}
+    if not mapped:
+        # hl.literal(set()) cannot infer an element type, so an empty mapping would crash
+        # opaquely here. A source that reaches the spine with nothing is a hard failure:
+        # surface it as a clear MappingRateError before any table is built.
+        raise MappingRateError(
+            f"{entry.source} mapped 0 of {report.n_in} identifiers onto the spine; "
+            f"nothing to prepare. First unmapped: {', '.join(report.unmapped[:10])}"
+        )
+
+    mapped_ids = hl.literal(mapped)
     prepared = source_ht.filter(mapped_ids.contains(source_ht.gene_id))
     prepared = prepared.select(*entry.columns)
 

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -56,6 +56,8 @@ def load_spec(path: str | Path) -> FeatureSpec:
     ------
     jsonschema.ValidationError
         If the document does not conform to feature_spec.schema.json.
+    ValueError
+        If two layer1 entries share an axis label.
     """
     doc = yaml.safe_load(Path(path).read_text())
     jsonschema.validate(doc, _schema())  # raises ValidationError on failure
@@ -71,4 +73,11 @@ def load_spec(path: str | Path) -> FeatureSpec:
         )
         for e in doc["layer1"]
     )
+    axes = [e.axis for e in entries]
+    duplicates = sorted({a for a in axes if axes.count(a) > 1})
+    if duplicates:
+        raise ValueError(
+            "duplicate axis label(s) in spec (each layer1 axis must be unique, it is the "
+            f"CLI addressing key): {', '.join(duplicates)}"
+        )
     return FeatureSpec(name=doc["name"], layer1=entries)

--- a/hvantk/skills/gevir/builder.py
+++ b/hvantk/skills/gevir/builder.py
@@ -5,11 +5,41 @@ TSV keyed by ``gene_id`` and wraps with Provenance.
 """
 from __future__ import annotations
 
+import glob
 import logging
+import os
 
 import hail as hl
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_gevir_path(parsed_input) -> str:
+    """Resolve the builder's input to the GeVIR table file itself.
+
+    gevir declares no ``lifecycle.parse``, so ``hvantk reprocess`` hands the builder the raw
+    *directory* (reprocess forwards ``raw_dir`` verbatim as ``parsed_input`` for no-parse
+    datasets), not the file inside it. ``hl.import_table`` cannot read a directory, so resolve
+    a directory to the single raw file it contains. A path that already points at a file is
+    returned unchanged, which keeps the direct ``build(<file>)`` calls (tests, snapshots)
+    working. The GeVIR catalog does not reliably name the file, so glob for the one file
+    rather than joining a fixed name (this is why it differs from structure's
+    ``_resolve_gtf_path``).
+    """
+    path = str(parsed_input)
+    if not os.path.isdir(path):
+        return path
+    candidates = sorted(
+        f
+        for f in glob.glob(os.path.join(path, "*"))
+        if os.path.isfile(f) and not os.path.basename(f).startswith(".")
+    )
+    if len(candidates) != 1:
+        raise ValueError(
+            f"expected exactly one raw file in directory {path!r}, found "
+            f"{len(candidates)}: {[os.path.basename(c) for c in candidates]}"
+        )
+    return candidates[0]
 
 
 def build_gevir_metrics(
@@ -36,7 +66,7 @@ def build_gevir_metrics(
     fields = params.get("fields", None)
 
     ht = hl.import_table(
-        paths=str(parsed_input),
+        paths=_resolve_gevir_path(parsed_input),
         impute=True,
         min_partitions=100,
         key="gene_id",

--- a/hvantk/skills/gevir/tests/test_builder.py
+++ b/hvantk/skills/gevir/tests/test_builder.py
@@ -20,6 +20,7 @@ from hvantk.tests._snapshot_utils import (
     load_snapshot,
     phase_b_snapshot_adapter,
 )
+
 # Aliased to avoid shadowing the fixture name `regenerate_snapshots` in the test signature
 from hvantk.tests._snapshot_utils import regenerate_snapshots as regenerate_snapshots_fn
 
@@ -53,15 +54,46 @@ def test_gevir_snapshot_round_trip(hail_session, tmp_path, regenerate_snapshots)
             snapshot_dir=SNAPSHOT_DIR,
             keys=SAMPLE_KEYS,
         )
-        pytest.skip("Snapshots regenerated; rerun without --regenerate-snapshots to assert.")
+        pytest.skip(
+            "Snapshots regenerated; rerun without --regenerate-snapshots to assert."
+        )
 
     output_path = str(tmp_path / "gevir.ht")
     builder(input_path=FIXTURE, output_path=output_path)
     ht = hl.read_table(output_path)
 
     expected_schema = load_snapshot(SNAPSHOT_DIR / "schema.json")
-    assert hail_schema_to_dict(ht) == expected_schema, "GeVIR schema drifted from snapshot"
+    assert (
+        hail_schema_to_dict(ht) == expected_schema
+    ), "GeVIR schema drifted from snapshot"
 
     expected_rows = load_snapshot(SNAPSHOT_DIR / "sample_rows.json")
     actual_rows = collect_sample_rows(ht, keys=SAMPLE_KEYS)
     assert actual_rows == expected_rows, "GeVIR sample rows drifted from snapshot"
+
+
+def test_resolve_gevir_path_returns_a_file_unchanged(tmp_path):
+    from hvantk.skills.gevir.builder import _resolve_gevir_path
+
+    f = tmp_path / "gevir.tsv"
+    f.write_text("gene_id\n")
+    assert _resolve_gevir_path(str(f)) == str(f)
+
+
+def test_resolve_gevir_path_resolves_a_directory_to_its_single_file(tmp_path):
+    from hvantk.skills.gevir.builder import _resolve_gevir_path
+
+    f = tmp_path / "gevir_metrics_pmid31873297.tsv.bgz"
+    f.write_bytes(b"x")
+    assert _resolve_gevir_path(str(tmp_path)) == str(f)
+
+
+def test_resolve_gevir_path_raises_when_a_directory_is_ambiguous(tmp_path):
+    import pytest
+
+    from hvantk.skills.gevir.builder import _resolve_gevir_path
+
+    (tmp_path / "a.tsv").write_text("x")
+    (tmp_path / "b.tsv").write_text("y")
+    with pytest.raises(ValueError, match="exactly one raw file"):
+        _resolve_gevir_path(str(tmp_path))

--- a/hvantk/tests/annotation/test_prepare.py
+++ b/hvantk/tests/annotation/test_prepare.py
@@ -66,3 +66,13 @@ def test_a_non_gene_id_key_is_rejected_in_p2a(hail_session):
     bad = SourceEntry("x", "s:d", "hgnc_id", ("mis_z",))
     with pytest.raises(ValueError, match="gene_id"):
         prepare_source(_source_ht(), {"ENSG1"}, bad)
+
+
+@pytest.mark.hail
+def test_a_source_that_maps_no_genes_raises_a_clear_error(hail_session):
+    from hvantk.algorithms.annotation.mapping import MappingRateError
+    from hvantk.algorithms.annotation.prepare import prepare_source
+
+    # The spine shares no gene_id with the source -> every row is unmapped.
+    with pytest.raises(MappingRateError, match="0 of 3"):
+        prepare_source(_source_ht(), {"ENSG_NONE"}, ENTRY)

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 SCHEMA = Path("hvantk/resources/schemas/feature_spec.schema.json")
 
 
@@ -144,7 +146,43 @@ def test_entry_raises_for_a_missing_axis(tmp_path):
         "    key: gene_id\n"
         "    columns: [mis_z]\n"
     )
-    import pytest
 
     with pytest.raises(KeyError):
         load_spec(p).entry("expression")
+
+
+def test_a_multi_entry_spec_addresses_each_axis_independently(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    doc = (
+        "name: t\n"
+        "layer1:\n"
+        "  - {axis: constraint, source: gnomad-metrics:metrics, key: gene_id, "
+        "columns: [mis_z]}\n"
+        "  - {axis: gevir, source: gevir:metrics, key: gene_id, "
+        "columns: [gevir_pct, virlof_pct]}\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(doc)
+
+    spec = load_spec(p)
+    assert spec.entry("constraint").source == "gnomad-metrics:metrics"
+    gevir = spec.entry("gevir")
+    assert gevir.source == "gevir:metrics"
+    assert gevir.columns == ("gevir_pct", "virlof_pct")
+
+
+def test_duplicate_axis_labels_are_rejected(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    doc = (
+        "name: t\n"
+        "layer1:\n"
+        "  - {axis: constraint, source: a:x, key: gene_id, columns: [c1]}\n"
+        "  - {axis: constraint, source: b:y, key: gene_id, columns: [c2]}\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(doc)
+
+    with pytest.raises(ValueError, match="duplicate axis"):
+        load_spec(p)


### PR DESCRIPTION
## P2c-1 — `prepare` empty-set guard + GeVIR (second gene_id-keyed source)

First increment of **P2c** (remaining sources) in the gene-feature-matrix rebuild. Deliberately the smallest, de-risking slice: harden the P2a `prepare` framework and prove it generalises to a **second** `gene_id`-keyed source (GeVIR) through the *unchanged* direct-mapping path — no schema change, no new key type, no aggregation transform.

### What changed (3 commits)
- **`prepare_source` empty-set guard** — raises a clear `MappingRateError` when a source maps zero genes onto the spine, instead of the opaque `hl.literal(set())` type-inference crash. (Also closes a real hole: an empty *source* would vacuously pass `enforce_rate` at `rate=1.0`.)
- **GeVIR spec entry** — `axis: gevir`, `source: gevir:metrics`, `columns: [gevir_pct, virlof_pct]`; and `load_spec` now **rejects duplicate axis labels** (the CLI addresses entries by `--axis`; the spec grows to a dozen entries in P2c-2..5).
- **gevir builder dir→file resolver** — the exit gate surfaced that `reprocess` forwards the raw *directory* to no-parse builders and gevir's `hl.import_table(<dir>)` crashed. Added `_resolve_gevir_path` (glob dir → single file), mirroring `ensembl-gene:structure`'s `_resolve_gtf_path`. GeVIR now builds independently via `reprocess`. Build output unchanged → **committed snapshots byte-identical**.

### Exit gate (Slurm, Hail local mode — job 18610495, exit 0)
Fast unit tests + all four repo invariants green; then on the **real 20,116-gene spine**:

| check | result |
|---|---|
| GeVIR genes / prepared onto spine | 19,361 → **18,427** |
| mapping rate (≥ 0.90) | **0.9518** |
| spine coverage (in [0.80, 0.98]) | **0.9160** |
| prepared gene_id-keyed, only `[gevir_pct, virlof_pct]` | ✅ |
| empty-set guard raises `MappingRateError` on a disjoint spine | ✅ |

(The ~4.8% of GeVIR that miss the spine is the expected gnomAD-v2/GRCh37 → release-113 gene-model gap, not a mapping defect.)

### Scope / safety
- **No dataset added** (GeVIR already registered) → `EXPECTED_DATASETS`/plugin-contract unchanged.
- Layering intact (`algorithms/` imports nothing from `skills`/`tools`); jsonschema stays 3.2.0-tolerant; gevir snapshots untouched.
- Reviews: each commit passed an independent task review; whole-branch review (opus) = **Ready to merge, 0 Critical / 0 Important**. 5 Minors, all triaged fine-to-defer.

### Deferred (separate hygiene, not this PR)
- gevir **catalog filename mismatch** (`gevir_metrics.tsv` vs committed `gevir_metrics_pmid31873297.tsv.bgz`) — the glob resolver sidesteps it; belongs with the fabricated-catalog cleanup.
- Pin `jsonschema>=4` in `environment.yml`.
