### PR TITLE
P2c-4a: expression matrix→gene reducer + Asp 2019 single-cell atlas

### DIFF
--- a/hvantk/algorithms/annotation/matrix.py
+++ b/hvantk/algorithms/annotation/matrix.py
@@ -4,8 +4,14 @@ Layering: pandas/numpy/anndata + stdlib only, plus sibling ``hvantk.algorithms``
 ``hvantk.skills``/``hvantk.tools``. The atlas arrives as data (an AnnData handed in by the caller).
 The reduced table then rides the existing P2c-2 ``key: symbol`` path onto the spine.
 
-Specificity is the EWCE fraction ``mean_group / sum_groups(mean)`` (the metric the manuscript used;
-the only one that reproduces the locked expression numbers).
+The per-group means this reducer consumes are produced by ``scanpy.get.aggregate`` (wrapped in
+``hvantk.algorithms.expression.matrix_utils.summarize``) -- i.e. the pseudobulk aggregation is a
+library call, not hand-rolled. Only the specificity *normalization* lives here: the EWCE fraction
+``mean_group / sum_groups(mean)`` (the metric the manuscript used; the only one that reproduces the
+locked expression numbers). No maintained dependency implements that exact L1 proportion -- scanpy
+has no specificity fn (its ``rank_genes_groups`` is DE markers on raw cells), and ``tspex``'s
+per-tissue ``spm`` is an L2/cosine metric, so both give different numbers. It is kept inline as a
+definitional row-normalization by design (confirmed with the user 2026-07-24).
 """
 from __future__ import annotations
 

--- a/hvantk/algorithms/annotation/matrix.py
+++ b/hvantk/algorithms/annotation/matrix.py
@@ -80,9 +80,17 @@ def reduce_matrix_to_gene(adata, mspec):
                 f"specificity targets {targets} not found among groups {list(spec_gg.columns)}"
             )
         tgt = spec_gg[present]
-        combined = (
-            tgt.max(axis=1) if mspec.specificity.combine == "max" else tgt.mean(axis=1)
-        )
+        combine = mspec.specificity.combine
+        if combine == "sum":
+            # Cell-CLASS specificity (EWCE level 1): the targets are subtypes of one class
+            # (e.g. atrial/ventricular/Myoz2 cardiomyocytes), so pool their fractions ->
+            # fraction of the gene's expression that is in the class. A pan-class gene
+            # (split across subtypes) reads high, which 'max' (peak single subtype) misses.
+            combined = tgt.sum(axis=1)
+        elif combine == "mean":
+            combined = tgt.mean(axis=1)
+        else:  # 'max' -- peak specificity to any single target
+            combined = tgt.max(axis=1)
         cols[f"{mspec.atlas}_{mspec.specificity.name}"] = combined
 
     out = pd.DataFrame(cols)

--- a/hvantk/algorithms/annotation/matrix.py
+++ b/hvantk/algorithms/annotation/matrix.py
@@ -1,0 +1,96 @@
+"""Reduce an expression summary (groups x genes) to a symbol-keyed per-gene feature table.
+
+Layering: pandas/numpy/anndata + stdlib only, plus sibling ``hvantk.algorithms`` modules; never
+``hvantk.skills``/``hvantk.tools``. The atlas arrives as data (an AnnData handed in by the caller).
+The reduced table then rides the existing P2c-2 ``key: symbol`` path onto the spine.
+
+Specificity is the EWCE fraction ``mean_group / sum_groups(mean)`` (the metric the manuscript used;
+the only one that reproduces the locked expression numbers).
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
+def _san(label: str) -> str:
+    """Column-safe token from a group label: lowercase, non-alnum -> single underscore."""
+    return re.sub(
+        r"_+", "_", re.sub(r"[^0-9a-zA-Z]+", "_", label.strip().lower())
+    ).strip("_")
+
+
+def ewce_specificity(mean_gg):
+    """Row-normalized mean expression: spec[g, k] = mean[g, k] / sum_k mean[g, :].
+
+    ``mean_gg`` is a genes x groups DataFrame. A gene with zero total mean (expressed nowhere)
+    maps to 0 in every group (not NaN), so it reads as non-specific rather than missing.
+    """
+    row_sums = mean_gg.sum(axis=1)
+    return mean_gg.div(row_sums.where(row_sums > 0), axis=0).fillna(0.0)
+
+
+def _layer_genes_by_group(adata, name, keep_idx, groups):
+    """Extract a layer as a genes x groups DataFrame (the summary stores groups x genes)."""
+    import numpy as np
+    import pandas as pd
+
+    m = adata.layers[name]
+    m = m.toarray() if hasattr(m, "toarray") else np.asarray(m)
+    return pd.DataFrame(
+        m[keep_idx, :].T,
+        index=list(adata.var.index),
+        columns=[groups[i] for i in keep_idx],
+    )
+
+
+def reduce_matrix_to_gene(adata, mspec):
+    """Reduce a summary AnnData to a symbol-keyed per-gene feature table.
+
+    Returns a DataFrame with a ``symbol`` column and the feature columns, one row per gene.
+    """
+    import pandas as pd
+
+    groups = [str(g).strip() for g in adata.obs.index]
+    drop = {str(g).strip() for g in mspec.drop_groups}
+    keep_idx = [i for i, g in enumerate(groups) if g not in drop]
+
+    mean_gg = _layer_genes_by_group(adata, "mean", keep_idx, groups)
+    cols = {}
+
+    for stat in mspec.stats:
+        layer = "fraction_expressed" if stat in ("fraction_expressed", "frac") else stat
+        df = (
+            mean_gg
+            if layer == "mean"
+            else _layer_genes_by_group(adata, layer, keep_idx, groups)
+        )
+        stat_tag = "frac" if layer == "fraction_expressed" else layer
+        for g in df.columns:
+            cols[f"{mspec.atlas}_{_san(g)}_{stat_tag}"] = df[g]
+
+    if mspec.specificity is not None:
+        spec_gg = ewce_specificity(mean_gg)
+        targets = [t.strip() for t in mspec.specificity.targets]
+        present = [c for c in spec_gg.columns if c in targets]
+        if not present:
+            raise ValueError(
+                f"specificity targets {targets} not found among groups {list(spec_gg.columns)}"
+            )
+        tgt = spec_gg[present]
+        combined = (
+            tgt.max(axis=1) if mspec.specificity.combine == "max" else tgt.mean(axis=1)
+        )
+        cols[f"{mspec.atlas}_{mspec.specificity.name}"] = combined
+
+    out = pd.DataFrame(cols)
+    out.index.name = "symbol"
+    out = out.groupby(
+        level=0
+    ).max()  # one row per gene; duplicate symbols collapse to max
+    logger.info(
+        "reduce_matrix_to_gene: %d genes, %d feature columns", len(out), out.shape[1]
+    )
+    return out.reset_index()

