### PR TITLE
feat(annotate): P3 — 'hvantk annotate compose' generic Layer-1 composer

### DIFF
--- a/hvantk/algorithms/annotation/compose.py
+++ b/hvantk/algorithms/annotation/compose.py
@@ -1,0 +1,141 @@
+"""Compose prepared Layer-1 sources onto the gene spine (Stage 2 of the annotation build).
+
+`compose` is Stage 2 of the annotation build (design §3): it left-joins every axis's
+prepared table (Stage 1, ``prepare.py``) onto the ``gene_id``-keyed spine, driven
+entirely by a :class:`~hvantk.algorithms.annotation.spec.FeatureSpec`. It is deliberately
+generic -- axis names, output columns, and any cohort-specific assumptions come only from
+the spec and the ``prepared_by_axis`` mapping the caller hands in; nothing about a
+specific axis or cohort is hard-coded here.
+
+A gene absent from an axis's prepared table stays missing (Hail missing) in that axis's
+declared columns -- compose never fills in a default. Each axis additionally gets a
+``{axis}_present`` boolean column, true iff the gene had a row in that axis's prepared
+table, so downstream consumers can tell "missing because absent from source" apart from
+any other reason a value might be null.
+
+Layering: this module imports Hail and sibling ``hvantk.algorithms.annotation`` modules
+only -- it must never import ``hvantk.skills`` or ``hvantk.tools`` (the source is data,
+already reduced to a Hail Table by Stage 1; compose has no business reading raw sources).
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def compose(spine, prepared_by_axis, spec):
+    """Left-join every ``spec.layer1`` axis's prepared table onto the spine.
+
+    Parameters
+    ----------
+    spine : hail.Table
+        The ``gene_id``-keyed spine (Stage 0).
+    prepared_by_axis : dict[str, hail.Table]
+        Axis label -> that axis's prepared, ``gene_id``-keyed table (Stage 1 output,
+        e.g. :func:`hvantk.algorithms.annotation.prepare.prepare_source`), one entry
+        per axis in ``spec.layer1``.
+    spec : hvantk.algorithms.annotation.spec.FeatureSpec
+
+    Returns
+    -------
+    (hail.Table, dict)
+        The composed, ``gene_id``-keyed table -- spine columns, every axis's declared
+        columns, and a ``{axis}_present`` bool per axis -- and a manifest reporting,
+        per axis and column, the non-null rate over the spine and the positive rate
+        (fraction > 0) among non-null values.
+
+    Raises
+    ------
+    ValueError
+        If two ``spec.layer1`` axes declare the same output column name. Checked in
+        pure Python before any Hail call.
+    KeyError
+        If ``prepared_by_axis`` is missing an axis that ``spec.layer1`` declares.
+    """
+    import hail as hl
+
+    _check_no_column_collisions(spec)
+
+    ht = spine
+    for entry in spec.layer1:
+        axis = entry.axis
+        if axis not in prepared_by_axis:
+            raise KeyError(
+                f"prepared_by_axis is missing axis {axis!r}, declared in spec "
+                f"{spec.name!r}"
+            )
+        prepared = prepared_by_axis[axis]
+        # `prepared[ht.gene_id]` is Hail's index-join idiom (Table.__getitem__ ->
+        # Table.index): a StructExpression of prepared's non-key fields, missing where
+        # ht.gene_id has no match in prepared -- exactly the left join we want, and the
+        # struct being missing (rather than any individual field) is what makes the
+        # presence flag correct regardless of whether a matched row's own column values
+        # happen to be null.
+        joined = prepared[ht.gene_id]
+        updates = {col: joined[col] for col in entry.columns}
+        updates[f"{axis}_present"] = hl.is_defined(joined)
+        ht = ht.annotate(**updates)
+
+    manifest = _build_manifest(ht, spec)
+    return ht, manifest
+
+
+def _check_no_column_collisions(spec) -> None:
+    """Raise if two ``spec.layer1`` axes declare the same output column name.
+
+    Pure Python, no Hail -- runs before any Hail call so the check (and the tests that
+    exercise it) do not need a Hail session.
+    """
+    owner: dict[str, str] = {}
+    for entry in spec.layer1:
+        for col in entry.columns:
+            if col in owner:
+                raise ValueError(
+                    f"duplicate output column {col!r}: declared by axis {owner[col]!r} "
+                    f"and axis {entry.axis!r}; name columns uniquely across the spec's "
+                    "layer1 axes"
+                )
+            owner[col] = entry.axis
+
+
+def _build_manifest(ht, spec) -> dict:
+    """Per axis+column non-null rate (over the spine) and positive rate (among non-null).
+
+    Computed with a single ``ht.aggregate`` call over every declared column, per the
+    design's manifest contract.
+    """
+    import hail as hl
+
+    columns = [col for entry in spec.layer1 for col in entry.columns]
+    n_genes = ht.count()
+
+    if not columns:
+        return {"n_genes": n_genes, "axes": {entry.axis: {} for entry in spec.layer1}}
+
+    stats = ht.aggregate(
+        hl.struct(
+            **{
+                col: hl.struct(
+                    nn=hl.agg.count_where(hl.is_defined(ht[col])),
+                    pos=hl.agg.count_where(ht[col] > 0),
+                )
+                for col in columns
+            }
+        )
+    )
+
+    axes: dict = {}
+    for entry in spec.layer1:
+        axis_manifest = {}
+        for col in entry.columns:
+            col_stats = stats[col]
+            nn = col_stats["nn"]
+            pos = col_stats["pos"]
+            axis_manifest[col] = {
+                "non_null_rate": (nn / n_genes) if n_genes else 0.0,
+                "positive_rate": (pos / nn) if nn else None,
+            }
+        axes[entry.axis] = axis_manifest
+
+    return {"n_genes": n_genes, "axes": axes}

--- a/hvantk/tests/annotation/test_annotate_cli.py
+++ b/hvantk/tests/annotation/test_annotate_cli.py
@@ -1,0 +1,314 @@
+"""CLI tests for ``hvantk annotate compose``.
+
+The malformed-``--prepared`` and axis-validation checks are pure Python (no spec,
+no Hail) and run in the fast suite; the end-to-end invocation writes/reads real Hail
+tables and is marked ``@pytest.mark.hail``.
+"""
+from __future__ import annotations
+
+import json
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from hvantk.tools.annotation.annotate_cli import (
+    _parse_prepared_option,
+    _validate_prepared_axes,
+    annotate_group,
+)
+
+
+def test_annotate_group_exposes_compose():
+    assert "compose" in annotate_group.commands
+
+
+# --------------------------------------------------------------------------
+# _parse_prepared_option -- pure Python, no Hail
+# --------------------------------------------------------------------------
+
+
+def test_parse_prepared_option_builds_axis_to_path_dict():
+    parsed = _parse_prepared_option(("constraint=/tmp/c.ht", "gevir=/tmp/g.ht"))
+    assert parsed == {"constraint": "/tmp/c.ht", "gevir": "/tmp/g.ht"}
+
+
+def test_parse_prepared_option_rejects_a_value_with_no_equals_sign():
+    with pytest.raises(click.UsageError, match="malformed"):
+        _parse_prepared_option(("constraint-only-path",))
+
+
+def test_parse_prepared_option_rejects_an_empty_axis_or_path():
+    with pytest.raises(click.UsageError, match="malformed"):
+        _parse_prepared_option(("=/tmp/c.ht",))
+    with pytest.raises(click.UsageError, match="malformed"):
+        _parse_prepared_option(("constraint=",))
+
+
+# --------------------------------------------------------------------------
+# _validate_prepared_axes -- pure Python, no Hail
+# --------------------------------------------------------------------------
+
+
+class _FakeEntry:
+    def __init__(self, axis):
+        self.axis = axis
+
+
+class _FakeSpec:
+    def __init__(self, name, axes):
+        self.name = name
+        self.layer1 = tuple(_FakeEntry(a) for a in axes)
+
+
+def test_validate_prepared_axes_passes_when_they_match_exactly():
+    spec = _FakeSpec("t", ["constraint", "gevir"])
+    _validate_prepared_axes(
+        spec, {"constraint": "/tmp/c.ht", "gevir": "/tmp/g.ht"}
+    )  # must not raise
+
+
+def test_validate_prepared_axes_raises_on_a_missing_spec_axis():
+    spec = _FakeSpec("t", ["constraint", "gevir"])
+    with pytest.raises(click.UsageError, match="gevir"):
+        _validate_prepared_axes(spec, {"constraint": "/tmp/c.ht"})
+
+
+def test_validate_prepared_axes_raises_on_an_unknown_axis():
+    spec = _FakeSpec("t", ["constraint"])
+    with pytest.raises(click.UsageError, match="unknown_axis"):
+        _validate_prepared_axes(
+            spec, {"constraint": "/tmp/c.ht", "unknown_axis": "/tmp/u.ht"}
+        )
+
+
+# --------------------------------------------------------------------------
+# End-to-end CLI invocation -- writes/reads real Hail tables.
+# --------------------------------------------------------------------------
+
+
+def _write_spine(path):
+    import hail as hl
+
+    ht = hl.Table.parallelize(
+        [
+            {"gene_id": "ENSG1", "gene_name": "A"},
+            {"gene_id": "ENSG2", "gene_name": "B"},
+            {"gene_id": "ENSG3", "gene_name": "C"},
+        ],
+        hl.tstruct(gene_id=hl.tstr, gene_name=hl.tstr),
+        key=["gene_id"],
+    )
+    ht.write(path, overwrite=True)
+
+
+def _write_constraint_axis(path):
+    import hail as hl
+
+    # ENSG1/ENSG2 only -- ENSG3 absent, exercising the no-imputation contract.
+    ht = hl.Table.parallelize(
+        [
+            {"gene_id": "ENSG1", "mis_z": 2.0},
+            {"gene_id": "ENSG2", "mis_z": -1.0},
+        ],
+        hl.tstruct(gene_id=hl.tstr, mis_z=hl.tfloat64),
+        key=["gene_id"],
+    )
+    ht.write(path, overwrite=True)
+
+
+def _write_gevir_axis(path):
+    import hail as hl
+
+    ht = hl.Table.parallelize(
+        [
+            {"gene_id": "ENSG2", "gevir_pct": 0.5},
+            {"gene_id": "ENSG3", "gevir_pct": 0.9},
+        ],
+        hl.tstruct(gene_id=hl.tstr, gevir_pct=hl.tfloat64),
+        key=["gene_id"],
+    )
+    ht.write(path, overwrite=True)
+
+
+def _write_spec(path):
+    path.write_text(
+        "name: test-spec\n"
+        "layer1:\n"
+        "  - {axis: constraint, source: gnomad-metrics:metrics, key: gene_id, "
+        "columns: [mis_z]}\n"
+        "  - {axis: gevir, source: gevir:table, key: gene_id, columns: [gevir_pct]}\n"
+    )
+
+
+@pytest.mark.hail
+def test_compose_cmd_writes_a_gene_id_keyed_matrix_and_manifest(hail_session, tmp_path):
+    import hail as hl
+
+    spec_path = tmp_path / "spec.yaml"
+    _write_spec(spec_path)
+
+    spine_path = str(tmp_path / "spine.ht")
+    _write_spine(spine_path)
+
+    constraint_path = str(tmp_path / "constraint.ht")
+    _write_constraint_axis(constraint_path)
+
+    gevir_path = str(tmp_path / "gevir.ht")
+    _write_gevir_axis(gevir_path)
+
+    output_path = str(tmp_path / "matrix.ht")
+    manifest_path = str(tmp_path / "manifest.json")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        annotate_group,
+        [
+            "compose",
+            "--spec",
+            str(spec_path),
+            "--spine",
+            spine_path,
+            "--prepared",
+            f"constraint={constraint_path}",
+            "--prepared",
+            f"gevir={gevir_path}",
+            "--output",
+            output_path,
+            "--manifest",
+            manifest_path,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    ht = hl.read_table(output_path)
+    assert list(ht.key) == ["gene_id"]
+    assert ht.count() == 3
+    assert set(ht.row) == {
+        "gene_id",
+        "gene_name",
+        "mis_z",
+        "gevir_pct",
+        "constraint_present",
+        "gevir_present",
+    }
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["n_genes"] == 3
+    assert set(manifest["axes"]) == {"constraint", "gevir"}
+
+
+@pytest.mark.hail
+def test_compose_cmd_defaults_manifest_path_alongside_output(hail_session, tmp_path):
+    spec_path = tmp_path / "spec.yaml"
+    _write_spec(spec_path)
+
+    spine_path = str(tmp_path / "spine.ht")
+    _write_spine(spine_path)
+
+    constraint_path = str(tmp_path / "constraint.ht")
+    _write_constraint_axis(constraint_path)
+
+    gevir_path = str(tmp_path / "gevir.ht")
+    _write_gevir_axis(gevir_path)
+
+    output_path = str(tmp_path / "matrix.ht")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        annotate_group,
+        [
+            "compose",
+            "--spec",
+            str(spec_path),
+            "--spine",
+            spine_path,
+            "--prepared",
+            f"constraint={constraint_path}",
+            "--prepared",
+            f"gevir={gevir_path}",
+            "--output",
+            output_path,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "matrix.ht.manifest.json").exists()
+
+
+def test_compose_cmd_errors_clearly_on_a_missing_axis(tmp_path):
+    spec_path = tmp_path / "spec.yaml"
+    _write_spec(spec_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        annotate_group,
+        [
+            "compose",
+            "--spec",
+            str(spec_path),
+            "--spine",
+            str(tmp_path / "spine.ht"),
+            "--prepared",
+            f"constraint={tmp_path / 'constraint.ht'}",
+            "--output",
+            str(tmp_path / "matrix.ht"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, KeyError)
+    assert "gevir" in result.output
+
+
+def test_compose_cmd_errors_clearly_on_an_unknown_axis(tmp_path):
+    spec_path = tmp_path / "spec.yaml"
+    _write_spec(spec_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        annotate_group,
+        [
+            "compose",
+            "--spec",
+            str(spec_path),
+            "--spine",
+            str(tmp_path / "spine.ht"),
+            "--prepared",
+            f"constraint={tmp_path / 'constraint.ht'}",
+            "--prepared",
+            f"gevir={tmp_path / 'gevir.ht'}",
+            "--prepared",
+            f"expression={tmp_path / 'expression.ht'}",
+            "--output",
+            str(tmp_path / "matrix.ht"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "expression" in result.output
+
+
+def test_compose_cmd_errors_clearly_on_a_malformed_prepared_value(tmp_path):
+    spec_path = tmp_path / "spec.yaml"
+    _write_spec(spec_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        annotate_group,
+        [
+            "compose",
+            "--spec",
+            str(spec_path),
+            "--spine",
+            str(tmp_path / "spine.ht"),
+            "--prepared",
+            "not-a-key-value-pair",
+            "--output",
+            str(tmp_path / "matrix.ht"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "malformed" in result.output

--- a/hvantk/tests/annotation/test_compose.py
+++ b/hvantk/tests/annotation/test_compose.py
@@ -1,0 +1,159 @@
+"""compose: generic Stage-2 left-join of prepared Layer-1 axes onto the spine."""
+from __future__ import annotations
+
+import pytest
+
+from hvantk.algorithms.annotation.spec import FeatureSpec, SourceEntry
+
+
+def _spine():
+    import hail as hl
+
+    return hl.Table.parallelize(
+        [
+            {"gene_id": "ENSG1", "gene_name": "A"},
+            {"gene_id": "ENSG2", "gene_name": "B"},
+            {"gene_id": "ENSG3", "gene_name": "C"},
+        ],
+        hl.tstruct(gene_id=hl.tstr, gene_name=hl.tstr),
+        key=["gene_id"],
+    )
+
+
+def _axis(rows, schema):
+    import hail as hl
+
+    return hl.Table.parallelize(rows, schema, key=["gene_id"])
+
+
+CONSTRAINT_ENTRY = SourceEntry(
+    axis="constraint",
+    source="gnomad-metrics:metrics",
+    key="gene_id",
+    columns=("mis_z",),
+)
+GEVIR_ENTRY = SourceEntry(
+    axis="gevir",
+    source="gevir:table",
+    key="gene_id",
+    columns=("gevir_pct",),
+)
+
+
+def _two_axis_spec():
+    return FeatureSpec(name="test-spec", layer1=(CONSTRAINT_ENTRY, GEVIR_ENTRY))
+
+
+def _constraint_axis_ht():
+    import hail as hl
+
+    # ENSG1/ENSG2 only -- ENSG3 absent.
+    return _axis(
+        [{"gene_id": "ENSG1", "mis_z": 2.0}, {"gene_id": "ENSG2", "mis_z": -1.0}],
+        hl.tstruct(gene_id=hl.tstr, mis_z=hl.tfloat64),
+    )
+
+
+def _gevir_axis_ht():
+    import hail as hl
+
+    # ENSG2/ENSG3 only -- ENSG1 absent.
+    return _axis(
+        [
+            {"gene_id": "ENSG2", "gevir_pct": 0.5},
+            {"gene_id": "ENSG3", "gevir_pct": 0.9},
+        ],
+        hl.tstruct(gene_id=hl.tstr, gevir_pct=hl.tfloat64),
+    )
+
+
+@pytest.mark.hail
+def test_compose_left_joins_all_axes_onto_the_spine(hail_session):
+    from hvantk.algorithms.annotation.compose import compose
+
+    prepared_by_axis = {
+        "constraint": _constraint_axis_ht(),
+        "gevir": _gevir_axis_ht(),
+    }
+    composed, manifest = compose(_spine(), prepared_by_axis, _two_axis_spec())
+
+    assert list(composed.key) == ["gene_id"]
+    assert composed.count() == 3
+    assert set(composed.row) == {
+        "gene_id",
+        "gene_name",
+        "mis_z",
+        "gevir_pct",
+        "constraint_present",
+        "gevir_present",
+    }
+
+
+@pytest.mark.hail
+def test_compose_never_imputes_missing_stays_missing(hail_session):
+    from hvantk.algorithms.annotation.compose import compose
+
+    prepared_by_axis = {
+        "constraint": _constraint_axis_ht(),
+        "gevir": _gevir_axis_ht(),
+    }
+    composed, _manifest = compose(_spine(), prepared_by_axis, _two_axis_spec())
+    rows = {r.gene_id: r for r in composed.collect()}
+
+    # ENSG3 absent from constraint -> mis_z missing (not 0), presence flag False.
+    assert rows["ENSG3"].mis_z is None
+    assert rows["ENSG3"].constraint_present is False
+
+    # ENSG1 absent from gevir -> gevir_pct missing, presence flag False.
+    assert rows["ENSG1"].gevir_pct is None
+    assert rows["ENSG1"].gevir_present is False
+
+
+@pytest.mark.hail
+def test_compose_presence_flag_true_when_axis_has_the_gene(hail_session):
+    from hvantk.algorithms.annotation.compose import compose
+
+    prepared_by_axis = {
+        "constraint": _constraint_axis_ht(),
+        "gevir": _gevir_axis_ht(),
+    }
+    composed, _manifest = compose(_spine(), prepared_by_axis, _two_axis_spec())
+    rows = {r.gene_id: r for r in composed.collect()}
+
+    # ENSG2 is present in BOTH axes.
+    row = rows["ENSG2"]
+    assert row.constraint_present is True
+    assert row.gevir_present is True
+    assert row.mis_z == pytest.approx(-1.0)
+    assert row.gevir_pct == pytest.approx(0.5)
+
+
+@pytest.mark.hail
+def test_compose_manifest_reports_nonnull_and_positive_rate(hail_session):
+    from hvantk.algorithms.annotation.compose import compose
+
+    # Single-axis spec so the manifest arithmetic is easy to hand-check:
+    # mis_z: ENSG1=2.0, ENSG2=-1.0, ENSG3 missing -> non-null 2/3, positive 1/2.
+    spec = FeatureSpec(name="test-spec", layer1=(CONSTRAINT_ENTRY,))
+    composed, manifest = compose(_spine(), {"constraint": _constraint_axis_ht()}, spec)
+
+    stats = manifest["axes"]["constraint"]["mis_z"]
+    assert stats["non_null_rate"] == pytest.approx(2 / 3)
+    assert stats["positive_rate"] == pytest.approx(1 / 2)
+    assert manifest["n_genes"] == 3
+
+
+def test_compose_raises_on_duplicate_output_column_across_axes():
+    # Pure-Python collision check -- must run without Hail (no @pytest.mark.hail).
+    from hvantk.algorithms.annotation.compose import compose
+
+    dup_entry = SourceEntry(
+        axis="gevir",
+        source="gevir:table",
+        key="gene_id",
+        columns=("mis_z",),  # collides with CONSTRAINT_ENTRY's "mis_z"
+    )
+    spec = FeatureSpec(name="test-spec", layer1=(CONSTRAINT_ENTRY, dup_entry))
+
+    with pytest.raises(ValueError, match="mis_z"):
+        compose(spine=None, prepared_by_axis={}, spec=spec)

--- a/hvantk/tools/annotation/annotate_cli.py
+++ b/hvantk/tools/annotation/annotate_cli.py
@@ -126,3 +126,97 @@ def prepare_cmd(spec, axis, input_path, spine, output, hgnc_path):
     enforce_rate(report, entry.min_mapping_rate)
     prepared.write(output, overwrite=True)
     click.echo(f"prepare {axis} ({entry.source}): {report.summary()} -> {output}")
+
+
+def _parse_prepared_option(values: tuple[str, ...]) -> dict[str, str]:
+    """Parse repeatable ``--prepared axis=path`` options into a dict.
+
+    Pure Python -- no Hail, no spec -- so it is unit-testable without a Hail session.
+    """
+    prepared_paths: dict[str, str] = {}
+    for value in values:
+        axis, sep, path = value.partition("=")
+        axis, path = axis.strip(), path.strip()
+        if not sep or not axis or not path:
+            raise click.UsageError(
+                f"--prepared value {value!r} is malformed; expected axis=path"
+            )
+        prepared_paths[axis] = path
+    return prepared_paths
+
+
+def _validate_prepared_axes(spec, prepared_paths: dict[str, str]) -> None:
+    """Raise a clear ``click.UsageError`` if ``--prepared`` doesn't match the spec's axes.
+
+    Checked in pure Python, before ``compose`` (which raises a raw ``KeyError`` on a
+    missing axis) and before any Hail call, so this is unit-testable without Hail.
+    """
+    spec_axes = {entry.axis for entry in spec.layer1}
+    prepared_axes = set(prepared_paths)
+
+    missing = sorted(spec_axes - prepared_axes)
+    if missing:
+        raise click.UsageError(
+            "missing --prepared for spec axis(es): " + ", ".join(missing)
+        )
+
+    unknown = sorted(prepared_axes - spec_axes)
+    if unknown:
+        raise click.UsageError(
+            "--prepared names axis(es) not declared in the spec "
+            f"{spec.name!r}: " + ", ".join(unknown)
+        )
+
+
+@annotate_group.command("compose")
+@click.option("--spec", required=True, help="Path to the feature-spec YAML.")
+@click.option("--spine", required=True, help="Path to the gene spine table (.ht).")
+@click.option(
+    "--prepared",
+    "prepared_opts",
+    required=True,
+    multiple=True,
+    help="Repeatable axis=path, one per spec layer1 axis (e.g. constraint=constraint.ht).",
+)
+@click.option(
+    "--output", required=True, help="Output path for the composed matrix (.ht)."
+)
+@click.option(
+    "--manifest",
+    default=None,
+    help="Output path for the manifest JSON (default: <output>.manifest.json).",
+)
+def compose_cmd(spec, spine, prepared_opts, output, manifest):
+    """Left-join every spec axis's prepared table onto the spine."""
+    import json
+
+    from hvantk.algorithms.annotation.compose import compose
+    from hvantk.algorithms.annotation.spec import load_spec
+
+    feature_spec = load_spec(spec)
+    prepared_paths = _parse_prepared_option(prepared_opts)
+    _validate_prepared_axes(feature_spec, prepared_paths)
+
+    manifest_path = manifest or f"{output}.manifest.json"
+
+    import hail as hl
+
+    from hvantk.core.utils.hail_context import init_hail
+
+    init_hail()
+
+    spine_ht = hl.read_table(spine)
+    prepared_by_axis = {
+        axis: hl.read_table(path) for axis, path in prepared_paths.items()
+    }
+
+    composed, report = compose(spine_ht, prepared_by_axis, feature_spec)
+    composed.write(output, overwrite=True)
+
+    with open(manifest_path, "w") as fh:
+        json.dump(report, fh, indent=2)
+
+    click.echo(
+        f"compose {feature_spec.name}: {report['n_genes']} genes x "
+        f"{len(feature_spec.layer1)} axes -> {output} (manifest: {manifest_path})"
+    )

