### PR TITLE
feat(annotate): P2c-3 — dbNSFP variant->gene tolerance aggregation (Layer 1)

### DIFF
--- a/hvantk/algorithms/annotation/prepare.py
+++ b/hvantk/algorithms/annotation/prepare.py
@@ -57,40 +57,86 @@ def prepare_source(source_ht, spine_gene_ids, entry, *, hgnc=None):
     mapper = GeneIdMapper(hgnc, spine)
 
     source_keys = source_ht[key].collect()
-    if key == "gene_id":
-        mapping, report = mapper.from_gene_ids(source_keys, source=entry.source)
-    elif key == "hgnc_id":
-        mapping, report = mapper.from_hgnc_ids(source_keys, source=entry.source)
-    else:  # symbol
-        mapping, report = mapper.from_symbols(source_keys, source=entry.source)
-
-    resolved = {k: v for k, v in mapping.items() if v is not None}
-    if not resolved:
-        raise MappingRateError(
-            f"{entry.source} mapped 0 of {report.n_in} identifiers onto the spine; "
-            f"nothing to prepare. First unmapped: {', '.join(report.unmapped[:10])}"
-        )
+    resolved, report = _resolve_to_gene_id(source_keys, key, entry.source, mapper)
 
     if key == "gene_id":
-        # Already gene_id-keyed: filter to the mapped ids and select columns.
         mapped_ids = hl.literal(set(resolved.values()))
         prepared = source_ht.filter(mapped_ids.contains(source_ht.gene_id))
         prepared = prepared.select(*entry.columns)
     else:
-        # Re-key: attach gene_id from the mapping, drop rows that did not resolve, key on gene_id.
-        lut = hl.literal(resolved)  # source_key -> gene_id
-        prepared = source_ht.annotate(gene_id=lut.get(source_ht[key]))
-        prepared = prepared.filter(hl.is_defined(prepared.gene_id))
-        prepared = prepared.key_by("gene_id").select(*entry.columns)
-        # One row per gene is a hard contract; a many-to-one mapping would duplicate a gene.
-        n_rows = prepared.count()
-        n_genes = prepared.distinct().count()
-        if n_rows != n_genes:
-            raise ValueError(
-                f"{entry.source}: {n_rows - n_genes} source rows resolve to the same "
-                f"gene_id (many-to-one); this source needs aggregation before prepare, not "
-                f"available until a later increment"
-            )
+        prepared = _rekey_onto_gene_id(
+            source_ht, key, resolved, entry.columns, entry.source
+        )
 
+    logger.info(report.summary())
+    return prepared, report
+
+
+def _resolve_to_gene_id(source_keys, to_space, source_label, mapper):
+    """Dispatch the mapper by id-space and drop unmapped; raise if nothing maps."""
+    if to_space == "gene_id":
+        mapping, report = mapper.from_gene_ids(source_keys, source=source_label)
+    elif to_space == "hgnc_id":
+        mapping, report = mapper.from_hgnc_ids(source_keys, source=source_label)
+    elif to_space == "symbol":
+        mapping, report = mapper.from_symbols(source_keys, source=source_label)
+    else:
+        raise ValueError(f"unsupported id-space {to_space!r}")
+    resolved = {k: v for k, v in mapping.items() if v is not None}
+    if not resolved:
+        raise MappingRateError(
+            f"{source_label} mapped 0 of {report.n_in} identifiers onto the spine; "
+            f"nothing to prepare. First unmapped: {', '.join(report.unmapped[:10])}"
+        )
+    return resolved, report
+
+
+def _rekey_onto_gene_id(source_ht, key_col, resolved, columns, source_label):
+    """Attach gene_id from ``resolved``, drop unresolved, key on gene_id, select columns.
+
+    Enforces one row per gene: a many-to-one mapping (or an un-aggregated source) raises.
+    """
+    import hail as hl
+
+    lut = hl.literal(resolved)
+    prepared = source_ht.annotate(gene_id=lut.get(source_ht[key_col]))
+    prepared = prepared.filter(hl.is_defined(prepared.gene_id))
+    prepared = prepared.key_by("gene_id").select(*columns)
+    n_rows = prepared.count()
+    n_genes = prepared.distinct().count()
+    if n_rows != n_genes:
+        raise ValueError(
+            f"{source_label}: {n_rows - n_genes} source rows resolve to the same gene_id "
+            f"(many-to-one); this source needs aggregation before prepare"
+        )
+    return prepared
+
+
+def prepare_variant_source(source_ht, spine_gene_ids, entry, *, hgnc=None):
+    """Aggregate a variant source to per-gene stats, then reconcile onto the spine.
+
+    ``entry.aggregate`` declares the group column, id-space, filter, and per-score stats. The
+    aggregated table is keyed on ``aggregate.by`` (an id in ``aggregate.to`` space); it is mapped
+    onto gene_id exactly like a gene-keyed source.
+    """
+    from hvantk.algorithms.annotation import transforms
+
+    agg = entry.aggregate
+    if agg is None:
+        raise ValueError(
+            f"entry {entry.source!r} has key 'variant' but no aggregate block"
+        )
+    if agg.to != "gene_id" and hgnc is None:
+        raise ValueError(
+            f"entry {entry.source!r} aggregates to {agg.to!r}, which needs the HGNC streamer"
+        )
+
+    grouped = transforms.aggregate_to_gene(source_ht, agg)  # keyed on agg.by
+    mapper = GeneIdMapper(hgnc, set(spine_gene_ids))
+    source_keys = grouped[agg.by].collect()
+    resolved, report = _resolve_to_gene_id(source_keys, agg.to, entry.source, mapper)
+    prepared = _rekey_onto_gene_id(
+        grouped, agg.by, resolved, entry.columns, entry.source
+    )
     logger.info(report.summary())
     return prepared, report

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -51,7 +51,7 @@ class SourceEntry:
     min_mapping_rate: float = 0.9
     origin: str | None = None
     ablate_separately: bool = False