--- a/hvantk/algorithms/annotation/matrix.py
+++ b/hvantk/algorithms/annotation/matrix.py
@@ -65,6 +65,8 @@ def reduce_matrix_to_gene(adata, mspec):
 
     mean_gg = _layer_genes_by_group(adata, "mean", keep_idx, groups)
     cols = {}
+    # sanitized column name -> source group label, to catch _san collisions
+    col_origin = {}
 
     for stat in mspec.stats:
         layer = "fraction_expressed" if stat in ("fraction_expressed", "frac") else stat
@@ -75,17 +77,29 @@ def reduce_matrix_to_gene(adata, mspec):
         )
         stat_tag = "frac" if layer == "fraction_expressed" else layer
         for g in df.columns:
-            cols[f"{mspec.atlas}_{_san(g)}_{stat_tag}"] = df[g]
+            key = f"{mspec.atlas}_{_san(g)}_{stat_tag}"
+            if key in col_origin:
+                raise ValueError(
+                    f"group labels {col_origin[key]!r} and {g!r} both sanitize to column "
+                    f"{key!r}; rename a group or use drop_groups to disambiguate"
+                )
+            col_origin[key] = g
+            cols[key] = df[g]
 
     if mspec.specificity is not None:
         spec_gg = ewce_specificity(mean_gg)
         targets = [t.strip() for t in mspec.specificity.targets]
-        present = [c for c in spec_gg.columns if c in targets]
-        if not present:
+        # Require EXACT coverage: a partially-present target set would silently pool the
+        # cell-class specificity over only the surviving subtypes (e.g. combine='sum' summing
+        # 1 of 3 cardiomyocyte subtypes), under-reporting every pan-class gene with no error.
+        missing = [t for t in targets if t not in spec_gg.columns]
+        if missing:
             raise ValueError(
-                f"specificity targets {targets} not found among groups {list(spec_gg.columns)}"
+                f"specificity targets {missing} absent from groups {list(spec_gg.columns)} "
+                f"(after strip/drop_groups); a partial target set would under-pool the "
+                f"cell-class specificity -- fix the spec or the atlas"
             )
-        tgt = spec_gg[present]
+        tgt = spec_gg[targets]
         combine = mspec.specificity.combine
         if combine == "sum":
             # Cell-CLASS specificity (EWCE level 1): the targets are subtypes of one class

--- a/hvantk/algorithms/annotation/prepare.py
+++ b/hvantk/algorithms/annotation/prepare.py
@@ -116,7 +116,9 @@ def prepare_matrix_source(matrix_ad, spine_gene_ids, entry, *, hgnc=None):
     """Reduce an expression-matrix AnnData to per-gene features, then reconcile onto the spine.
 
     ``entry.matrix`` declares the reduction (group axis, per-group stats, EWCE specificity). The
-    reduced table is symbol-keyed and rides the existing symbol resolve+rekey tail onto gene_id.
+    reduced table is symbol-keyed; it rides the existing symbol resolve step onto gene_id, then
+    collapses symbol-collisions (two symbols -> one gene) by max rather than raising, because a
+    matrix is a matrix->gene reduction (see :func:`_collapse_matrix_onto_gene_id`).
     """
     import hail as hl
 
@@ -139,11 +141,33 @@ def prepare_matrix_source(matrix_ad, spine_gene_ids, entry, *, hgnc=None):
     resolved, report = _resolve_to_gene_id(
         grouped.symbol.collect(), "symbol", entry.source, mapper
     )
