### PR TITLE
fix(review): fail loud on ambiguous builder inputs + guard rerank feature assembly

### DIFF
--- a/hvantk/algorithms/rerank/engine.py
+++ b/hvantk/algorithms/rerank/engine.py
@@ -7,9 +7,13 @@ from hvantk.algorithms.rerank.reranker import ReRanker
 from hvantk.algorithms.rerank.tiers import TierAssigner
 from hvantk.algorithms.rerank.evaluator import Evaluator, EvalResult
 
+
 @dataclass
 class RerankResult:
-    table: pd.DataFrame; metrics: EvalResult; coverage: dict
+    table: pd.DataFrame
+    metrics: EvalResult
+    coverage: dict
+
 
 def rerank(config) -> RerankResult:
     validate(config)
@@ -19,47 +23,96 @@ def rerank(config) -> RerankResult:
     df = matrix.merge(prior, on="gene", how="left")
     df["y"] = df["gene"].isin(pos).astype(int)
     feat_cols = [c for c in matrix.columns if c != "gene"]
-    for c in feat_cols: df[c] = pd.to_numeric(df[c], errors="coerce")
+    if not feat_cols:
+        raise ValueError(
+            "no feature columns in the assembled matrix: every feature axis contributed only "
+            "a 'gene' column. Check the feature specs and that each axis table carries numeric "
+            "columns."
+        )
+    for c in feat_cols:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
     y = df["y"].values
     covered = sum(1 for g in pos if g in set(matrix["gene"]))
     if pos and covered / len(pos) < config.min_label_coverage:
         raise ValueError(
             f"label/feature join coverage too low: only {covered}/{len(pos)} "
-            f"({covered/len(pos):.0%}) positive units are in the feature matrix — likely a gene-symbol/build mismatch")
-    n_pos = int(y.sum()); n_neg = int(len(y) - n_pos)
+            f"({covered/len(pos):.0%}) positive units are in the feature matrix — likely a gene-symbol/build mismatch"
+        )
+    n_pos = int(y.sum())
+    n_neg = int(len(y) - n_pos)
     if min(n_pos, n_neg) < config.folds:
         raise ValueError(
             f"too few examples for {config.folds}-fold OOF: {n_pos} positive / {n_neg} negative units "
-            f"(need >= {config.folds} of each class). Provide more labels or lower Config.folds.")
+            f"(need >= {config.folds} of each class). Provide more labels or lower Config.folds."
+        )
     scores = ReRanker(config.calibration, config.folds).score(df, feat_cols, y)
     audit_table = df
     if config.cohort is not None:
         cohort_cols = config.cohort.load()
-        add = [c for c in cohort_cols.columns if c != "gene" and c not in audit_table.columns]
+        add = [
+            c
+            for c in cohort_cols.columns
+            if c != "gene" and c not in audit_table.columns
+        ]
         audit_table = df.merge(cohort_cols[["gene"] + add], on="gene", how="left")
     flag_reason = config.audit.apply(audit_table).reset_index(drop=True)
-    flag = (flag_reason != "")
-    tiers = TierAssigner(config.tiers).assign(scores)      # pure credibility, no flag input
-    groups = {ax.name: [c for c in ax.load().columns if c != "gene" and c in feat_cols] for ax in config.features}
+    flag = flag_reason != ""
+    tiers = TierAssigner(config.tiers).assign(scores)  # pure credibility, no flag input
+    groups = {
+        ax.name: [c for c in ax.load().columns if c != "gene" and c in feat_cols]
+        for ax in config.features
+    }
     groups = {k: v for k, v in groups.items() if v}
     baseline = next(iter(groups))
     metrics = Evaluator().evaluate(df, feat_cols, y, scores, groups, baseline)
-    table = pd.DataFrame({"gene": df.gene, "prior_stat": df.prior_stat, "score": scores,
-                          "flag": flag.values, "flag_reason": flag_reason.values, "y": y})
-    table = pd.concat([table.reset_index(drop=True), tiers.reset_index(drop=True)], axis=1)
+    table = pd.DataFrame(
+        {
+            "gene": df.gene,
+            "prior_stat": df.prior_stat,
+            "score": scores,
+            "flag": flag.values,
+            "flag_reason": flag_reason.values,
+            "y": y,
+        }
+    )
+    table = pd.concat(
+        [table.reset_index(drop=True), tiers.reset_index(drop=True)], axis=1
+    )
     table["score_percentile"] = (table["score"].rank(pct=True) * 100).round(1)
     # Append extra genes excluded from model scoring (e.g. HCAR1: too few case variants).
     # They are unscored and carry an advisory flag; they are NOT forced onto the tier ladder.
     if config.extra_flagged_genes:
         extra_y = {g: int(g in pos) for g in config.extra_flagged_genes}