-    aggregate: "AggregateSpec | None" = None
+    aggregate: AggregateSpec | None = None
 
 
 @dataclass(frozen=True)
@@ -66,7 +66,7 @@ class FeatureSpec:
         raise KeyError(f"no layer1 entry for axis {axis!r}")
 
 
-def _build_aggregate(raw: dict | None) -> "AggregateSpec | None":
+def _build_aggregate(raw: dict | None) -> AggregateSpec | None:
     if raw is None:
         return None
     scores = tuple(

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -27,6 +27,22 @@ def _schema() -> dict:
 
 
 @dataclass(frozen=True)
+class ScoreSpec:
+    name: str
+    column: str
+    stats: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AggregateSpec:
+    by: str
+    to: str
+    scores: tuple[ScoreSpec, ...]
+    filter: str | None = None
+    reduce: str = "max"
+
+
+@dataclass(frozen=True)
 class SourceEntry:
     axis: str
     source: str
@@ -35,6 +51,7 @@ class SourceEntry:
     min_mapping_rate: float = 0.9
     origin: str | None = None
     ablate_separately: bool = False
+    aggregate: "AggregateSpec | None" = None
 
 
 @dataclass(frozen=True)
@@ -49,6 +66,22 @@ class FeatureSpec:
         raise KeyError(f"no layer1 entry for axis {axis!r}")
 
 
+def _build_aggregate(raw: dict | None) -> "AggregateSpec | None":
+    if raw is None:
+        return None
+    scores = tuple(
+        ScoreSpec(name=name, column=sc["column"], stats=tuple(sc["stats"]))
+        for name, sc in raw["scores"].items()
+    )
+    return AggregateSpec(
+        by=raw["by"],
+        to=raw["to"],
+        scores=scores,
+        filter=raw.get("filter"),
+        reduce=raw.get("reduce", "max"),
+    )
+
+
 def load_spec(path: str | Path) -> FeatureSpec:
     """Read a feature-spec YAML, validate it against the schema, and return a FeatureSpec.
 
@@ -57,7 +90,8 @@ def load_spec(path: str | Path) -> FeatureSpec:
     jsonschema.ValidationError
         If the document does not conform to feature_spec.schema.json.
     ValueError
-        If two layer1 entries share an axis label.
+        If two layer1 entries share an axis label, or an entry's ``key`` and ``aggregate``
+        presence disagree (``key == "variant"`` requires ``aggregate`` and vice versa).
     """
     doc = yaml.safe_load(Path(path).read_text())
     jsonschema.validate(doc, _schema())  # raises ValidationError on failure
@@ -70,6 +104,7 @@ def load_spec(path: str | Path) -> FeatureSpec:
             min_mapping_rate=e.get("min_mapping_rate", 0.9),
             origin=e.get("origin"),
             ablate_separately=e.get("ablate_separately", False),
+            aggregate=_build_aggregate(e.get("aggregate")),
         )
         for e in doc["layer1"]
     )