-    prepared = _rekey_onto_gene_id(
+    prepared = _collapse_matrix_onto_gene_id(
         grouped, "symbol", resolved, entry.columns, entry.source
     )
     logger.info(report.summary())
     return prepared, report
+
+
+def _collapse_matrix_onto_gene_id(source_ht, key_col, resolved, columns, source_label):
+    """Attach gene_id, drop unresolved, and collapse symbol-collisions onto one row per gene.
+
+    Two distinct symbols can resolve to one ``gene_id`` (HGNC aliases / previous symbols). For a
+    plain gene table that is an error -- there is no combine rule -- so :func:`_rekey_onto_gene_id`
+    raises. An expression matrix, however, is a matrix->gene reduction: colliding symbols are
+    combined by ``max``, matching the reducer's own duplicate-symbol collapse
+    (:func:`hvantk.algorithms.annotation.matrix.reduce_matrix_to_gene`). All P2c-4 matrix features
+    (EWCE specificity, fraction expressed, mean expression) are "larger = more signal", so taking
+    the max keeps the strongest evidence when one gene carries two symbol rows.
+    """
+    import hail as hl
+
+    lut = hl.literal(resolved)
+    attached = source_ht.annotate(gene_id=lut.get(source_ht[key_col]))
+    attached = attached.filter(hl.is_defined(attached.gene_id))
+    collapsed = attached.group_by(attached.gene_id).aggregate(
+        **{c: hl.agg.max(attached[c]) for c in columns}
+    )
+    return collapsed
 
 
 def prepare_variant_source(source_ht, spine_gene_ids, entry, *, hgnc=None):

--- a/hvantk/algorithms/annotation/prepare.py
+++ b/hvantk/algorithms/annotation/prepare.py
@@ -112,6 +112,40 @@ def _rekey_onto_gene_id(source_ht, key_col, resolved, columns, source_label):
     return prepared
 
 
+def prepare_matrix_source(matrix_ad, spine_gene_ids, entry, *, hgnc=None):
+    """Reduce an expression-matrix AnnData to per-gene features, then reconcile onto the spine.
+
+    ``entry.matrix`` declares the reduction (group axis, per-group stats, EWCE specificity). The
+    reduced table is symbol-keyed and rides the existing symbol resolve+rekey tail onto gene_id.
+    """
+    import hail as hl
+
+    from hvantk.algorithms.annotation import matrix as matrix_mod
+
+    if entry.matrix is None:
+        raise ValueError(
+            f"entry {entry.source!r} prepared as matrix but has no matrix block"
+        )
+    if hgnc is None:
+        raise ValueError(
+            f"entry {entry.source!r} is a symbol-keyed matrix source; needs the HGNC streamer"
+        )
+
+    df = matrix_mod.reduce_matrix_to_gene(
+        matrix_ad, entry.matrix
+    )  # 'symbol' + feature cols
+    grouped = hl.Table.from_pandas(df, key=["symbol"])
+    mapper = GeneIdMapper(hgnc, set(spine_gene_ids))
+    resolved, report = _resolve_to_gene_id(
+        grouped.symbol.collect(), "symbol", entry.source, mapper
+    )
+    prepared = _rekey_onto_gene_id(
+        grouped, "symbol", resolved, entry.columns, entry.source
+    )
+    logger.info(report.summary())
+    return prepared, report
+
+
 def prepare_variant_source(source_ht, spine_gene_ids, entry, *, hgnc=None):
     """Aggregate a variant source to per-gene stats, then reconcile onto the spine.
 

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -43,6 +43,24 @@ class AggregateSpec:
 
 
 @dataclass(frozen=True)
+class SpecificitySpec:
+    method: str
+    targets: tuple[str, ...]
+    combine: str = "max"
+    name: str = "spec"
+
+
+@dataclass(frozen=True)
+class MatrixSpec:
+    group_axis: str
+    atlas: str
+    tissue_tag: str | None = None
+    stats: tuple[str, ...] = ()
+    drop_groups: tuple[str, ...] = ()
+    specificity: SpecificitySpec | None = None
+
+
+@dataclass(frozen=True)
 class SourceEntry:
     axis: str
     source: str
@@ -52,6 +70,7 @@ class SourceEntry:
     origin: str | None = None
     ablate_separately: bool = False
     aggregate: AggregateSpec | None = None
+    matrix: MatrixSpec | None = None
 
 
 @dataclass(frozen=True)
@@ -82,6 +101,30 @@ def _build_aggregate(raw: dict | None) -> AggregateSpec | None:
     )
 
 
+def _build_matrix(raw: dict | None) -> MatrixSpec | None:
+    if raw is None:
+        return None
+    specificity_raw = raw.get("specificity")
+    specificity = (
+        None
+        if specificity_raw is None
+        else SpecificitySpec(
+            method=specificity_raw["method"],
+            targets=tuple(specificity_raw["targets"]),
+            combine=specificity_raw.get("combine", "max"),
+            name=specificity_raw.get("name", "spec"),
+        )
+    )
+    return MatrixSpec(
+        group_axis=raw["group_axis"],
+        atlas=raw["atlas"],
+        tissue_tag=raw.get("tissue_tag"),
+        stats=tuple(raw.get("stats", ())),
+        drop_groups=tuple(raw.get("drop_groups", ())),
+        specificity=specificity,
+    )
+
+
 def load_spec(path: str | Path) -> FeatureSpec:
     """Read a feature-spec YAML, validate it against the schema, and return a FeatureSpec.
 
@@ -90,8 +133,10 @@ def load_spec(path: str | Path) -> FeatureSpec:
     jsonschema.ValidationError
         If the document does not conform to feature_spec.schema.json.
     ValueError
-        If two layer1 entries share an axis label, or an entry's ``key`` and ``aggregate``
-        presence disagree (``key == "variant"`` requires ``aggregate`` and vice versa).
+        If two layer1 entries share an axis label, an entry's ``key`` and ``aggregate``
+        presence disagree (``key == "variant"`` requires ``aggregate`` and vice versa), or an
+        entry has a ``matrix`` block with ``key`` other than ``"symbol"`` (the reduced table
+        the matrix reducer produces is symbol-keyed).
     """
     doc = yaml.safe_load(Path(path).read_text())
     jsonschema.validate(doc, _schema())  # raises ValidationError on failure
@@ -105,6 +150,7 @@ def load_spec(path: str | Path) -> FeatureSpec:
             origin=e.get("origin"),
             ablate_separately=e.get("ablate_separately", False),
             aggregate=_build_aggregate(e.get("aggregate")),
+            matrix=_build_matrix(e.get("matrix")),
         )
         for e in doc["layer1"]
     )
@@ -119,5 +165,11 @@ def load_spec(path: str | Path) -> FeatureSpec:
         if (e.key == "variant") != (e.aggregate is not None):
             raise ValueError(
                 f"entry {e.source!r}: key 'variant' requires an aggregate block and vice versa"
+            )
+    for e in entries:
+        if e.matrix is not None and e.key != "symbol":
+            raise ValueError(
+                f"entry {e.source!r} has a matrix block, which requires key: symbol "
+                f"(the reduced table is symbol-keyed); got key {e.key!r}"
             )
     return FeatureSpec(name=doc["name"], layer1=entries)

--- a/hvantk/resources/schemas/feature_spec.schema.json
+++ b/hvantk/resources/schemas/feature_spec.schema.json
@@ -42,10 +42,41 @@
         "min_mapping_rate": {"type": "number", "minimum": 0, "maximum": 1},
         "origin": {"type": "string"},
         "ablate_separately": {"type": "boolean"},
-        "aggregate": {"$ref": "#/$defs/aggregateSpec"}
+        "aggregate": {"$ref": "#/$defs/aggregateSpec"},
+        "matrix": {"$ref": "#/$defs/matrixSpec"}
       },
       "if": {"properties": {"key": {"const": "variant"}}, "required": ["key"]},
       "then": {"required": ["aggregate"]}
+    },
+    "matrixSpec": {
+      "type": "object",
+      "required": ["group_axis", "atlas"],
+      "additionalProperties": false,
+      "properties": {
+        "group_axis": {"type": "string", "minLength": 1},
+        "atlas": {"type": "string", "minLength": 1},
+        "tissue_tag": {"type": "string"},
+        "stats": {
+          "type": "array",
+          "items": {"type": "string", "enum": ["mean", "fraction_expressed", "frac"]}
+        },
+        "drop_groups": {"type": "array", "items": {"type": "string"}},
+        "specificity": {
+          "type": "object",
+          "required": ["method", "targets"],
+          "additionalProperties": false,
+          "properties": {
+            "method": {"type": "string", "enum": ["ewce_fraction"]},
+            "targets": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"type": "string", "minLength": 1}
+            },
+            "combine": {"type": "string", "enum": ["max", "mean"]},
+            "name": {"type": "string", "minLength": 1}
+          }
+        }
+      }
     },
     "aggregateSpec": {
       "type": "object",

--- a/hvantk/resources/schemas/feature_spec.schema.json
+++ b/hvantk/resources/schemas/feature_spec.schema.json
@@ -72,7 +72,7 @@
               "minItems": 1,
               "items": {"type": "string", "minLength": 1}
             },
-            "combine": {"type": "string", "enum": ["max", "mean"]},
+            "combine": {"type": "string", "enum": ["max", "mean", "sum"]},
             "name": {"type": "string", "minLength": 1}
           }
         }

--- a/hvantk/tests/annotation/test_matrix.py
+++ b/hvantk/tests/annotation/test_matrix.py
@@ -1,0 +1,82 @@
+"""matrix.py: EWCE specificity + summary-AnnData -> per-gene table."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def test_ewce_specificity_is_row_normalized_mean():
+    from hvantk.algorithms.annotation.matrix import ewce_specificity
+
+    # gene X: mean 3 in group A, 1 in B -> spec 0.75/0.25; gene Y: 0 everywhere -> 0.
+    mean_gg = pd.DataFrame({"A": [3.0, 0.0], "B": [1.0, 0.0]}, index=["X", "Y"])
+    spec = ewce_specificity(mean_gg)
+    assert spec.loc["X", "A"] == pytest.approx(0.75)
+    assert spec.loc["X", "B"] == pytest.approx(0.25)
+    assert spec.loc["Y", "A"] == pytest.approx(0.0)  # unexpressed gene -> 0, not NaN
+
+
+def _summary_adata():
+    import anndata as ad
+
+    # 2 groups x 3 genes. group ' CM ' (whitespace) is the specificity target.
+    genes = ["TNNT2", "ACTB", "DUP"]
+    groups = [" CM ", "Other"]
+    mean = np.array([[10.0, 5.0, 4.0], [0.0, 5.0, 4.0]])  # groups x genes
+    frac = np.array([[0.9, 0.8, 0.7], [0.1, 0.8, 0.7]])
+    a = ad.AnnData(
+        X=None,
+        obs=pd.DataFrame({"celltype": groups, "n_cells": [100, 200]}, index=groups),
+        var=pd.DataFrame(index=genes),
+        layers={"mean": mean, "fraction_expressed": frac},
+    )
+    return a
+
+
+def _mspec(stats=(), targets=("CM",), name="cm_spec"):
+    from hvantk.algorithms.annotation.spec import MatrixSpec, SpecificitySpec
+
+    return MatrixSpec(
+        group_axis="celltype",
+        atlas="asp",
+        tissue_tag="cardiac",
+        stats=tuple(stats),
+        drop_groups=(),
+        specificity=SpecificitySpec(
+            method="ewce_fraction", targets=tuple(targets), combine="max", name=name
+        ),
+    )
+
+
+def test_reduce_emits_specificity_and_strips_group_whitespace():
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+
+    df = reduce_matrix_to_gene(_summary_adata(), _mspec())
+    assert list(df.columns) == ["symbol", "asp_cm_spec"]
+    row = df.set_index("symbol")
+    # TNNT2: mean 10 in CM, 0 in Other -> spec 1.0. ACTB: 5/5 -> 0.5.
+    assert row.loc["TNNT2", "asp_cm_spec"] == pytest.approx(1.0)
+    assert row.loc["ACTB", "asp_cm_spec"] == pytest.approx(0.5)
+
+
+def test_reduce_collapses_duplicate_symbols_with_max():
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+
+    a = _summary_adata()
+    a.var_names = ["TNNT2", "ACTB", "TNNT2"]  # DUP renamed to a duplicate TNNT2
+    df = reduce_matrix_to_gene(a, _mspec()).set_index("symbol")
+    assert df.index.is_unique  # one row per symbol
+    # the two TNNT2 rows (spec 1.0 and 0.5) collapse to max 1.0
+    assert df.loc["TNNT2", "asp_cm_spec"] == pytest.approx(1.0)
+
+
+def test_reduce_emits_per_group_stats_when_declared():
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+
+    df = reduce_matrix_to_gene(_summary_adata(), _mspec(stats=("mean",))).set_index(
+        "symbol"
+    )
+    # per-group mean columns, group label sanitized (' CM ' -> 'cm'); plus the specificity col
+    assert "asp_cm_mean" in df.columns and "asp_other_mean" in df.columns
+    assert df.loc["TNNT2", "asp_cm_mean"] == pytest.approx(10.0)

--- a/hvantk/tests/annotation/test_matrix.py
+++ b/hvantk/tests/annotation/test_matrix.py
@@ -107,6 +107,38 @@ def test_reduce_sum_combine_pools_subtype_fractions_for_a_cell_class():
     assert row.loc["SPECIFIC", "asp_cm_spec"] == pytest.approx(1.0)
 
 
+def test_reduce_raises_when_a_declared_specificity_target_is_absent():
+    # A partially-present target set must fail loudly, not silently pool over the survivors
+    # (which would under-report every pan-class gene's cell-class specificity).
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+
+    # _summary_adata has groups 'CM' and 'Other'; 'GHOST' is not present.
+    with pytest.raises(ValueError, match="GHOST"):
+        reduce_matrix_to_gene(_summary_adata(), _mspec(targets=("CM", "GHOST")))
+
+
+def test_reduce_raises_on_sanitized_group_label_collision():
+    import anndata as ad
+
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+    from hvantk.algorithms.annotation.spec import MatrixSpec
+
+    # 'T-cell' and 'T cell' both sanitize to 't_cell' -> the per-group stat columns would
+    # otherwise silently overwrite each other.
+    groups = ["T-cell", "T cell"]
+    a = ad.AnnData(
+        X=None,
+        obs=pd.DataFrame({"celltype": groups}, index=groups),
+        var=pd.DataFrame(index=["A", "B"]),
+        layers={"mean": np.array([[1.0, 2.0], [3.0, 4.0]])},
+    )
+    mspec = MatrixSpec(
+        group_axis="celltype", atlas="asp", stats=("mean",), specificity=None
+    )
+    with pytest.raises(ValueError, match="sanitize"):
+        reduce_matrix_to_gene(a, mspec)
+
+
 def test_reduce_emits_per_group_stats_when_declared():
     from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
 

--- a/hvantk/tests/annotation/test_matrix.py
+++ b/hvantk/tests/annotation/test_matrix.py
@@ -71,6 +71,42 @@ def test_reduce_collapses_duplicate_symbols_with_max():
     assert df.loc["TNNT2", "asp_cm_spec"] == pytest.approx(1.0)
 
 
+def test_reduce_sum_combine_pools_subtype_fractions_for_a_cell_class():
+    # A cell CLASS (e.g. cardiomyocytes) split across subtypes: combine='sum' pools the
+    # per-subtype EWCE fractions so a pan-class gene reads high; 'max' would take only the
+    # single strongest subtype and under-read it.
+    import anndata as ad
+
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+    from hvantk.algorithms.annotation.spec import MatrixSpec, SpecificitySpec
+
+    genes = ["PAN", "SPECIFIC"]
+    groups = ["CM_a", "CM_b", "Other"]
+    # PAN: expressed equally in both CM subtypes, nowhere else -> per-subtype spec 0.5, sum 1.0.
+    # SPECIFIC: only in CM_a -> per-subtype spec 1.0/0.0, sum 1.0, but max is also 1.0.
+    mean = np.array([[5.0, 5.0], [5.0, 0.0], [0.0, 0.0]])  # groups x genes
+    a = ad.AnnData(
+        X=None,
+        obs=pd.DataFrame({"celltype": groups}, index=groups),
+        var=pd.DataFrame(index=genes),
+        layers={"mean": mean},
+    )
+    mspec = MatrixSpec(
+        group_axis="celltype",
+        atlas="asp",
+        specificity=SpecificitySpec(
+            method="ewce_fraction",
+            targets=("CM_a", "CM_b"),
+            combine="sum",
+            name="cm_spec",
+        ),
+    )
+    row = reduce_matrix_to_gene(a, mspec).set_index("symbol")
+    # PAN pooled across both CM subtypes reads fully CM (0.5 + 0.5); 'max' would give only 0.5.
+    assert row.loc["PAN", "asp_cm_spec"] == pytest.approx(1.0)
+    assert row.loc["SPECIFIC", "asp_cm_spec"] == pytest.approx(1.0)
+
+
 def test_reduce_emits_per_group_stats_when_declared():
     from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
 

--- a/hvantk/tests/annotation/test_prepare.py
+++ b/hvantk/tests/annotation/test_prepare.py
@@ -306,3 +306,50 @@ def test_prepare_matrix_source_reduces_and_maps_onto_spine(hail_session):
     d = {r.gene_id: r.asp_cm_spec for r in prepared.collect()}
     assert d["ENSG_T"] == pytest.approx(1.0)  # TNNT2: CM-specific
     assert d["ENSG_A"] == pytest.approx(0.5)  # ACTB: ubiquitous
+
+
+@pytest.mark.hail
+def test_prepare_matrix_source_collapses_symbol_collisions_onto_one_gene(hail_session):
+    # Two distinct atlas symbols (an alias and its current symbol) resolve to ONE gene_id.
+    # Unlike a plain gene table, a matrix must combine them (by max), not raise.
+    import anndata as ad
+    import numpy as np
+    import pandas as pd
+
+    from hvantk.algorithms.annotation.prepare import prepare_matrix_source
+    from hvantk.algorithms.annotation.spec import (
+        MatrixSpec,
+        SpecificitySpec,
+        SourceEntry,
+    )
+
+    genes = ["TNNT2", "TNNT2_ALIAS"]  # both map to ENSG_T
+    a = ad.AnnData(
+        X=None,
+        obs=pd.DataFrame({"celltype": ["CM", "Other"]}, index=["CM", "Other"]),
+        var=pd.DataFrame(index=genes),
+        # TNNT2 fully CM-specific (spec 1.0); the alias row is ubiquitous (spec 0.5).
+        layers={"mean": np.array([[10.0, 5.0], [0.0, 5.0]])},
+    )
+    entry = SourceEntry(
+        axis="expr",
+        source="ucsc-cellbrowser:asp_2019",
+        key="symbol",
+        columns=("asp_cm_spec",),
+        matrix=MatrixSpec(
+            group_axis="celltype",
+            atlas="asp",
+            specificity=SpecificitySpec("ewce_fraction", ("CM",), "max", "cm_spec"),
+        ),
+    )
+    fake = _FakeHGNC(
+        canonical={"TNNT2": "TNNT2", "TNNT2_ALIAS": "TNNT2_ALIAS"},
+        symbol_to_hgnc={"TNNT2": "HGNC:T", "TNNT2_ALIAS": "HGNC:T"},
+        hgnc_to_ensembl={"HGNC:T": "ENSG_T"},
+    )
+    prepared, report = prepare_matrix_source(a, {"ENSG_T"}, entry, hgnc=fake)
+    assert list(prepared.key) == ["gene_id"]
+    assert prepared.count() == 1  # collapsed to one row, not raised
+    assert prepared.distinct().count() == 1
+    d = {r.gene_id: r.asp_cm_spec for r in prepared.collect()}
+    assert d["ENSG_T"] == pytest.approx(1.0)  # max(1.0 CM-specific, 0.5 ubiquitous)

--- a/hvantk/tests/annotation/test_prepare.py
+++ b/hvantk/tests/annotation/test_prepare.py
@@ -260,3 +260,49 @@ def test_prepare_source_gene_id_path_unchanged(hail_session):
     prepared, report = prepare_source(_source_ht(), {"ENSG1", "ENSG2"}, ENTRY)
     assert list(prepared.key) == ["gene_id"]
     assert sorted(prepared.gene_id.collect()) == ["ENSG1", "ENSG2"]
+
+
+@pytest.mark.hail
+def test_prepare_matrix_source_reduces_and_maps_onto_spine(hail_session):
+    import anndata as ad
+    import numpy as np
+    import pandas as pd
+
+    from hvantk.algorithms.annotation.prepare import prepare_matrix_source
+    from hvantk.algorithms.annotation.spec import (
+        MatrixSpec,
+        SpecificitySpec,
+        SourceEntry,
+    )
+
+    genes = ["TNNT2", "ACTB", "OFFGENE"]
+    a = ad.AnnData(
+        X=None,
+        obs=pd.DataFrame({"celltype": ["CM", "Other"]}, index=["CM", "Other"]),
+        var=pd.DataFrame(index=genes),
+        layers={"mean": np.array([[10.0, 5.0, 1.0], [0.0, 5.0, 1.0]])},
+    )
+    entry = SourceEntry(
+        axis="expr",
+        source="ucsc-cellbrowser:asp_2019",
+        key="symbol",
+        columns=("asp_cm_spec",),
+        matrix=MatrixSpec(
+            group_axis="celltype",
+            atlas="asp",
+            specificity=SpecificitySpec("ewce_fraction", ("CM",), "max", "cm_spec"),
+        ),
+    )
+    # HGNC fake: TNNT2/ACTB resolve onto the spine; OFFGENE resolves off-spine.
+    fake = _FakeHGNC(
+        canonical={"TNNT2": "TNNT2", "ACTB": "ACTB", "OFFGENE": "OFFGENE"},
+        symbol_to_hgnc={"TNNT2": "HGNC:T", "ACTB": "HGNC:A", "OFFGENE": "HGNC:O"},
+        hgnc_to_ensembl={"HGNC:T": "ENSG_T", "HGNC:A": "ENSG_A", "HGNC:O": "ENSG_OFF"},
+    )
+    prepared, report = prepare_matrix_source(a, {"ENSG_T", "ENSG_A"}, entry, hgnc=fake)
+    assert list(prepared.key) == ["gene_id"]
+    assert set(prepared.row) == {"gene_id", "asp_cm_spec"}
+    assert sorted(prepared.gene_id.collect()) == ["ENSG_A", "ENSG_T"]  # OFFGENE dropped
+    d = {r.gene_id: r.asp_cm_spec for r in prepared.collect()}
+    assert d["ENSG_T"] == pytest.approx(1.0)  # TNNT2: CM-specific
+    assert d["ENSG_A"] == pytest.approx(0.5)  # ACTB: ubiquitous

--- a/hvantk/tests/annotation/test_spec.py
+++ b/hvantk/tests/annotation/test_spec.py
@@ -280,3 +280,46 @@ def test_aggregate_on_a_non_variant_key_is_allowed_by_schema_but_ignored(tmp_pat
     p = tmp_path / "s.yaml"
     p.write_text(doc)
     assert load_spec(p).entry("c").aggregate is None
+
+
+def test_matrix_entry_parses(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    doc = (
+        "name: t\n"
+        "layer1:\n"
+        "  - axis: expr\n"
+        "    source: ucsc-cellbrowser:asp_2019\n"
+        "    key: symbol\n"
+        "    columns: [asp_cm_spec]\n"
+        "    matrix:\n"
+        "      group_axis: celltype\n"
+        "      atlas: asp\n"
+        "      tissue_tag: cardiac\n"
+        "      specificity: {method: ewce_fraction, targets: [Ventricular cardiomyocytes], combine: max, name: cm_spec}\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(doc)
+    e = load_spec(p).entry("expr")
+    assert e.matrix.group_axis == "celltype" and e.matrix.atlas == "asp"
+    assert e.matrix.specificity.method == "ewce_fraction"
+    assert e.matrix.specificity.targets == ("Ventricular cardiomyocytes",)
+    assert e.matrix.specificity.combine == "max"
+
+
+def test_matrix_requires_symbol_key(tmp_path):
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    doc = (
+        "name: t\n"
+        "layer1:\n"
+        "  - axis: expr\n"
+        "    source: s:a\n"
+        "    key: gene_id\n"
+        "    columns: [asp_cm_spec]\n"
+        "    matrix: {group_axis: celltype, atlas: asp}\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(doc)
+    with pytest.raises(ValueError, match="matrix"):
+        load_spec(p)

--- a/hvantk/tools/annotation/annotate_cli.py
+++ b/hvantk/tools/annotation/annotate_cli.py
@@ -82,6 +82,7 @@ def prepare_cmd(spec, axis, input_path, spine, output, hgnc_path):
 
     from hvantk.algorithms.annotation.mapping import enforce_rate
     from hvantk.algorithms.annotation.prepare import (
+        prepare_matrix_source,
         prepare_source,
         prepare_variant_source,
     )
@@ -91,7 +92,6 @@ def prepare_cmd(spec, axis, input_path, spine, output, hgnc_path):
     init_hail()
 
     entry = load_spec(spec).entry(axis)
-    source_ht = hl.read_table(input_path)
     spine_ids = hl.read_table(spine).gene_id.collect()
 
     needs_hgnc = entry.key in ("hgnc_id", "symbol") or (
@@ -109,11 +109,18 @@ def prepare_cmd(spec, axis, input_path, spine, output, hgnc_path):
 
         hgnc = HGNCGeneCatalogStreamer.from_path(hgnc_path)
 
-    if entry.key == "variant":
+    if entry.matrix is not None:
+        import anndata
+
+        matrix_ad = anndata.read_h5ad(input_path)
+        prepared, report = prepare_matrix_source(matrix_ad, spine_ids, entry, hgnc=hgnc)
+    elif entry.key == "variant":
+        source_ht = hl.read_table(input_path)
         prepared, report = prepare_variant_source(
             source_ht, spine_ids, entry, hgnc=hgnc
         )
     else:
+        source_ht = hl.read_table(input_path)
         prepared, report = prepare_source(source_ht, spine_ids, entry, hgnc=hgnc)
     enforce_rate(report, entry.min_mapping_rate)
     prepared.write(output, overwrite=True)

--- a/hvantk/tools/annotation/annotate_cli.py
+++ b/hvantk/tools/annotation/annotate_cli.py
@@ -64,7 +64,8 @@ def spine_cmd(gene_table, hgnc, output, biotype):
     "--input",
     "input_path",
     required=True,
-    help="Path to the built source AnnotationTable (.ht).",
+    help="Path to the built source: an AnnotationTable (.ht), or an AnnData (.h5ad) "
+    "for a matrix entry.",
 )
 @click.option("--spine", required=True, help="Path to the gene spine table (.ht).")
 @click.option(


### PR DESCRIPTION
## P2c-4a — expression matrix→gene reducer + Asp 2019 single-cell atlas

Extends `hvantk annotate prepare` to reduce an **expression matrix** (groups × genes summary AnnData) onto the canonical `gene_id` spine, and wires the first single-cell atlas (Asp 2019 fetal heart) through it. Sixth increment of the gene-feature-matrix rebuild (P2c series); follows #217 (GeVIR), #218 (retire `ensembl-gene:genes` + hgnc_id/symbol keys), #219 (dbNSFP variant→gene aggregation).

### What it adds
- **`algorithms/annotation/matrix.py`** (new, pure pandas/numpy — no Hail/skills/tools): `reduce_matrix_to_gene` collapses a summary AnnData to a symbol-keyed per-gene feature table. Per-cell-type EWCE specificity `spec[g,k] = mean[g,k] / Σ_k mean[g,:]`, combined over target subtypes by `max | mean | sum`.
- **`algorithms/annotation/spec.py`**: `MatrixSpec` / `SpecificitySpec` frozen dataclasses, `SourceEntry.matrix`, and a `load_spec` invariant (a `matrix` block requires `key: symbol`).
- **`algorithms/annotation/prepare.py`**: `prepare_matrix_source` — reduce → `hl.Table.from_pandas(key=symbol)` → resolve symbols→gene_id (existing P2c-2 path) → collapse symbol-collisions onto one row per gene.
- **`tools/annotation/annotate_cli.py`**: matrix entries read `.h5ad` via anndata; variant/gene entries read `hl.read_table`.
- **`resources/schemas/feature_spec.schema.json`**: `matrixSpec` `$def` + `combine` enum `[max, mean, sum]` (all Draft-7-safe; CI pins jsonschema 3.2.0).

No new plugin/dataset (the atlas is consumed from disk) — `EXPECTED_DATASETS` unchanged. The Asp spec entry lives in gitignored `local/`.

### Two real gaps the Slurm gate caught (fixed here)
1. **Symbol-collision collapse** (`f545cfe`) — two distinct atlas symbols (HGNC aliases / previous symbols) can resolve to one `gene_id`; this only surfaces *after* symbol→gene_id resolution, above the pure-pandas reducer. A matrix is a matrix→gene reduction with a declared combine, so colliding symbols now **combine by max** (mirroring the reducer's own duplicate-symbol collapse) instead of hitting the many-to-one guard. The plain gene-table path still raises (no combine rule there).
2. **`combine=sum` for cell-class specificity** (`f798b7d`) — the Asp atlas splits cardiomyocytes into 3 subtypes, so `combine=max` under-read pan-CM genes (TNNT2 0.37, picking one subtype). `sum` pools the subtype fractions (canonical EWCE level-1 cell-class specificity) → TNNT2 **0.938**.

### Library survey (scanpy / tspex)
Confirmed the pseudobulk aggregation is **already `scanpy.get.aggregate`** (via `matrix_utils.summarize` — that's what built the Asp summary this reducer consumes). scanpy has no `x/Σx` specificity function (its `rank_genes_groups` is DE markers on raw cells); `tspex` offers scalar τ / L2 `spm`. The EWCE L1 proportion has no exact maintained dependency and is the manuscript-reproducing metric, so it stays inline **by design** (documented in the module docstring).

### Final adversarial review
Whole-branch review (3 lenses × adversarial verify): **APPROVE-WITH-NITS**, 0 Critical. Two confirmed silent-data-loss traps the gate didn't exercise, both fixed in `8163024`:
- reducer now **fails loud on a partially-present target set** (was: silently pooled the survivors);
- reducer now **raises on `_san` group-label collisions** (was: silent column overwrite).
Each with a regression test.

### Validation (Slurm, Hail local mode, Java 11)
Asp summary → reduce → map onto the real spine:
- 14,000 genes, **one row per gene** (arity invariant clean)
- external-symbol **mapping rate 0.914** (Asp clone-name vars don't map — expected)
- **TNNT2 CM-spec 0.938 vs ACTB 0.026** (36× separation — biology sanity check)
- all annotation unit tests + the 4 repo invariants (dependency-directions, plugin-smoke, plugin-contract) pass

### Layering / CI
`algorithms/annotation/*` adds no `skills`/`tools` import; schema changes Draft-7-safe; black + flake8 (E9/F) clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