-        extra_rows = pd.DataFrame([{
-            "gene": g, "prior_stat": float("nan"), "score": float("nan"),
-            "score_percentile": float("nan"), "flag": True,
-            "flag_reason": "insufficient_data", "y": extra_y.get(g, 0),
-            "tier": "unscored", "verdict": "unscored",
-        } for g in config.extra_flagged_genes if g not in set(df.gene)])
+        extra_rows = pd.DataFrame(
+            [
+                {
+                    "gene": g,
+                    "prior_stat": float("nan"),
+                    "score": float("nan"),
+                    "score_percentile": float("nan"),
+                    "flag": True,
+                    "flag_reason": "insufficient_data",
+                    "y": extra_y.get(g, 0),
+                    "tier": "unscored",
+                    "verdict": "unscored",
+                }
+                for g in config.extra_flagged_genes
+                if g not in set(df.gene)
+            ]
+        )
         if len(extra_rows):
             table = pd.concat([table, extra_rows], ignore_index=True)
-    table = table[["gene", "prior_stat", "score", "score_percentile",
-                   "tier", "verdict", "flag", "flag_reason", "y"]]
+    table = table[
+        [
+            "gene",
+            "prior_stat",
+            "score",
+            "score_percentile",
+            "tier",
+            "verdict",
+            "flag",
+            "flag_reason",
+            "y",
+        ]
+    ]
     return RerankResult(table=table, metrics=metrics, coverage=coverage)

--- a/hvantk/algorithms/rerank/features.py
+++ b/hvantk/algorithms/rerank/features.py
@@ -10,16 +10,36 @@ logger = logging.getLogger(__name__)
 class FeatureAssembler:
     def assemble(self, config):
         frames = []
+        col_owner = {}  # non-gene feature column -> the axis that first declared it
         for ax in config.features:
             fr = ax.load()
             if fr["gene"].duplicated().any():
                 n_dup = int(fr["gene"].duplicated().sum())
                 logger.warning(
                     "rerank feature axis '%s': %d duplicate gene key(s) dropped (kept first) "
-                    "to avoid a cartesian blow-up on the outer join", ax.name, n_dup)
+                    "to avoid a cartesian blow-up on the outer join",
+                    ax.name,
+                    n_dup,
+                )
                 fr = fr.drop_duplicates("gene", keep="first")
+            # Feature column names must be unique across axes: the outer join below would
+            # otherwise suffix a shared name to `_x`/`_y`, which both feeds the model twice
+            # and silently breaks the per-axis grouping in engine.py (it matches columns by
+            # exact name). Fail loud instead. (PR #222 review.)
+            clashes = [c for c in fr.columns if c != "gene" and c in col_owner]
+            if clashes:
+                raise ValueError(
+                    f"rerank feature axis '{ax.name}' declares column(s) {clashes} already "
+                    f"provided by axis '{col_owner[clashes[0]]}'; feature column names must be "
+                    f"unique across axes. Rename the columns in the axis tables."
+                )
+            for c in fr.columns:
+                if c != "gene":
+                    col_owner[c] = ax.name
             frames.append(fr)
-        matrix = functools.reduce(lambda l, r: l.merge(r, on="gene", how="outer"), frames)
+        matrix = functools.reduce(
+            lambda l, r: l.merge(r, on="gene", how="outer"), frames
+        )
         coverage = {}
         for ax, fr in zip(config.features, frames):
             present = matrix["gene"].isin(set(fr["gene"]))