--- a/hvantk/tools/annotation/annotate_cli.tool.yaml
+++ b/hvantk/tools/annotation/annotate_cli.tool.yaml
@@ -18,6 +18,8 @@ subcommands:
     description: Build the protein-coding gene spine from ensembl-gene:structure + hgnc:lookup
   - name: prepare
     description: Map one annotation source onto the spine's gene_id and select its columns
+  - name: compose
+    description: Left-join every spec layer1 axis's prepared table onto the spine into one matrix
 requires:
   hail: true
   network: false


### PR DESCRIPTION
## P3 — `hvantk annotate compose` (generic Layer-1 composer)

Stage 2 of the gene-feature-matrix build (design §3/§7). Adds a **generic, spec-driven composer** that left-joins each axis's prepared (Stage 1) `gene_id`-keyed table onto the gene spine, producing a Layer-1 gene feature matrix, plus the `hvantk annotate compose` CLI that drives it.

### What it does
`compose(spine, prepared_by_axis, spec) -> (table, manifest)`:
- Left-joins every `spec.layer1` axis's prepared table onto the `gene_id`-keyed spine.
- **Never imputes** (design §9): a gene absent from an axis's prepared table stays Hail-missing in that axis's columns — no fill/coalesce/default.
- Adds a `{axis}_present` boolean per axis (`hl.is_defined` of the whole join struct), so consumers can tell "absent from source" apart from "present but null".
- Emits a **manifest**: per axis+column `non_null_rate` (over the spine) and `positive_rate` (fraction > 0 **among non-null**), computed in a single `ht.aggregate`.
- **Cross-axis column-collision guard** → `ValueError`, raised in pure Python before any Hail call.