@@ -80,4 +115,9 @@ def load_spec(path: str | Path) -> FeatureSpec:
             "duplicate axis label(s) in spec (each layer1 axis must be unique, it is the "
             f"CLI addressing key): {', '.join(duplicates)}"
         )
+    for e in entries:
+        if (e.key == "variant") != (e.aggregate is not None):
+            raise ValueError(
+                f"entry {e.source!r}: key 'variant' requires an aggregate block and vice versa"
+            )
     return FeatureSpec(name=doc["name"], layer1=entries)

--- a/hvantk/algorithms/annotation/transforms.py
+++ b/hvantk/algorithms/annotation/transforms.py
@@ -1,0 +1,113 @@
+"""Declarative variant->gene aggregation (design decision 5's transform vocabulary).
+
+Layering: this module imports hail + stdlib ONLY. It never imports a ``hvantk.skills`` or
+``hvantk.tools`` module -- the source arrives as a Hail Table handed in by the caller (same
+contract as ``prepare.py``). Identifier reconciliation onto the spine happens afterwards, in
+``prepare.py``, via the existing GeneIdMapper; this module only reshapes a variant table into
+one row per ``agg.by`` value.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+FRAC_GT_PREFIX = "frac_gt_"
+
+
+def _missense_predicate(ht):
+    """A dbNSFP row is missense iff aaref/aaalt are two distinct standard residues.
+
+    dbNSFP's ``variant_all`` file enumerates all possible nonsynonymous SNVs; there is no VEP
+    Consequence column. aaalt == 'X' is a stop-gain, aaref == 'X' a stop-loss, '.' is missing;
+    all are excluded, leaving substitutions between standard amino acids.
+    """
+    import hail as hl
+
+    return (
+        (ht.aaref != ht.aaalt)
+        & (ht.aaref != "X")
+        & (ht.aaalt != "X")
+        & (ht.aaref != ".")
+        & (ht.aaalt != ".")
+    )
+
+
+# Named row predicates a spec ``aggregate.filter`` may reference. A closed registry (not an
+# eval'd expression) keeps declarative config free of an injection surface; extend by adding a
+# named predicate, not by growing an expression grammar.
+PREDICATES = {"missense": _missense_predicate}
+
+
+def _max_over_dict(dict_expr):
+    """Reduce a per-transcript ``dict<transcript_id, float>`` to one scalar per variant.
+
+    ``max`` over the dict's non-missing values. REVEL/CADD are broadcast-identical across a
+    variant's transcripts (so max == the single value); MPC can differ mildly and max is a
+    defensible single pick. ``hl.max`` skips missing elements (filter_missing=True default) and
+    returns missing for an all-missing/empty dict.
+    """
+    import hail as hl
+
+    return hl.max(dict_expr.values())
+
+
+# Named transcript-dict reducers (``aggregate.reduce``). Default ``max``.
+REDUCERS = {"max": _max_over_dict}
+
+
+def _agg_for(token, col):
+    """Map a stat token to a Hail aggregator over a scalar column expression."""
+    import hail as hl
+
+    if token == "mean":
+        return hl.agg.mean(col)
+    if token == "max":
+        return hl.agg.max(col)
+    if token == "min":
+        return hl.agg.min(col)
+    if token == "count":
+        return hl.agg.count_where(hl.is_defined(col))
+    if token.startswith(FRAC_GT_PREFIX):
+        thr = float(token[len(FRAC_GT_PREFIX) :])
+        return hl.agg.fraction(hl.is_defined(col) & (col > thr))
+    raise ValueError(f"unknown stat token {token!r}")
+
+
+def output_name(score, token):
+    """Canonical feature-column name for a (score, stat) pair, e.g. revel_frac_gt_0.5."""
+    return f"{score}_{token}"
+
+
+def aggregate_to_gene(source_ht, agg):
+    """Collapse a variant table to one row per ``agg.by`` value.
+
+    Steps: filter (named predicate) -> reduce each score's transcript-dict to a per-variant
+    scalar -> explode the ';'-delimited ``agg.by`` gene string to distinct genes -> group_by that
+    gene -> the declared stats + ``n_possible_missense``. Returns a Table keyed on ``agg.by``,
+    carrying exactly the ``output_name(score, token)`` columns plus ``n_possible_missense``. No
+    spine reconciliation here -- the caller (prepare.py) maps ``agg.by`` onto gene_id.
+    """
+    import hail as hl
+
+    ht = source_ht
+    if agg.filter:
+        ht = ht.filter(PREDICATES[agg.filter](ht))
+
+    reducer = REDUCERS[agg.reduce]
+    ht = ht.annotate(**{s.name: reducer(ht[s.column]) for s in agg.scores})
+
+    # dbNSFP's Ensembl_geneid is a ';'-string (aligned with the transcript array); a variant can
+    # be missense in several genes. Explode to distinct genes so each real gene gets the variant.
+    ht = ht.annotate(_gene=hl.set(ht[agg.by].split(";")))
+    ht = ht.explode(ht._gene)
+
+    aggregations = {}
+    for s in agg.scores:
+        for token in s.stats:
+            aggregations[output_name(s.name, token)] = _agg_for(token, ht[s.name])
+    aggregations["n_possible_missense"] = hl.agg.count()
+
+    grouped = ht.group_by(**{agg.by: ht._gene}).aggregate(**aggregations)
+    logger.info("aggregate_to_gene: %d genes", grouped.count())
+    return grouped

--- a/hvantk/algorithms/annotation/transforms.py
+++ b/hvantk/algorithms/annotation/transforms.py
@@ -70,7 +70,10 @@ def _agg_for(token, col):
         return hl.agg.count_where(hl.is_defined(col))
     if token.startswith(FRAC_GT_PREFIX):
         thr = float(token[len(FRAC_GT_PREFIX) :])
-        return hl.agg.fraction(hl.is_defined(col) & (col > thr))
+        # Denominator is the SCORED variants (col defined), consistent with `mean` above and
+        # the research brief's intent: an undiluted fraction, so a partial-coverage score is
+        # not biased downward by unscored variants counting as "not > thr".
+        return hl.agg.filter(hl.is_defined(col), hl.agg.fraction(col > thr))
     raise ValueError(f"unknown stat token {token!r}")
 
 

--- a/hvantk/resources/schemas/feature_spec.schema.json
+++ b/hvantk/resources/schemas/feature_spec.schema.json
@@ -33,7 +33,7 @@
       "properties": {
         "axis": {"type": "string", "minLength": 1},
         "source": {"type": "string", "minLength": 1},
-        "key": {"type": "string", "enum": ["gene_id", "hgnc_id", "symbol"]},
+        "key": {"type": "string", "enum": ["gene_id", "hgnc_id", "symbol", "variant"]},
         "columns": {
           "type": "array",
           "minItems": 1,
@@ -41,7 +41,34 @@
         },
         "min_mapping_rate": {"type": "number", "minimum": 0, "maximum": 1},
         "origin": {"type": "string"},
-        "ablate_separately": {"type": "boolean"}
+        "ablate_separately": {"type": "boolean"},
+        "aggregate": {"$ref": "#/$defs/aggregateSpec"}
+      },
+      "if": {"properties": {"key": {"const": "variant"}}, "required": ["key"]},
+      "then": {"required": ["aggregate"]}
+    },
+    "aggregateSpec": {
+      "type": "object",
+      "required": ["by", "to", "scores"],
+      "additionalProperties": false,
+      "properties": {
+        "by": {"type": "string", "minLength": 1},
+        "to": {"type": "string", "enum": ["gene_id", "hgnc_id", "symbol"]},
+        "filter": {"type": "string", "minLength": 1},
+        "reduce": {"type": "string", "minLength": 1},
+        "scores": {
+          "type": "object", "minProperties": 1,
+          "additionalProperties": {
+            "type": "object", "required": ["column", "stats"], "additionalProperties": false,
+            "properties": {
+              "column": {"type": "string", "minLength": 1},
+              "stats": {"type": "array", "minItems": 1, "items": {"anyOf": [
+                {"type": "string", "enum": ["mean", "max", "min", "count"]},
+                {"type": "string", "pattern": "^frac_gt_-?[0-9]+(\\.[0-9]+)?$"}
+              ]}}
+            }
+          }
+        }
       }
     }
   }

--- a/hvantk/tests/annotation/test_prepare.py
+++ b/hvantk/tests/annotation/test_prepare.py
@@ -171,3 +171,92 @@ def test_two_keys_mapping_to_one_gene_is_rejected(hail_session):
         prepare_source(
             src, {"ENSG1"}, SourceEntry("x", "s:hg", "hgnc_id", ("score",)), hgnc=fake
         )
+
+
+def _tol_entry():
+    from hvantk.algorithms.annotation.spec import AggregateSpec, ScoreSpec, SourceEntry
+
+    agg = AggregateSpec(
+        by="Ensembl_geneid",
+        to="gene_id",
+        filter="missense",
+        reduce="max",
+        scores=(ScoreSpec("revel", "REVEL_score", ("mean", "max", "frac_gt_0.5")),),
+    )
+    return SourceEntry(
+        axis="tolerance",
+        source="dbnsfp:variants",
+        key="variant",
+        columns=("revel_mean", "revel_max", "revel_frac_gt_0.5", "n_possible_missense"),
+        aggregate=agg,
+    )
+
+
+@pytest.mark.hail
+def test_prepare_variant_source_aggregates_and_maps_onto_spine(hail_session):
+    import hail as hl
+
+    from hvantk.algorithms.annotation.prepare import prepare_variant_source
+
+    # variant table: 2 missense in ENSG_A (on spine), 1 in ENSG_OFF (not on spine).
+    rows = [
+        {
+            "locus": hl.locus("chr1", 100, "GRCh38"),
+            "alleles": ["A", "C"],
+            "aaref": "M",
+            "aaalt": "T",
+            "Ensembl_geneid": "ENSG_A",
+            "REVEL_score": {"t1": 0.9},
+        },
+        {
+            "locus": hl.locus("chr1", 200, "GRCh38"),
+            "alleles": ["G", "T"],
+            "aaref": "R",
+            "aaalt": "Q",
+            "Ensembl_geneid": "ENSG_A",
+            "REVEL_score": {"t1": 0.1},
+        },
+        {
+            "locus": hl.locus("chr1", 300, "GRCh38"),
+            "alleles": ["C", "A"],
+            "aaref": "D",
+            "aaalt": "N",
+            "Ensembl_geneid": "ENSG_OFF",
+            "REVEL_score": {"t1": 0.5},
+        },
+    ]
+    src = hl.Table.parallelize(
+        rows,
+        hl.tstruct(
+            locus=hl.tlocus("GRCh38"),
+            alleles=hl.tarray(hl.tstr),
+            aaref=hl.tstr,
+            aaalt=hl.tstr,
+            Ensembl_geneid=hl.tstr,
+            REVEL_score=hl.tdict(hl.tstr, hl.tfloat64),
+        ),
+        key=["locus", "alleles"],
+    )
+    prepared, report = prepare_variant_source(src, {"ENSG_A"}, _tol_entry())
+    assert list(prepared.key) == ["gene_id"]
+    assert set(prepared.row) == {
+        "gene_id",
+        "revel_mean",
+        "revel_max",
+        "revel_frac_gt_0.5",
+        "n_possible_missense",
+    }
+    assert prepared.gene_id.collect() == ["ENSG_A"]  # ENSG_OFF dropped (off spine)
+    row = prepared.collect()[0]
+    assert row.n_possible_missense == 2 and row.revel_max == pytest.approx(0.9)
+    assert report.n_mapped == 1 and report.n_in == 2  # 2 aggregated genes; 1 on spine
+
+
+@pytest.mark.hail
+def test_prepare_source_gene_id_path_unchanged(hail_session):
+    # Guard the refactor: the direct gene_id path still behaves as in P2c-2.
+    from hvantk.algorithms.annotation.prepare import prepare_source
+
+    prepared, report = prepare_source(_source_ht(), {"ENSG1", "ENSG2"}, ENTRY)
+    assert list(prepared.key) == ["gene_id"]
+    assert sorted(prepared.gene_id.collect()) == ["ENSG1", "ENSG2"]

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -221,3 +221,62 @@ def test_an_unknown_key_is_still_rejected(tmp_path):
 
     with pytest.raises(jsonschema.ValidationError):
         load_spec(p)
+
+
+def test_variant_key_with_aggregate_parses(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    doc = (
+        "name: t\n"
+        "layer1:\n"
+        "  - axis: tolerance\n"
+        "    source: dbnsfp:variants\n"
+        "    key: variant\n"
+        "    columns: [revel_mean, revel_frac_gt_0.5]\n"
+        "    aggregate:\n"
+        "      by: Ensembl_geneid\n"
+        "      to: gene_id\n"
+        "      filter: missense\n"
+        "      scores:\n"
+        "        revel: {column: REVEL_score, stats: [mean, frac_gt_0.5]}\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(doc)
+    spec = load_spec(p)
+    e = spec.entry("tolerance")
+    assert e.key == "variant"
+    assert e.aggregate.by == "Ensembl_geneid" and e.aggregate.to == "gene_id"
+    assert e.aggregate.reduce == "max"  # default
+    assert e.aggregate.scores[0].name == "revel"
+    assert e.aggregate.scores[0].column == "REVEL_score"
+    assert e.aggregate.scores[0].stats == ("mean", "frac_gt_0.5")
+
+
+def test_variant_key_without_aggregate_is_rejected(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    doc = (
+        "name: t\n"
+        "layer1:\n"
+        "  - {axis: x, source: s:d, key: variant, columns: [c1]}\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(doc)
+    with pytest.raises(
+        Exception
+    ):  # jsonschema ValidationError (if/then) or ValueError (load_spec check)
+        load_spec(p)
+
+
+def test_aggregate_on_a_non_variant_key_is_allowed_by_schema_but_ignored(tmp_path):
+    # A gene_id entry with no aggregate still parses; aggregate defaults to None.
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    doc = (
+        "name: t\n"
+        "layer1:\n"
+        "  - {axis: c, source: gnomad-metrics:metrics, key: gene_id, columns: [mis_z]}\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(doc)
+    assert load_spec(p).entry("c").aggregate is None

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -1,4 +1,4 @@
-"""Feature-spec parsing and validation (keys: gene_id, hgnc_id, symbol)."""
+"""Feature-spec parsing and validation (keys: gene_id, hgnc_id, symbol, variant)."""
 from __future__ import annotations
 
 import json

--- a/hvantk/tests/annotation/test_transforms.py
+++ b/hvantk/tests/annotation/test_transforms.py
@@ -1,0 +1,131 @@
+"""transforms.py: stat-token vocabulary + gene aggregation."""
+from __future__ import annotations
+
+import pytest
+
+
+def test_output_name_is_score_underscore_token():
+    from hvantk.algorithms.annotation.transforms import output_name
+
+    assert output_name("revel", "mean") == "revel_mean"
+    assert output_name("revel", "frac_gt_0.5") == "revel_frac_gt_0.5"
+
+
+def test_unknown_stat_token_is_rejected():
+    import hail as hl  # only for a scalar expr to pass in
+
+    from hvantk.algorithms.annotation.transforms import _agg_for
+
+    with pytest.raises(ValueError, match="unknown stat token"):
+        _agg_for("median", hl.float64(1.0))
+
+
+def _variant_ht():
+    import hail as hl
+
+    # 3 variants: v1/v2 missense in ENSG_A; v3 stop-gain (aaalt X) -> filtered out.
+    # REVEL_score is a per-transcript dict; the two transcript values are equal (broadcast).
+    rows = [
+        {
+            "locus": hl.locus("chr1", 100, "GRCh38"),
+            "alleles": ["A", "C"],
+            "aaref": "M",
+            "aaalt": "T",
+            "Ensembl_geneid": "ENSG_A;ENSG_A",
+            "REVEL_score": {"t1": 0.9, "t2": 0.9},
+            "MPC_score": {"t1": 2.0, "t2": 2.0},
+            "CADD_phred": {"t1": 25.0, "t2": 25.0},
+        },
+        {
+            "locus": hl.locus("chr1", 200, "GRCh38"),
+            "alleles": ["G", "T"],
+            "aaref": "R",
+            "aaalt": "Q",
+            "Ensembl_geneid": "ENSG_A;ENSG_B",
+            "REVEL_score": {"t1": 0.1, "t2": 0.1},
+            "MPC_score": {"t1": 0.5, "t2": 0.5},
+            "CADD_phred": {"t1": 5.0, "t2": 5.0},
+        },
+        {
+            "locus": hl.locus("chr1", 300, "GRCh38"),
+            "alleles": ["C", "A"],
+            "aaref": "W",
+            "aaalt": "X",
+            "Ensembl_geneid": "ENSG_A",
+            "REVEL_score": {"t1": 0.99},
+            "MPC_score": {"t1": 3.0},
+            "CADD_phred": {"t1": 40.0},
+        },
+    ]
+    return hl.Table.parallelize(
+        rows,
+        hl.tstruct(
+            locus=hl.tlocus("GRCh38"),
+            alleles=hl.tarray(hl.tstr),
+            aaref=hl.tstr,
+            aaalt=hl.tstr,
+            Ensembl_geneid=hl.tstr,
+            REVEL_score=hl.tdict(hl.tstr, hl.tfloat64),
+            MPC_score=hl.tdict(hl.tstr, hl.tfloat64),
+            CADD_phred=hl.tdict(hl.tstr, hl.tfloat64),
+        ),
+        key=["locus", "alleles"],
+    )
+
+
+def _agg_spec():
+    from hvantk.algorithms.annotation.spec import AggregateSpec, ScoreSpec
+
+    return AggregateSpec(
+        by="Ensembl_geneid",
+        to="gene_id",
+        filter="missense",
+        reduce="max",
+        scores=(
+            ScoreSpec("revel", "REVEL_score", ("mean", "max", "frac_gt_0.5")),
+            ScoreSpec("mpc", "MPC_score", ("mean", "max")),
+            ScoreSpec("cadd", "CADD_phred", ("mean", "max")),
+        ),
+    )
+
+
+@pytest.mark.hail
+def test_aggregate_to_gene_collapses_missense_variants_per_gene(hail_session):
+    import hail as hl
+
+    from hvantk.algorithms.annotation.transforms import aggregate_to_gene
+
+    grouped = aggregate_to_gene(_variant_ht(), _agg_spec())
+    assert list(grouped.key) == ["Ensembl_geneid"]
+    assert set(grouped.row) == {
+        "Ensembl_geneid",
+        "revel_mean",
+        "revel_max",
+        "revel_frac_gt_0.5",
+        "mpc_mean",
+        "mpc_max",
+        "cadd_mean",
+        "cadd_max",
+        "n_possible_missense",
+    }
+    d = {r.Ensembl_geneid: r for r in grouped.collect()}
+    # ENSG_A: v1(0.9) and v2(0.1) are missense; v3(stop-gain) filtered out.
+    assert d["ENSG_A"].n_possible_missense == 2
+    assert d["ENSG_A"].revel_max == pytest.approx(0.9)
+    assert d["ENSG_A"].revel_mean == pytest.approx(0.5)
+    assert d["ENSG_A"]["revel_frac_gt_0.5"] == pytest.approx(0.5)  # 1 of 2 > 0.5
+    # ENSG_B: only v2 (0.1).
+    assert d["ENSG_B"].n_possible_missense == 1
+    assert d["ENSG_B"].revel_max == pytest.approx(0.1)
+
+
+@pytest.mark.hail
+def test_stop_gain_and_stop_loss_are_excluded(hail_session):
+    import hail as hl
+
+    from hvantk.algorithms.annotation.transforms import PREDICATES
+
+    ht = _variant_ht()
+    missense = ht.filter(PREDICATES["missense"](ht))
+    # v3 (aaalt == "X") is the only non-missense row.
+    assert missense.count() == 2

--- a/hvantk/tools/annotation/annotate_cli.py
+++ b/hvantk/tools/annotation/annotate_cli.py
@@ -81,7 +81,10 @@ def prepare_cmd(spec, axis, input_path, spine, output, hgnc_path):
     import hail as hl
 
     from hvantk.algorithms.annotation.mapping import enforce_rate
-    from hvantk.algorithms.annotation.prepare import prepare_source
+    from hvantk.algorithms.annotation.prepare import (
+        prepare_source,
+        prepare_variant_source,
+    )
     from hvantk.algorithms.annotation.spec import load_spec
     from hvantk.core.utils.hail_context import init_hail
 
@@ -91,18 +94,27 @@ def prepare_cmd(spec, axis, input_path, spine, output, hgnc_path):
     source_ht = hl.read_table(input_path)
     spine_ids = hl.read_table(spine).gene_id.collect()
 
+    needs_hgnc = entry.key in ("hgnc_id", "symbol") or (
+        entry.key == "variant"
+        and entry.aggregate is not None
+        and entry.aggregate.to != "gene_id"
+    )
     hgnc = None
-    if entry.key != "gene_id":
+    if needs_hgnc:
         if not hgnc_path:
             raise click.UsageError(
-                f"entry {entry.source!r} has key {entry.key!r}; pass --hgnc <hgnc:lookup .ht>"
+                f"entry {entry.source!r} needs --hgnc <hgnc:lookup .ht>"
             )
         from hvantk.skills.hgnc.streamers import HGNCGeneCatalogStreamer
 
         hgnc = HGNCGeneCatalogStreamer.from_path(hgnc_path)
 
-    prepared, report = prepare_source(source_ht, spine_ids, entry, hgnc=hgnc)
-    enforce_rate(report, entry.min_mapping_rate)  # raises MappingRateError if too low
+    if entry.key == "variant":
+        prepared, report = prepare_variant_source(
+            source_ht, spine_ids, entry, hgnc=hgnc
+        )
+    else:
+        prepared, report = prepare_source(source_ht, spine_ids, entry, hgnc=hgnc)
+    enforce_rate(report, entry.min_mapping_rate)
     prepared.write(output, overwrite=True)
-
     click.echo(f"prepare {axis} ({entry.source}): {report.summary()} -> {output}")


### PR DESCRIPTION
## P2c-3 — dbNSFP variant→gene "tolerance" aggregation (Layer 1)

The first **variant-level** source in the gene-feature-matrix rebuild: the design's **Layer-1 `tolerance` axis** — per-gene mean/max/frac_gt of REVEL/MPC/CADD over **all possible missense** in `dbnsfp:variants`, as a `gene_id`-keyed prepared artifact that composes onto the spine like every other source. A *new* gene-intrinsic feature (the ablation decides whether it adds over constraint); it reproduces no manuscript number by design — the cohort `varagg` features are Layer 2 / P4.

### What changed (6 commits)
- **`transforms.py`** (new) — the aggregation vocabulary: a `missense` predicate (from `aaref`/`aaalt`; no VEP consequence column exists), a `max`-over-transcript-dict reducer (dbNSFP scores are per-transcript dicts), the `mean`/`max`/`min`/`count`/`frac_gt_<thr>` stat vocab (real Hail aggregators only), and `aggregate_to_gene` (filter → reduce → explode `Ensembl_geneid` → group-by-gene stats + `n_possible_missense`).
- **Spec** — `key: "variant"` + an `aggregate` block (`by`/`to`/`filter`/`reduce`/`scores`), `AggregateSpec`/`ScoreSpec` dataclasses, an `if/then` requiring aggregate for variant keys, and the `tolerance` entry.
- **`prepare_variant_source`** — extracts `prepare_source`'s mapper/re-key tail into shared helpers (behaviour-preserving; the gene_id branch is byte-identical), aggregates a variant source, then reconciles `Ensembl_geneid` → spine via `from_gene_ids`.
- **CLI** — `prepare_cmd` dispatches `key == "variant"` → `prepare_variant_source`; a `variant`+`to: gene_id` entry needs no `--hgnc`.

### Variant→gene mapping
Uses **dbNSFP's own `Ensembl_geneid`** (it already computed `aaref`/`aaalt` per transcript, so it knows each missense's gene), reconciled onto the release-113 spine via the existing `from_gene_ids` mapper. This **supersedes design §6's coordinate→interval wording** (the spine has only whole-gene spans, which overlap → an interval join would misattribute missense). The cross-release gap is measured + gated (GeVIR pattern), not fatal.

### Exit gate (Slurm, Hail local — job 18618812, exit 0)
All new hail-marked tests (`aggregate_to_gene`, `prepare_variant_source`) + the 4 repo invariants pass; then the **full transform on the chr21 subset** of the real dbNSFP 4.9a HT:

| check | result |
|---|---|
| genes aggregated onto spine (chr21) | **215** |
| mapping rate (`Ensembl_geneid` → spine) | **0.9389** (in the expected ~0.92–0.97 band) |
| gene_id-keyed, columns == entry.columns, `revel_mean` present | ✅ |
| one row per gene (arity invariant) | ✅ 215==215 |

The full genome-wide aggregation is the design's "cache paid once" — a **separately-submitted Tier-2 job**, not this gate; the chr21 subset proves the mechanism + invariants fast.

### Reviews / safety
Each of the 6 commits passed an independent task review; whole-branch review (opus) = **merge-ready, 0 Critical / 0 Important**. The one substantive Minor it raised — the `frac_gt` denominator (implementation used *all* variants; the research brief wanted *scored* variants, consistent with `mean`) — was **fixed** (`hl.agg.filter(is_defined, fraction(>thr))`) and re-validated on the gate. Layering (transforms = hail+stdlib; `algorithms/` never imports `skills`), jsonschema-3.2.0/Draft7 safety (independently verified with `Draft7Validator`), one-row-per-gene, and behaviour-preservation of `prepare_source` all hold. **No dataset added** → `EXPECTED_DATASETS`/plugin-contract unchanged.

### Deferred (follow-ups, non-blocking)
Tier-2 full-genome aggregation cache; a stop-loss fixture row; a `checkpoint` for the Tier-2 pass; the dbNSFP catalog "4.7"→"4.9a" + `jsonschema>=4` hygiene items.