--- a/hvantk/skills/gnomad_metrics/builder.py
+++ b/hvantk/skills/gnomad_metrics/builder.py
@@ -51,6 +51,16 @@ def build_gnomad_metrics_metrics(
             raise FileNotFoundError(
                 f"No gnomAD constraint file (*.bgz/*.tsv) found in {src}"
             )
+        if len(candidates) > 1:
+            # Do not silently pick the first: a raw dir holding more than one constraint
+            # file (e.g. v2.1.1 + v4.0, or by_gene + by_transcript) would build the wrong
+            # table. Mirror the sibling gevir builder and fail loud. (PR #222 review.)
+            raise ValueError(
+                f"expected exactly one gnomAD constraint file in {src}, found "
+                f"{len(candidates)}: {[c.name for c in candidates]}. Point --raw-dir at a "
+                f"directory holding a single version's constraint file, or pass an explicit "
+                f"file path."
+            )
         src = candidates[0]
         logger.info("Resolved gnomAD constraint file: %s", src)
 

--- a/hvantk/skills/gnomad_metrics/tests/test_builder.py
+++ b/hvantk/skills/gnomad_metrics/tests/test_builder.py
@@ -20,11 +20,26 @@ from hvantk.tests._snapshot_utils import (
     load_snapshot,
     phase_b_snapshot_adapter,
 )
+
 # Aliased to avoid shadowing the fixture name `regenerate_snapshots` in the test signature
 from hvantk.tests._snapshot_utils import regenerate_snapshots as regenerate_snapshots_fn
 
-FIXTURE = "hvantk/tests/testdata/raw/gnomad/gnomad.v2.1.1.lof_metrics.by_gene.chr20.tsv.bgz"
+FIXTURE = (
+    "hvantk/tests/testdata/raw/gnomad/gnomad.v2.1.1.lof_metrics.by_gene.chr20.tsv.bgz"
+)
 SNAPSHOT_DIR = Path("hvantk/skills/gnomad_metrics/tests/snapshots")
+
+
+def test_build_raises_when_raw_dir_holds_multiple_constraint_files(tmp_path):
+    # A raw dir with more than one constraint file (e.g. v2.1.1 + v4.0) must fail loud rather
+    # than silently build from candidates[0]. Guard raises before any Hail call. (PR #222 review.)
+    from hvantk.skills.gnomad_metrics.builder import build_gnomad_metrics_metrics
+
+    (tmp_path / "gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz").write_text("x")
+    (tmp_path / "gnomad.v4.0.constraint_metrics.tsv").write_text("x")
+    with pytest.raises(ValueError, match="exactly one gnomAD constraint file"):
+        build_gnomad_metrics_metrics(str(tmp_path), None)
+
 
 # Real keys, taken from an actual build of the fixture -- collect_sample_rows raises
 # KeyError for any key absent from the table, so these cannot be invented.
@@ -39,12 +54,16 @@ SAMPLE_KEYS = [
 
 
 @pytest.mark.hail
-def test_gnomad_metrics_snapshot_round_trip(hail_session, tmp_path, regenerate_snapshots):
+def test_gnomad_metrics_snapshot_round_trip(
+    hail_session, tmp_path, regenerate_snapshots
+):
     """Build gnomAD constraint metrics from fixture; assert schema and sample-row stability."""
     import hail as hl
     from hvantk.skills.gnomad_metrics.builder import build_gnomad_metrics_metrics
 
-    builder = phase_b_snapshot_adapter(build_gnomad_metrics_metrics, "gnomad-metrics:metrics")
+    builder = phase_b_snapshot_adapter(
+        build_gnomad_metrics_metrics, "gnomad-metrics:metrics"
+    )
 
     if regenerate_snapshots:
         regenerate_snapshots_fn(
@@ -53,15 +72,21 @@ def test_gnomad_metrics_snapshot_round_trip(hail_session, tmp_path, regenerate_s
             snapshot_dir=SNAPSHOT_DIR,
             keys=SAMPLE_KEYS,
         )
-        pytest.skip("Snapshots regenerated; rerun without --regenerate-snapshots to assert.")
+        pytest.skip(
+            "Snapshots regenerated; rerun without --regenerate-snapshots to assert."
+        )
 
     output_path = str(tmp_path / "gnomad_metrics.ht")
     builder(input_path=FIXTURE, output_path=output_path)
     ht = hl.read_table(output_path)
 
     expected_schema = load_snapshot(SNAPSHOT_DIR / "schema.json")
-    assert hail_schema_to_dict(ht) == expected_schema, "gnomAD constraint metrics schema drifted from snapshot"
+    assert (
+        hail_schema_to_dict(ht) == expected_schema
+    ), "gnomAD constraint metrics schema drifted from snapshot"
 
     expected_rows = load_snapshot(SNAPSHOT_DIR / "sample_rows.json")
     actual_rows = collect_sample_rows(ht, keys=SAMPLE_KEYS)
-    assert actual_rows == expected_rows, "gnomAD constraint metrics sample rows drifted from snapshot"
+    assert (
+        actual_rows == expected_rows
+    ), "gnomAD constraint metrics sample rows drifted from snapshot"

--- a/hvantk/skills/ucsc_cellbrowser/builder.py
+++ b/hvantk/skills/ucsc_cellbrowser/builder.py
@@ -28,9 +28,9 @@ __all__ = [
 
 # Map compound dataset names → Phase B schema IDs.
 _SCHEMA_IDS: dict[str, str] = {
-    "ucsc-cellbrowser:default":   "ucsc-cellbrowser-default-v1",
+    "ucsc-cellbrowser:default": "ucsc-cellbrowser-default-v1",
     "ucsc-cellbrowser:adult-ctx": "ucsc-cellbrowser-adult-ctx-v1",
-    "ucsc-cellbrowser:dev-ctx":   "ucsc-cellbrowser-dev-ctx-v1",
+    "ucsc-cellbrowser:dev-ctx": "ucsc-cellbrowser-dev-ctx-v1",
 }
 
 
@@ -63,22 +63,37 @@ def _resolve_ucsc_inputs(parsed_input):
         if os.path.isdir(os.path.join(root, d))
     ]
 
-    def _find(names):
-        for directory in search_dirs:
-            for name in names:
-                candidate = os.path.join(directory, name)
-                if os.path.exists(candidate):
-                    return candidate
+    def _first_present(directory, names):
+        for name in names:
+            candidate = os.path.join(directory, name)
+            if os.path.exists(candidate):
+                return candidate
         return None
 
-    expr = _find(expr_names)
-    meta = _find(meta_names)
-    if expr is None or meta is None:
+    # A dataset's download carries its expression matrix and metadata together, so collect the
+    # locations holding BOTH and require exactly one. A raw dir reused across the sibling
+    # datasets (default / adult-ctx / dev-ctx) would otherwise let the search silently pick the
+    # alphabetically-first subdir and stamp the wrong schema_id; requiring a single location
+    # also rules out pairing an expression file from one dir with metadata from another.
+    # (PR #222 review.)
+    hits = []
+    for directory in search_dirs:
+        expr = _first_present(directory, expr_names)
+        meta = _first_present(directory, meta_names)
+        if expr and meta:
+            hits.append((directory, expr, meta))
+    if not hits:
         raise FileNotFoundError(
             f"UCSC builder: could not locate an expression matrix {expr_names} and "
-            f"metadata {meta_names} under {root!r} (searched {search_dirs})"
+            f"metadata {meta_names} together under {root!r} (searched {search_dirs})"
         )
-    return expr, meta
+    if len(hits) > 1:
+        raise ValueError(
+            f"UCSC builder: found expression+metadata in multiple locations "
+            f"{[h[0] for h in hits]} under {root!r}; point --raw-dir at a single dataset's "
+            f"download so the correct schema_id is stamped."
+        )
+    return hits[0][1], hits[0][2]
 
 
 def build_ucsc_cellbrowser(

--- a/hvantk/skills/ucsc_cellbrowser/tests/test_builder_input_resolution.py
+++ b/hvantk/skills/ucsc_cellbrowser/tests/test_builder_input_resolution.py
@@ -49,3 +49,16 @@ def test_raw_dir_flat(tmp_path):
 def test_missing_files_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         _resolve_ucsc_inputs(str(tmp_path))
+
+
+def test_raw_dir_with_multiple_dataset_subdirs_raises(tmp_path):
+    # Reusing one --raw-dir across the sibling datasets (default/adult-ctx/dev-ctx) leaves
+    # expression+metadata in more than one subdir; the builder must fail loud rather than pick
+    # the alphabetically-first and stamp the wrong schema_id. (PR #222 review.)
+    for acc in ("adult-ctx-accession", "dev-ctx-accession"):
+        d = tmp_path / acc
+        d.mkdir()
+        (d / EXPRESSION_MATRIX_FILE_NAME).write_text("gene\tcell1\n")
+        (d / METADATA_FILE_NAME).write_text("cell\ttype\n")
+    with pytest.raises(ValueError, match="multiple locations"):
+        _resolve_ucsc_inputs(str(tmp_path))

--- a/hvantk/tests/rerank/test_features.py
+++ b/hvantk/tests/rerank/test_features.py
@@ -3,17 +3,43 @@ import pandas as pd
 from hvantk.algorithms.rerank.config import FeatureAxis
 from hvantk.algorithms.rerank.features import FeatureAssembler
 
+
 class _Cfg:
     def __init__(self):
-        self.features=[
-          FeatureAxis("a", lambda: pd.DataFrame({"gene":["A","B"],"x":[1.0,2.0]})),
-          FeatureAxis("b", lambda: pd.DataFrame({"gene":["A"],"y":[9.0]})),
+        self.features = [
+            FeatureAxis(
+                "a", lambda: pd.DataFrame({"gene": ["A", "B"], "x": [1.0, 2.0]})
+            ),
+            FeatureAxis("b", lambda: pd.DataFrame({"gene": ["A"], "y": [9.0]})),
         ]
-        self.cohort=None
+        self.cohort = None
+
 
 def test_assemble_outer_join_and_coverage():
     m, cov = FeatureAssembler().assemble(_Cfg())
-    assert set(m.gene) == {"A","B"}
-    assert list(m.columns) == ["gene","x","y"]
-    assert m.loc[m.gene=="B","y"].isna().all()         # B missing from axis b -> NaN
-    assert cov["b"] == 0.5                              # 1 of 2 genes covered
+    assert set(m.gene) == {"A", "B"}
+    assert list(m.columns) == ["gene", "x", "y"]
+    assert m.loc[m.gene == "B", "y"].isna().all()  # B missing from axis b -> NaN
+    assert cov["b"] == 0.5  # 1 of 2 genes covered
+
+
+class _CfgClash:
+    def __init__(self):
+        self.features = [
+            FeatureAxis(
+                "a", lambda: pd.DataFrame({"gene": ["A", "B"], "score": [1.0, 2.0]})
+            ),
+            FeatureAxis(
+                "b", lambda: pd.DataFrame({"gene": ["A"], "score": [9.0]})
+            ),  # 'score' clashes
+        ]
+        self.cohort = None
+
+
+def test_assemble_raises_on_column_name_collision_across_axes():
+    # A feature column name shared by two axes would be suffixed _x/_y by the outer join,
+    # silently breaking per-axis grouping; assemble must fail loud instead. (PR #222 review.)
+    import pytest
+
+    with pytest.raises(ValueError, match="unique across axes"):
+        FeatureAssembler().assemble(_CfgClash())


### PR DESCRIPTION
Addresses the #222 code-review findings (Copilot + adversarial review). Four defensive-hardening fixes on already-merged code, each with a regression test where a guard raises:

- **gnomad-metrics builder** — raise if a raw dir holds more than one constraint file (v2.1.1 + v4.0, or by_gene + by_transcript) instead of silently building `candidates[0]`. Mirrors the sibling GeVIR guard. (Flagged by Copilot, 3 review agents, and originally qodo on #199.)
- **ucsc-cellbrowser `_resolve_ucsc_inputs`** — require expression+metadata in exactly one location; reusing one `--raw-dir` across the three sibling datasets (default/adult-ctx/dev-ctx) would otherwise pick the alphabetically-first subdir and stamp the wrong `schema_id`.
- **rerank `FeatureAssembler.assemble`** — raise on a feature-column name shared by two axes (the outer join would suffix it `_x`/`_y`, feeding the model twice and silently breaking per-axis grouping in `engine.py`).
- **rerank `engine`** — clear error when the assembled matrix has no feature columns (was a cryptic scikit-learn "0 feature(s)" failure).

Also black-formats the touched files (resolves the ported PEP8 style in the two rerank files edited).

**Deferred** (noted in the review, lower value): the remaining rerank module PEP8 (config/evaluator/tiers) and two docstring-accuracy nitpicks (mapping.py, reranker.py) — happy to fold in if wanted.

Verified: the 3 new guard tests + the full rerank/gnomad/ucsc suites pass (non-hail); plugin-smoke green; flake8 (E9,F63,F7,F82)=0; black clean on changed files. Once merged to `dev` this flows into release PR #222.