CLI: `hvantk annotate compose --spec <yaml> --spine <ht> --prepared axis=path [repeatable] --output <ht> [--manifest <json>]`. Malformed / missing / unknown `--prepared` → clear `click.UsageError`, raised **before** `init_hail()` (so `compose()`'s raw `KeyError` never surfaces).

Output is a plain `AnnotationTable` keyed on `gene_id` — no new artifact type.

### Generic by construction
Nothing about CHD or any cohort/axis is hard-coded. All axis names, columns, and keys come from the spec; the only hard-coded domain name is `gene_id`. Validated on the CHD Layer-1 axes (constraint / gevir / expression) but no CHD logic is baked in.

### Tests
- `test_compose.py`: 6 (5 `@pytest.mark.hail` — left-join / never-imputes / presence-flag True+False / manifest math; 1 pure-Python duplicate-column).
- `test_annotate_cli.py`: 10 non-hail (parse/validate/UsageError, incl. asserting the raw `KeyError` is intercepted) + 2 hail end-to-end.

The compose Hail unit + CLI tests run in CI's **Plugin contract (hail)** job (GitHub runners have Hail), so code correctness is CI-covered.

### Review
- Both commits passed independent adversarial per-task review (0 findings each).
- Final whole-branch Opus review: **CLEAN** — all contracts verified (generic, never-imputes, presence-flag off the whole join struct, manifest denominators, collision guard pre-Hail, CLI ordering, layering `algorithms ↛ skills/tools`, every `hl.*` real, tests assert real behavior).

### Deferred / follow-ups
1. **Real-data Slurm gate** (compose on the real 20k spine + structural checks) is **blocked on an HPC partition/association issue** (admin-side: `rosa.p` retired → `all_cpu.p`, account not yet re-associated). The sbatch is ready (`local/sbatch/p3_compose_gate.sbatch`); it will run once the cluster association is restored. This is a *real-data structural* run — not covered by CI, but not a code-correctness gap.
2. **Reviewer-flagged MINOR hardening** (latent — no current/planned spec triggers either): (a) a declared axis column that collides with a *spine* column name would silently overwrite it (collision guard is cross-axis only); (b) the manifest assumes numeric columns (`count_where(col > 0)`). Recommend folding (a) into the next increment as a fail-loud guard.
3. **Full Gate-1 AUC reproduction** (0.693/0.765/+0.066 ±0.005) needs the `eqtl` axis prepared into the framework + Layer-2 reuse — the natural next increment.

**Do not merge** until reviewed/approved (and ideally the real-data gate is green). Target `dev`, never `main`.
