### PR TITLE
feat(burden): hvantk cohort burden — gene-burden Fisher-exact prior origination

### DIFF
--- a/hvantk/algorithms/burden/__init__.py
+++ b/hvantk/algorithms/burden/__init__.py
@@ -1,0 +1,1 @@
+"""Gene-burden testing: variant→gene aggregation + Fisher-exact prior origination."""

--- a/hvantk/algorithms/burden/aggregate.py
+++ b/hvantk/algorithms/burden/aggregate.py
@@ -1,0 +1,123 @@
+"""Hail aggregation for gene-burden: clean MT -> per-gene[,route] carrier structures.
+
+``build_per_gene_carrier_mt`` is the SHARED primitive: it collapses variants to a
+per-(gene[,route]) x per-sample carrier MatrixTable with ``hets``/``homs``/``multi_het``
+entries. The gene-set enrichment path (enrichex) is rewired onto it in a later task, so
+its output schema deliberately matches the function it replaces
+(``hvantk.algorithms.enrichex.burden.compute_per_gene_burden_mt``) when ``route_field``
+is None.
+
+Everything statistical happens later in ``fet.py`` on small collected frames; this module
+only does the distributed per-sample counting and the fail-loud input contract.
+"""
+from __future__ import annotations
+
+import logging
+
+try:
+    import hail as hl
+except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
+    hl = None  # type: ignore
+    _HAIL_IMPORT_ERROR = exc
+else:
+    _HAIL_IMPORT_ERROR = None
+
+from hvantk.algorithms.burden.checks import (
+    check_required_fields,
+    check_key_space,
+    check_carrier_mode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _require_hail() -> None:
+    if hl is None:  # pragma: no cover - depends on env
+        raise ImportError(
+            "Hail is required for gene-burden aggregation."
+        ) from _HAIL_IMPORT_ERROR
+
+
+def _is_array(expr) -> bool:
+    return str(expr.dtype).startswith("array<")
+
+
+def build_per_gene_carrier_mt(mt, *, gene_field: str, route_field: str | None = None):
+    """variants -> per-(gene[,route]) x per-sample carrier MT (hets/homs/multi_het).
+
+    Identical to enrichex's ``compute_per_gene_burden_mt`` when ``route_field`` is
+    None (that function is rewired onto this primitive in a later task).
+    """
+    _require_hail()
+    if route_field is not None and _is_array(mt[route_field]):
+        mt = mt.explode_rows(mt[route_field])
+
+    mt = mt.filter_rows(hl.is_defined(mt[gene_field]))
+    if route_field is not None:
+        mt = mt.filter_rows(hl.is_defined(mt[route_field]))
+        grouped = mt.group_rows_by(mt[gene_field], mt[route_field])
+    else:
+        grouped = mt.group_rows_by(mt[gene_field])
+
+    return grouped.aggregate(
+        hets=hl.agg.count_where(mt.GT.is_het()),
+        homs=hl.agg.count_where(mt.GT.is_hom_var()),
+        multi_het=hl.agg.count_where(mt.GT.is_het()) >= 2,
+    )
+
+
+def qualifies_expr(carrier_mt, carrier_mode: str):
+    """Boolean entry expr: sample carries >=1 qualifying variant in this gene[,route]."""
+    check_carrier_mode(carrier_mode)
+    if carrier_mode == "het":
+        return carrier_mt.hets > 0
+    if carrier_mode == "hom":
+        return carrier_mt.homs > 0
+    if carrier_mode == "chet":
+        return carrier_mt.multi_het
+    return carrier_mt.multi_het | (carrier_mt.homs > 0)  # homs_chet
+
+
+def assert_clean_mt(
+    mt, *, gene_col: str, route_col: str, arm_col: str, key: str
+) -> None:
+    """Fail loud if the MT violates the clean-input contract.
+
+    Runs the pure field-name checks first (cheap, no Spark job), then the
+    data-dependent checks: bi-allelic rows and a defined, binary arm column.
+    """
+    _require_hail()
+    check_key_space(key)
+    check_required_fields(
+        row_fields=list(mt.row),
+        entry_fields=list(mt.entry),
+        col_fields=list(mt.col),
+        gene_col=gene_col,
+        route_col=route_col,
+        arm_col=arm_col,
+    )
+
+    n_multi = mt.filter_rows(hl.len(mt.alleles) != 2).count_rows()
+    if n_multi:
+        raise ValueError(
+            f"{n_multi} multiallelic row(s): the burden op requires split, bi-allelic "
+            "variants. Run hl.split_multi upstream."
+        )
+
+    stats = mt.aggregate_cols(
+        hl.struct(
+            n=hl.agg.count(),
+            n_defined=hl.agg.count_where(hl.is_defined(mt[arm_col])),
+            n_true=hl.agg.count_where(mt[arm_col]),
+        )
+    )
+    if stats.n_defined != stats.n:
+        raise ValueError(
+            f"case/control column {arm_col!r} must be a defined boolean for every sample; "
+            f"{stats.n - stats.n_defined}/{stats.n} are missing (sample QC is upstream)."
+        )
+    if stats.n_true == 0 or stats.n_true == stats.n:
+        raise ValueError(
+            f"case/control column {arm_col!r} must be binary: found "
+            f"{stats.n_true} cases / {stats.n - stats.n_true} controls."
+        )

--- a/hvantk/algorithms/burden/aggregate.py
+++ b/hvantk/algorithms/burden/aggregate.py
@@ -12,8 +12,6 @@ only does the distributed per-sample counting and the fail-loud input contract.
 """
 from __future__ import annotations
 
-import logging
-
 try:
     import hail as hl
 except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
@@ -27,8 +25,6 @@ from hvantk.algorithms.burden.checks import (
     check_key_space,
     check_carrier_mode,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _require_hail() -> None:
@@ -174,7 +170,11 @@ def variant_reductions(
     carrier_mode,
     score_field: str | None = None,
 ):
-    """Per-(gene,route) reduction inputs from per-variant arm carrier counts."""
+    """Per-(gene,route) reduction inputs from per-variant arm carrier counts.
+
+    Note: ``ctrl_freq`` (below) is the control-CARRIER frequency of a variant
+    (distinct control carriers / control samples), not an allele frequency.
+    """
     _require_hail()
     if _is_array(mt[route_field]):
         mt = mt.explode_rows(mt[route_field])
@@ -190,6 +190,8 @@ def variant_reductions(
         _n_ctrl_carr=hl.agg.count_where(carr & ~mt[arm_field]),
         _score=score,
     )
+    # _ctrl_freq is the control-carrier frequency (carriers / control samples), not
+    # an allele frequency -- see `variant_reductions` docstring.
     mt = mt.annotate_rows(_ctrl_freq=mt._n_ctrl_carr / n_ctrl if n_ctrl else 0.0)
     rows = mt.rows()
     grouped = rows.group_by(gene=rows[gene_field], route=rows[route_field]).aggregate(

--- a/hvantk/algorithms/burden/aggregate.py
+++ b/hvantk/algorithms/burden/aggregate.py
@@ -178,6 +178,10 @@ def variant_reductions(
     _require_hail()
     if _is_array(mt[route_field]):
         mt = mt.explode_rows(mt[route_field])
+    # Drop undefined gene/route so this frame stays consistent with count_2x2 (which
+    # filters both via build_per_gene_carrier_mt); otherwise (gene=None/route=None)
+    # groups appear here, never match a Fisher winner, and waste work.
+    mt = mt.filter_rows(hl.is_defined(mt[gene_field]) & hl.is_defined(mt[route_field]))
     carr = _carrier_variant_expr(mt, carrier_mode)
     n_ctrl = mt.aggregate_cols(hl.agg.count_where(~mt[arm_field]))
     score = (

--- a/hvantk/algorithms/burden/aggregate.py
+++ b/hvantk/algorithms/burden/aggregate.py
@@ -121,3 +121,101 @@ def assert_clean_mt(
             f"case/control column {arm_col!r} must be binary: found "
             f"{stats.n_true} cases / {stats.n - stats.n_true} controls."
         )
+
+
+def _carrier_variant_expr(mt, carrier_mode: str):
+    """Per-(variant,sample) 'is a carrier' expr for the per-variant reductions."""
+    check_carrier_mode(carrier_mode)
+    if carrier_mode == "hom":
+        return mt.GT.is_hom_var()
+    # het / chet / homs_chet all count a het genotype as a carrier at the variant level;
+    # chet vs homs_chet only change the *gene-level* qualifies rule (qualifies_expr).
+    return (
+        mt.GT.is_het() | mt.GT.is_hom_var()
+        if carrier_mode == "homs_chet"
+        else mt.GT.is_het()
+    )
+
+
+def count_2x2(mt, *, gene_field, route_field, arm_field, carrier_mode):
+    """Per-(gene,route) distinct-sample carrier counts by arm -> pandas DataFrame."""
+    _require_hail()
+    cmt = build_per_gene_carrier_mt(mt, gene_field=gene_field, route_field=route_field)
+    # carry the arm annotation onto the carrier MT's columns (same sample keys).
+    # mt.cols() must be captured once: two separate calls return two distinct Table
+    # objects, and Hail rejects combining expressions from different source objects.
+    mt_cols = mt.cols()
+    arm = mt_cols.select(_is_case=mt_cols[arm_field])
+    cmt = cmt.annotate_cols(_is_case=arm[cmt.col_key]._is_case)
+    q = qualifies_expr(cmt, carrier_mode)
+    cmt = cmt.annotate_rows(
+        a=hl.agg.count_where(q & cmt._is_case),
+        b=hl.agg.count_where(q & ~cmt._is_case),
+    )
+    arm_totals = mt.aggregate_cols(
+        hl.struct(
+            n_case=hl.agg.count_where(mt[arm_field]),
+            n_control=hl.agg.count_where(~mt[arm_field]),
+        )
+    )
+    pdf = cmt.rows().to_pandas()
+    pdf = pdf.rename(columns={gene_field: "gene", route_field: "route"})
+    pdf["n_case"] = arm_totals.n_case
+    pdf["n_control"] = arm_totals.n_control
+    return pdf[["gene", "route", "a", "b", "n_case", "n_control"]]
+
+
+def variant_reductions(
+    mt,
+    *,
+    gene_field,
+    route_field,
+    arm_field,
+    carrier_mode,
+    score_field: str | None = None,
+):
+    """Per-(gene,route) reduction inputs from per-variant arm carrier counts."""
+    _require_hail()
+    if _is_array(mt[route_field]):
+        mt = mt.explode_rows(mt[route_field])
+    carr = _carrier_variant_expr(mt, carrier_mode)
+    n_ctrl = mt.aggregate_cols(hl.agg.count_where(~mt[arm_field]))
+    score = (
+        mt[score_field]
+        if (score_field and score_field in mt.row)
+        else hl.missing(hl.tfloat64)
+    )
+    mt = mt.annotate_rows(
+        _n_case_carr=hl.agg.count_where(carr & mt[arm_field]),
+        _n_ctrl_carr=hl.agg.count_where(carr & ~mt[arm_field]),
+        _score=score,
+    )
+    mt = mt.annotate_rows(_ctrl_freq=mt._n_ctrl_carr / n_ctrl if n_ctrl else 0.0)
+    rows = mt.rows()
+    grouped = rows.group_by(gene=rows[gene_field], route=rows[route_field]).aggregate(
+        n_case_var=hl.agg.count_where(rows._n_case_carr > 0),
+        conc_num=hl.agg.filter(rows._n_case_carr > 0, hl.agg.max(rows._n_case_carr)),
+        conc_den=hl.agg.sum(rows._n_case_carr),
+        n_case_private=hl.agg.count_where(
+            (rows._n_case_carr > 0) & (rows._n_ctrl_carr == 0)
+        ),
+        score_sum=hl.agg.filter(rows._n_case_carr > 0, hl.agg.sum(rows._score)),
+        score_n=hl.agg.count_where(
+            (rows._n_case_carr > 0) & hl.is_defined(rows._score)
+        ),
+        drivers=hl.agg.filter(
+            rows._n_case_carr > 0,
+            hl.agg.collect(hl.struct(cc=rows._n_case_carr, ctrl_freq=rows._ctrl_freq)),
+        ),
+    )
+    pdf = grouped.to_pandas()
+    # to_pandas() renders array<struct> cells as plain Python lists of
+    # hail.utils.struct.Struct. Struct already supports d["cc"] (its __getitem__
+    # delegates to _get_field), so this conversion isn't strictly required for the
+    # downstream pandas layer's exact access pattern -- it's kept anyway to make the
+    # cross-layer contract (algorithms/burden -> fet.py) explicit plain dicts rather
+    # than a Hail-specific type, decoupling that layer from Hail regardless of version.
+    pdf["drivers"] = pdf["drivers"].apply(
+        lambda cell: [{"cc": x["cc"], "ctrl_freq": x["ctrl_freq"]} for x in cell]
+    )
+    return pdf

--- a/hvantk/algorithms/burden/checks.py
+++ b/hvantk/algorithms/burden/checks.py
@@ -32,6 +32,11 @@ def check_required_fields(
     route_col: str,
     arm_col: str,
 ) -> None:
+    for req in ("locus", "alleles"):
+        if req not in row_fields:
+            raise ValueError(
+                f"variant key field {req!r} not found in MatrixTable row fields {row_fields}"
+            )
     if gene_col not in row_fields:
         raise ValueError(
             f"gene column {gene_col!r} not found in MatrixTable row fields {row_fields}"

--- a/hvantk/algorithms/burden/checks.py
+++ b/hvantk/algorithms/burden/checks.py
@@ -1,0 +1,52 @@
+"""Pure-Python contract checks for the gene-burden op (no Hail).
+
+These validate the *names and vocabulary* of a burden request so a malformed call
+fails fast with an actionable message before any Spark start-up, exactly like
+``hvantk/algorithms/cohort/checks.py``. Data-dependent checks (bi-allelic rows,
+binary arm) live in ``aggregate.assert_clean_mt`` because they need the MatrixTable.
+"""
+from __future__ import annotations
+
+KEY_SPACES: tuple[str, ...] = ("gene_id", "hgnc_id", "symbol")
+CARRIER_MODES: tuple[str, ...] = ("het", "hom", "chet", "homs_chet")
+
+
+def check_key_space(key: str) -> None:
+    if key not in KEY_SPACES:
+        raise ValueError(
+            f"unknown gene key space {key!r}; must be one of {KEY_SPACES}"
+        )
+
+
+def check_carrier_mode(mode: str) -> None:
+    if mode not in CARRIER_MODES:
+        raise ValueError(
+            f"unknown carrier mode {mode!r}; must be one of {CARRIER_MODES}"
+        )
+
+
+def check_required_fields(
+    row_fields: list[str],
+    entry_fields: list[str],
+    col_fields: list[str],
+    *,
+    gene_col: str,
+    route_col: str,
+    arm_col: str,
+) -> None:
+    if gene_col not in row_fields:
+        raise ValueError(
+            f"gene column {gene_col!r} not found in MatrixTable row fields {row_fields}"
+        )
+    if route_col not in row_fields:
+        raise ValueError(
+            f"route column {route_col!r} not found in MatrixTable row fields {row_fields}"
+        )
+    if "GT" not in entry_fields:
+        raise ValueError(
+            f"genotype entry field 'GT' not found in MatrixTable entry fields {entry_fields}"
+        )
+    if arm_col not in col_fields:
+        raise ValueError(
+            f"case/control column {arm_col!r} not found in MatrixTable column fields {col_fields}"
+        )

--- a/hvantk/algorithms/burden/checks.py
+++ b/hvantk/algorithms/burden/checks.py
@@ -13,9 +13,7 @@ CARRIER_MODES: tuple[str, ...] = ("het", "hom", "chet", "homs_chet")
 
 def check_key_space(key: str) -> None:
     if key not in KEY_SPACES:
-        raise ValueError(
-            f"unknown gene key space {key!r}; must be one of {KEY_SPACES}"
-        )
+        raise ValueError(f"unknown gene key space {key!r}; must be one of {KEY_SPACES}")
 
 
 def check_carrier_mode(mode: str) -> None:

--- a/hvantk/algorithms/burden/fet.py
+++ b/hvantk/algorithms/burden/fet.py
@@ -1,0 +1,95 @@
+"""Fisher-exact gene-burden statistics on the small collected frames (no Hail).
+
+Given per-(gene,route) 2x2 counts and reduction inputs from ``aggregate.py``, compute
+the Fisher p/OR, take the min-p route as the gene's prior, attach the architecture
+reductions of that winning route, and (optionally) a multiple-testing-corrected column.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy.stats import fisher_exact
+
+
+def fisher_2x2(a: int, b: int, c: int, d: int) -> tuple[float, float]:
+    odds_ratio, p_value = fisher_exact([[a, b], [c, d]], alternative="two-sided")
+    return float(p_value), float(odds_ratio)
+
+
+def add_fisher(counts_df: pd.DataFrame) -> pd.DataFrame:
+    df = counts_df.copy()
+    df["c"] = df["n_case"] - df["a"]
+    df["d"] = df["n_control"] - df["b"]
+    stats = df.apply(
+        lambda r: fisher_2x2(int(r.a), int(r.b), int(r.c), int(r.d)), axis=1
+    )
+    df["p"] = [s[0] for s in stats]
+    df["odds_ratio"] = [s[1] for s in stats]
+    return df
+
+
+def pick_min_p(fisher_df: pd.DataFrame) -> pd.DataFrame:
+    df = fisher_df.sort_values(["gene", "p", "route"]).drop_duplicates(
+        "gene", keep="first"
+    )
+    return df.rename(columns={"p": "minp"})[["gene", "route", "minp", "odds_ratio"]]
+
+
+def _driver_af(drivers) -> float:
+    if not isinstance(drivers, (list, np.ndarray)) or len(drivers) == 0:
+        return float("nan")
+    top = max(drivers, key=lambda d: d["cc"])
+    return float(top["ctrl_freq"])
+
+
+def finalize_reductions(reductions_df: pd.DataFrame) -> pd.DataFrame:
+    df = reductions_df.copy()
+    df["conc"] = np.where(df["conc_den"] > 0, df["conc_num"] / df["conc_den"], np.nan)
+    df["driver_af"] = df["drivers"].apply(_driver_af)
+    df["frac_case_private"] = np.where(
+        df["n_case_var"] > 0, df["n_case_private"] / df["n_case_var"], np.nan
+    )
+    df["mean_score_case"] = np.where(
+        df["score_n"] > 0, df["score_sum"] / df["score_n"], np.nan
+    )
+    return df[
+        [
+            "gene",
+            "route",
+            "n_case_var",
+            "conc",
+            "driver_af",
+            "mean_score_case",
+            "frac_case_private",
+        ]
+    ]
+
+
+def apply_mtc(df: pd.DataFrame, method: str) -> pd.DataFrame:
+    out = df.copy()
+    p = out["minp"].to_numpy(dtype=float)
+    n = len(p)
+    if method == "bonferroni":
+        out["p_adj"] = np.minimum(p * n, 1.0)
+    elif method == "bh":
+        order = np.argsort(p)
+        ranked = p[order] * n / (np.arange(1, n + 1))
+        # enforce monotonicity from the largest p downward
+        ranked = np.minimum.accumulate(ranked[::-1])[::-1]
+        adj = np.empty(n)
+        adj[order] = np.minimum(ranked, 1.0)
+        out["p_adj"] = adj
+    else:
+        raise ValueError(f"unknown MTC method {method!r}; use 'bh' or 'bonferroni'")
+    return out
+
+
+def run_gene_burden_fet(
+    counts_df: pd.DataFrame, reductions_df: pd.DataFrame, *, mtc: str | None = None
+) -> pd.DataFrame:
+    winners = pick_min_p(add_fisher(counts_df))
+    reds = finalize_reductions(reductions_df)
+    out = winners.merge(reds, on=["gene", "route"], how="left")
+    if mtc is not None:
+        out = apply_mtc(out, mtc)
+    return out

--- a/hvantk/algorithms/burden/fet.py
+++ b/hvantk/algorithms/burden/fet.py
@@ -20,9 +20,12 @@ def add_fisher(counts_df: pd.DataFrame) -> pd.DataFrame:
     df = counts_df.copy()
     df["c"] = df["n_case"] - df["a"]
     df["d"] = df["n_control"] - df["b"]
-    stats = df.apply(
-        lambda r: fisher_2x2(int(r.a), int(r.b), int(r.c), int(r.d)), axis=1
-    )
+    # itertuples avoids the per-row Series construction of apply(axis=1); the
+    # per-row scipy fisher_exact call is unchanged, as is row order.
+    stats = [
+        fisher_2x2(int(r.a), int(r.b), int(r.c), int(r.d))
+        for r in df.itertuples(index=False)
+    ]
     df["p"] = [s[0] for s in stats]
     df["odds_ratio"] = [s[1] for s in stats]
     return df

--- a/hvantk/algorithms/burden/fet.py
+++ b/hvantk/algorithms/burden/fet.py
@@ -36,6 +36,10 @@ def pick_min_p(fisher_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _driver_af(drivers) -> float:
+    # "af" here is the control-CARRIER frequency (carriers / control samples) of the
+    # max-case-carrier ("cc") driver variant, not an allele frequency; the exact
+    # allele-vs-carrier semantics are pinned by the CHD reproduction gate -- do not
+    # change without re-running it.
     if not isinstance(drivers, (list, np.ndarray)) or len(drivers) == 0:
         return float("nan")
     top = max(drivers, key=lambda d: d["cc"])

--- a/hvantk/algorithms/burden/pipeline.py
+++ b/hvantk/algorithms/burden/pipeline.py
@@ -1,6 +1,12 @@
 """One-call gene-burden FET: clean MT -> assembled CohortManifest-conformant gene table."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hail as hl
+    import pandas as pd
+
 from hvantk.algorithms.burden.aggregate import (
     assert_clean_mt,
     count_2x2,
@@ -10,16 +16,61 @@ from hvantk.algorithms.burden.fet import run_gene_burden_fet
 
 
 def run_from_mt(
-    mt,
+    mt: "hl.MatrixTable",
     *,
-    gene_col,
-    route_col,
-    arm_col,
-    key,
-    carrier_mode="het",
-    score_field=None,
-    mtc=None,
-):
+    gene_col: str,
+    route_col: str,
+    arm_col: str,
+    key: str,
+    carrier_mode: str = "het",
+    score_field: str | None = None,
+    mtc: str | None = None,
+) -> "pd.DataFrame":
+    """Run the gene-burden Fisher-exact op end-to-end on a clean MatrixTable.
+
+    Pipeline: validate the clean-input contract (``assert_clean_mt``) -> per-
+    (gene[,route]) 2x2 carrier counts and variant-level reduction inputs
+    (``aggregate.py``, distributed Hail) -> Fisher-exact test + min-p route
+    selection + architecture reductions (``fet.py``, local pandas). The
+    result is one row per gene, taken at its min-p ("winning") route, and is
+    CohortManifest-conformant; a ``p_adj`` column is added when *mtc* is set.
+
+    Parameters
+    ----------
+    mt : hl.MatrixTable
+        Clean, split bi-allelic cohort MatrixTable with genotypes (``GT``),
+        a gene column, a route (variant-class) column, and a binary
+        case/control column.
+    gene_col : str
+        Row field naming the gene (values live in the *key* key-space).
+    route_col : str
+        Row field naming the variant-class "route" (e.g. lof/missense);
+        may be ``array<str>``, in which case a variant contributes to every
+        route it is tagged with.
+    arm_col : str
+        Column (sample) field: boolean, True for cases, False for controls.
+    key : str
+        Gene key space *gene_col* values live in; one of
+        ``checks.KEY_SPACES`` (``"gene_id"``, ``"hgnc_id"``, ``"symbol"``).
+    carrier_mode : str
+        Genotype-to-carrier rule; one of ``checks.CARRIER_MODES``
+        (``"het"``, ``"hom"``, ``"chet"``, ``"homs_chet"``). Default ``"het"``.
+    score_field : str, optional
+        Row field with a per-variant prediction score (e.g. REVEL) reduced
+        into ``mean_score_case``. ``None`` (default) disables the reduction.
+    mtc : str, optional
+        Multiple-testing-correction method (``"bonferroni"`` or ``"bh"``)
+        applied to the gene-level min-p; ``None`` (default) skips it.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per gene (column ``"gene"``) with its winning ``route``,
+        Fisher ``minp``/``odds_ratio``, and that route's architecture
+        reductions (``n_case_var``, ``conc``, ``driver_af``,
+        ``mean_score_case``, ``frac_case_private``), plus ``p_adj`` when
+        *mtc* is set.
+    """
     assert_clean_mt(
         mt, gene_col=gene_col, route_col=route_col, arm_col=arm_col, key=key
     )

--- a/hvantk/algorithms/burden/pipeline.py
+++ b/hvantk/algorithms/burden/pipeline.py
@@ -1,0 +1,41 @@
+"""One-call gene-burden FET: clean MT -> assembled CohortManifest-conformant gene table."""
+from __future__ import annotations
+
+from hvantk.algorithms.burden.aggregate import (
+    assert_clean_mt,
+    count_2x2,
+    variant_reductions,
+)
+from hvantk.algorithms.burden.fet import run_gene_burden_fet
+
+
+def run_from_mt(
+    mt,
+    *,
+    gene_col,
+    route_col,
+    arm_col,
+    key,
+    carrier_mode="het",
+    score_field=None,
+    mtc=None,
+):
+    assert_clean_mt(
+        mt, gene_col=gene_col, route_col=route_col, arm_col=arm_col, key=key
+    )
+    counts = count_2x2(
+        mt,
+        gene_field=gene_col,
+        route_field=route_col,
+        arm_field=arm_col,
+        carrier_mode=carrier_mode,
+    )
+    reductions = variant_reductions(
+        mt,
+        gene_field=gene_col,
+        route_field=route_col,
+        arm_field=arm_col,
+        carrier_mode=carrier_mode,
+        score_field=score_field,
+    )
+    return run_gene_burden_fet(counts, reductions, mtc=mtc)

--- a/hvantk/algorithms/enrichex/burden.py
+++ b/hvantk/algorithms/enrichex/burden.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
+
     # Artifact types — used only in string annotations for the Phase P
     # artifact-typed wrappers. Imported under TYPE_CHECKING so flake8 sees
     # the names; the wrappers themselves import lazily inside the function
@@ -41,6 +42,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
 else:
     _HAIL_IMPORT_ERROR = None
 
+from hvantk.algorithms.burden.aggregate import build_per_gene_carrier_mt
 from hvantk.algorithms.enrichex.constants import (
     DEFAULT_AF_FIELD,
     DEFAULT_CONSEQUENCE_FIELD,
@@ -230,12 +232,8 @@ def compute_per_gene_burden_mt(
     # Filter to rows with gene annotation
     mt = mt.filter_rows(hl.is_defined(mt[gene_field]))
 
-    # Aggregate variants -> genes per sample
-    mt_genes = mt.group_rows_by(mt[gene_field]).aggregate(
-        hets=hl.agg.count_where(mt.GT.is_het()),
-        homs=hl.agg.count_where(mt.GT.is_hom_var()),
-        multi_het=hl.agg.count_where(mt.GT.is_het()) >= 2,
-    )
+    # Aggregate variants -> genes per sample (shared primitive; identical schema)
+    mt_genes = build_per_gene_carrier_mt(mt, gene_field=gene_field)
 
     n_genes = mt_genes.count_rows()
     logger.info("  %d unique genes after aggregation", n_genes)
@@ -404,9 +402,7 @@ def compute_geneset_burden_mt(
     # No-op for the canonical pipeline (parse_geneset_tsv already dedups); this
     # only affects callers passing raw, duplicate-containing lists, where the
     # deduped membership would otherwise disagree with len()-based sizes.
-    gene_sets = {
-        name: list(dict.fromkeys(genes)) for name, genes in gene_sets.items()
-    }
+    gene_sets = {name: list(dict.fromkeys(genes)) for name, genes in gene_sets.items()}
 
     # Pre-filter gene sets by minimum size
     if min_gene_set_size > 0:

--- a/hvantk/tests/burden/test_aggregate_hail.py
+++ b/hvantk/tests/burden/test_aggregate_hail.py
@@ -82,7 +82,7 @@ def test_assert_clean_mt_rejects_multiallelic():
     # with the gene/route/arm/GT fields assert_clean_mt requires.
     mt = hl.utils.range_matrix_table(n_rows=1, n_cols=1)
     mt = mt.annotate_rows(
-        locus=hl.locus("1", 400, reference_genome="GRCh38"),
+        locus=hl.locus("chr1", 400, reference_genome="GRCh38"),
         alleles=["A", "C", "G"],
         SYMBOL="GENEC",
         csq_group="lof",

--- a/hvantk/tests/burden/test_aggregate_hail.py
+++ b/hvantk/tests/burden/test_aggregate_hail.py
@@ -1,0 +1,115 @@
+import pytest
+import hail as hl
+
+from hvantk.algorithms.burden.aggregate import (
+    build_per_gene_carrier_mt,
+    assert_clean_mt,
+    qualifies_expr,
+)
+
+pytestmark = pytest.mark.hail
+
+
+def _toy_mt():
+    """3 variants (2 in GENEA/lof, 1 in GENEB/mis) x 4 samples.
+
+    Carrier pattern: variant0 (GENEA/lof) het in s0 (case); variant1
+    (GENEA/lof) het in s1 (case); variant2 (GENEB/mis) het in s2 (control).
+    Everyone else is hom-ref. s0/s1 are cases; s2/s3 are controls.
+
+    Built on ``hl.utils.range_matrix_table`` (not ``from_rows_table``, which
+    yields a zero-column MT that cannot be given samples via annotate_cols).
+    Shared by later tasks' tests -- keep it a clean, reusable helper.
+    """
+    mt = hl.utils.range_matrix_table(n_rows=3, n_cols=4)
+
+    genes = hl.literal(["GENEA", "GENEA", "GENEB"])
+    routes = hl.literal(["lof", "lof", "mis"])
+    positions = hl.literal([100, 200, 300])
+    alt_alleles = hl.literal(["C", "G", "T"])
+    mt = mt.annotate_rows(
+        locus=hl.locus("1", positions[mt.row_idx], reference_genome="GRCh38"),
+        alleles=hl.array(["A", alt_alleles[mt.row_idx]]),
+        SYMBOL=genes[mt.row_idx],
+        csq_group=routes[mt.row_idx],
+    )
+    mt = mt.key_rows_by("locus", "alleles")
+
+    sample_ids = hl.literal(["s0", "s1", "s2", "s3"])
+    mt = mt.annotate_cols(s=sample_ids[mt.col_idx], is_case=mt.col_idx < 2)
+    mt = mt.key_cols_by("s")
+
+    # variant_i is carried het by sample_i for i in {0, 1, 2}; everyone else hom-ref.
+    mt = mt.annotate_entries(
+        GT=hl.if_else(mt.row_idx == mt.col_idx, hl.call(0, 1), hl.call(0, 0))
+    )
+    return mt.drop("row_idx", "col_idx")
+
+
+def test_carrier_primitive_schema_no_route():
+    mt = _toy_mt()
+    out = build_per_gene_carrier_mt(mt, gene_field="SYMBOL")
+    assert set(out.entry) == {"hets", "homs", "multi_het"}
+    assert list(out.row_key) == ["SYMBOL"]
+
+
+def test_carrier_primitive_with_route_keys_on_gene_and_route():
+    mt = _toy_mt()
+    out = build_per_gene_carrier_mt(mt, gene_field="SYMBOL", route_field="csq_group")
+    assert list(out.row_key) == ["SYMBOL", "csq_group"]
+    # GENEA/lof exists, GENEB/mis exists
+    rows = out.rows()
+    genes = rows.aggregate(hl.agg.collect_as_set(rows.SYMBOL))
+    assert genes == {"GENEA", "GENEB"}
+
+
+def test_assert_clean_mt_rejects_missing_route():
+    mt = _toy_mt().drop("csq_group")
+    with pytest.raises(ValueError, match="route column 'csq_group' not found"):
+        assert_clean_mt(
+            mt,
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
+            key="symbol",
+        )
+
+
+def test_assert_clean_mt_rejects_multiallelic():
+    # A tiny, standalone 1x1 MT whose single row is multiallelic (3 alleles),
+    # with the gene/route/arm/GT fields assert_clean_mt requires.
+    mt = hl.utils.range_matrix_table(n_rows=1, n_cols=1)
+    mt = mt.annotate_rows(
+        locus=hl.locus("1", 400, reference_genome="GRCh38"),
+        alleles=["A", "C", "G"],
+        SYMBOL="GENEC",
+        csq_group="lof",
+    )
+    mt = mt.key_rows_by("locus", "alleles")
+    mt = mt.annotate_cols(s="s0", is_case=True)
+    mt = mt.key_cols_by("s")
+    mt = mt.annotate_entries(GT=hl.call(0, 0))
+    mt = mt.drop("row_idx", "col_idx")
+
+    with pytest.raises(ValueError, match="multiallelic"):
+        assert_clean_mt(
+            mt,
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
+            key="symbol",
+        )
+
+
+def test_assert_clean_mt_rejects_non_binary_arm():
+    mt = _toy_mt().annotate_cols(is_case=hl.missing(hl.tbool))
+    with pytest.raises(
+        ValueError, match="case/control column 'is_case' must be a defined boolean"
+    ):
+        assert_clean_mt(
+            mt,
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
+            key="symbol",
+        )

--- a/hvantk/tests/burden/test_aggregate_hail.py
+++ b/hvantk/tests/burden/test_aggregate_hail.py
@@ -7,6 +7,7 @@ from hvantk.algorithms.burden.aggregate import (
     count_2x2,
     variant_reductions,
 )
+from hvantk.algorithms.burden.fet import finalize_reductions
 from hvantk.algorithms.burden.pipeline import run_from_mt
 
 pytestmark = pytest.mark.hail
@@ -176,3 +177,163 @@ def test_run_from_mt_end_to_end():
     for col in ["route", "minp", "odds_ratio", "n_case_var", "conc", "driver_af"]:
         assert col in df.columns
     assert df.loc["GENEA", "n_case_var"] == 2
+    # GENEA's only route in _toy_mt() is lof, so it must be the winning route.
+    assert df.loc["GENEA", "route"] == "lof"
+
+
+def test_build_per_gene_carrier_mt_entry_values():
+    """Concrete hets/homs/multi_het entry values, not just row-key/shape."""
+    mt = _toy_mt()
+    out = build_per_gene_carrier_mt(mt, gene_field="SYMBOL", route_field="csq_group")
+    entries = out.entries().to_pandas()
+
+    def _entry(gene, route, sample):
+        rows = entries[
+            (entries.SYMBOL == gene)
+            & (entries.csq_group == route)
+            & (entries.s == sample)
+        ]
+        assert len(rows) == 1
+        return rows.iloc[0]
+
+    # variant0 (GENEA/lof) is het carried by s0 only.
+    s0 = _entry("GENEA", "lof", "s0")
+    assert s0["hets"] == 1
+    assert s0["homs"] == 0
+    assert not bool(s0["multi_het"])
+
+    # variant1 (GENEA/lof) is het carried by s1 only.
+    s1 = _entry("GENEA", "lof", "s1")
+    assert s1["hets"] == 1
+
+    # s2/s3 carry no GENEA/lof variant.
+    assert _entry("GENEA", "lof", "s2")["hets"] == 0
+    assert _entry("GENEA", "lof", "s3")["hets"] == 0
+
+    # variant2 (GENEB/mis) is het carried by s2 only.
+    assert _entry("GENEB", "mis", "s2")["hets"] == 1
+    assert _entry("GENEB", "mis", "s3")["hets"] == 0
+
+
+def _array_route_mt():
+    """1 variant in GENEA tagged with TWO routes (lof, missC), het in s0.
+
+    Exercises the ``array<str>`` explode_rows branch (``_is_array``) of
+    ``build_per_gene_carrier_mt``: a variant tagged with multiple routes
+    must contribute to every one of them.
+    """
+    mt = hl.utils.range_matrix_table(n_rows=1, n_cols=2)
+    mt = mt.annotate_rows(
+        locus=hl.locus("chr1", 500, reference_genome="GRCh38"),
+        alleles=hl.array(["A", "C"]),
+        SYMBOL="GENEA",
+        csq_group=hl.literal(["lof", "missC"]),
+    )
+    mt = mt.key_rows_by("locus", "alleles")
+
+    sample_ids = hl.literal(["s0", "s1"])
+    mt = mt.annotate_cols(s=sample_ids[mt.col_idx], is_case=mt.col_idx == 0)
+    mt = mt.key_cols_by("s")
+
+    mt = mt.annotate_entries(
+        GT=hl.if_else(mt.col_idx == 0, hl.call(0, 1), hl.call(0, 0))
+    )
+    return mt.drop("row_idx", "col_idx")
+
+
+def test_build_per_gene_carrier_mt_explodes_array_route():
+    mt = _array_route_mt()
+    out = build_per_gene_carrier_mt(mt, gene_field="SYMBOL", route_field="csq_group")
+    assert list(out.row_key) == ["SYMBOL", "csq_group"]
+    rows = out.rows()
+    keys = rows.aggregate(
+        hl.agg.collect_as_set(hl.struct(SYMBOL=rows.SYMBOL, csq_group=rows.csq_group))
+    )
+    assert keys == {
+        hl.Struct(SYMBOL="GENEA", csq_group="lof"),
+        hl.Struct(SYMBOL="GENEA", csq_group="missC"),
+    }
+
+    # the single variant carries s0 as a het -> both exploded (gene,route) rows
+    # must see s0 as a carrier.
+    entries = out.entries().to_pandas()
+    for route in ("lof", "missC"):
+        row = entries[
+            (entries.SYMBOL == "GENEA")
+            & (entries.csq_group == route)
+            & (entries.s == "s0")
+        ]
+        assert len(row) == 1
+        assert row.iloc[0]["hets"] == 1
+
+
+def _hom_carrier_mt():
+    """1 variant in GENEA, hom-var in s0 (case), hom-ref in s1 (control).
+
+    Exercises ``carrier_mode="hom"`` in ``count_2x2`` (vs. the default "het").
+    """
+    mt = hl.utils.range_matrix_table(n_rows=1, n_cols=2)
+    mt = mt.annotate_rows(
+        locus=hl.locus("chr1", 600, reference_genome="GRCh38"),
+        alleles=hl.array(["A", "C"]),
+        SYMBOL="GENEA",
+        csq_group="lof",
+    )
+    mt = mt.key_rows_by("locus", "alleles")
+
+    sample_ids = hl.literal(["s0", "s1"])
+    mt = mt.annotate_cols(s=sample_ids[mt.col_idx], is_case=mt.col_idx == 0)
+    mt = mt.key_cols_by("s")
+
+    mt = mt.annotate_entries(
+        GT=hl.if_else(mt.col_idx == 0, hl.call(1, 1), hl.call(0, 0))
+    )
+    return mt.drop("row_idx", "col_idx")
+
+
+def test_count_2x2_hom_carrier_mode_vs_het():
+    mt = _hom_carrier_mt()
+    hom_df = count_2x2(
+        mt,
+        gene_field="SYMBOL",
+        route_field="csq_group",
+        arm_field="is_case",
+        carrier_mode="hom",
+    ).set_index(["gene", "route"])
+    het_df = count_2x2(
+        mt,
+        gene_field="SYMBOL",
+        route_field="csq_group",
+        arm_field="is_case",
+        carrier_mode="het",
+    ).set_index(["gene", "route"])
+    # s0 (case) is hom-var -> counted as a carrier under "hom", not under "het".
+    assert hom_df.loc[("GENEA", "lof"), "a"] == 1
+    assert het_df.loc[("GENEA", "lof"), "a"] == 0
+
+
+def test_variant_reductions_score_field_reflects_case_scores():
+    mt = _toy_mt()
+    # REVEL-like float score keyed by position: variant0=0.8, variant1=0.6, variant2=0.3.
+    revel_by_pos = hl.literal(
+        {100: 0.8, 200: 0.6, 300: 0.3}, dtype=hl.tdict(hl.tint32, hl.tfloat64)
+    )
+    mt = mt.annotate_rows(revel=revel_by_pos.get(mt.locus.position))
+
+    df = variant_reductions(
+        mt,
+        gene_field="SYMBOL",
+        route_field="csq_group",
+        arm_field="is_case",
+        carrier_mode="het",
+        score_field="revel",
+    ).set_index(["gene", "route"])
+    # GENEA/lof case-carried variants are variant0 (revel=0.8, s0) and
+    # variant1 (revel=0.6, s1) -> score_sum/score_n reflect both.
+    assert df.loc[("GENEA", "lof"), "score_sum"] == pytest.approx(1.4)
+    assert df.loc[("GENEA", "lof"), "score_n"] == 2
+    # GENEB/mis's only variant is carried by a control -> no case-carried scores.
+    assert df.loc[("GENEB", "mis"), "score_n"] == 0
+
+    fin = finalize_reductions(df.reset_index()).set_index(["gene", "route"])
+    assert fin.loc[("GENEA", "lof"), "mean_score_case"] == pytest.approx(0.7)

--- a/hvantk/tests/burden/test_aggregate_hail.py
+++ b/hvantk/tests/burden/test_aggregate_hail.py
@@ -30,7 +30,7 @@ def _toy_mt():
     positions = hl.literal([100, 200, 300])
     alt_alleles = hl.literal(["C", "G", "T"])
     mt = mt.annotate_rows(
-        locus=hl.locus("1", positions[mt.row_idx], reference_genome="GRCh38"),
+        locus=hl.locus("chr1", positions[mt.row_idx], reference_genome="GRCh38"),
         alleles=hl.array(["A", alt_alleles[mt.row_idx]]),
         SYMBOL=genes[mt.row_idx],
         csq_group=routes[mt.row_idx],

--- a/hvantk/tests/burden/test_aggregate_hail.py
+++ b/hvantk/tests/burden/test_aggregate_hail.py
@@ -7,6 +7,7 @@ from hvantk.algorithms.burden.aggregate import (
     count_2x2,
     variant_reductions,
 )
+from hvantk.algorithms.burden.pipeline import run_from_mt
 
 pytestmark = pytest.mark.hail
 
@@ -158,3 +159,20 @@ def test_variant_reductions_counts_and_drivers():
     top = max(drivers, key=lambda d: d["cc"])
     assert top["cc"] == 1
     assert top["ctrl_freq"] == 0.0
+
+
+def test_run_from_mt_end_to_end():
+    mt = _toy_mt()
+    df = run_from_mt(
+        mt,
+        gene_col="SYMBOL",
+        route_col="csq_group",
+        arm_col="is_case",
+        key="symbol",
+        carrier_mode="het",
+    ).set_index("gene")
+    # GENEA carried only by cases -> its prior route is lof with a low-ish p; columns present
+    assert "GENEA" in df.index
+    for col in ["route", "minp", "odds_ratio", "n_case_var", "conc", "driver_af"]:
+        assert col in df.columns
+    assert df.loc["GENEA", "n_case_var"] == 2

--- a/hvantk/tests/burden/test_aggregate_hail.py
+++ b/hvantk/tests/burden/test_aggregate_hail.py
@@ -4,7 +4,8 @@ import hail as hl
 from hvantk.algorithms.burden.aggregate import (
     build_per_gene_carrier_mt,
     assert_clean_mt,
-    qualifies_expr,
+    count_2x2,
+    variant_reductions,
 )
 
 pytestmark = pytest.mark.hail
@@ -113,3 +114,47 @@ def test_assert_clean_mt_rejects_non_binary_arm():
             arm_col="is_case",
             key="symbol",
         )
+
+
+def test_count_2x2_distinct_sample_carriers():
+    mt = _toy_mt()  # GENEA/lof: s0(case),s1(case) carriers; GENEB/mis: s2(control)
+    df = count_2x2(
+        mt,
+        gene_field="SYMBOL",
+        route_field="csq_group",
+        arm_field="is_case",
+        carrier_mode="het",
+    ).set_index(["gene", "route"])
+    assert df.loc[("GENEA", "lof"), "a"] == 2  # 2 case carriers
+    assert df.loc[("GENEA", "lof"), "b"] == 0  # 0 control carriers
+    assert df.loc[("GENEB", "mis"), "a"] == 0
+    assert df.loc[("GENEB", "mis"), "b"] == 1
+    assert df.loc[("GENEA", "lof"), "n_case"] == 2
+    assert df.loc[("GENEA", "lof"), "n_control"] == 2
+
+
+def test_variant_reductions_counts_and_drivers():
+    mt = _toy_mt()
+    df = variant_reductions(
+        mt,
+        gene_field="SYMBOL",
+        route_field="csq_group",
+        arm_field="is_case",
+        carrier_mode="het",
+    ).set_index(["gene", "route"])
+    # GENEA/lof has 2 variants, each carried by 1 distinct case -> n_case_var == 2
+    assert df.loc[("GENEA", "lof"), "n_case_var"] == 2
+    assert df.loc[("GENEA", "lof"), "conc_num"] == 1  # max single-variant case carriers
+    assert df.loc[("GENEA", "lof"), "conc_den"] == 2  # sum of case carriers
+    # both GENEA variants are case-private (0 control carriers)
+    assert df.loc[("GENEA", "lof"), "n_case_private"] == 2
+    # GENEB/mis is carried only by a control -> no case variants
+    assert df.loc[("GENEB", "mis"), "n_case_var"] == 0
+
+    # drivers must be usable exactly the way Task 4's pandas layer will use it:
+    # max(drivers, key=lambda d: d["cc"]) then d["ctrl_freq"].
+    drivers = df.loc[("GENEA", "lof"), "drivers"]
+    assert len(drivers) == 2
+    top = max(drivers, key=lambda d: d["cc"])
+    assert top["cc"] == 1
+    assert top["ctrl_freq"] == 0.0

--- a/hvantk/tests/burden/test_checks.py
+++ b/hvantk/tests/burden/test_checks.py
@@ -1,7 +1,10 @@
 import pytest
 from hvantk.algorithms.burden.checks import (
-    KEY_SPACES, CARRIER_MODES,
-    check_key_space, check_carrier_mode, check_required_fields,
+    KEY_SPACES,
+    CARRIER_MODES,
+    check_key_space,
+    check_carrier_mode,
+    check_required_fields,
 )
 
 
@@ -24,16 +27,23 @@ def test_required_fields_all_present_ok():
         row_fields=["locus", "alleles", "SYMBOL", "csq_group"],
         entry_fields=["GT"],
         col_fields=["s", "is_case"],
-        gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+        gene_col="SYMBOL",
+        route_col="csq_group",
+        arm_col="is_case",
     )
 
 
 def test_required_fields_missing_gene_names_it():
-    with pytest.raises(ValueError, match="gene column 'SYMBOL' not found in MatrixTable row fields"):
+    with pytest.raises(
+        ValueError, match="gene column 'SYMBOL' not found in MatrixTable row fields"
+    ):
         check_required_fields(
             row_fields=["locus", "alleles", "csq_group"],
-            entry_fields=["GT"], col_fields=["s", "is_case"],
-            gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+            entry_fields=["GT"],
+            col_fields=["s", "is_case"],
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
         )
 
 
@@ -41,15 +51,42 @@ def test_required_fields_missing_gt_names_it():
     with pytest.raises(ValueError, match="genotype entry field 'GT' not found"):
         check_required_fields(
             row_fields=["locus", "alleles", "SYMBOL", "csq_group"],
-            entry_fields=["AD"], col_fields=["s", "is_case"],
-            gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+            entry_fields=["AD"],
+            col_fields=["s", "is_case"],
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
         )
 
 
 def test_required_fields_missing_arm_names_it():
-    with pytest.raises(ValueError, match="case/control column 'is_case' not found in MatrixTable column fields"):
+    with pytest.raises(
+        ValueError,
+        match="case/control column 'is_case' not found in MatrixTable column fields",
+    ):
         check_required_fields(
             row_fields=["locus", "alleles", "SYMBOL", "csq_group"],
-            entry_fields=["GT"], col_fields=["s"],
-            gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+            entry_fields=["GT"],
+            col_fields=["s"],
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
+        )
+
+
+def test_carrier_modes_value():
+    assert CARRIER_MODES == ("het", "hom", "chet", "homs_chet")
+
+
+def test_required_fields_missing_route_names_it():
+    with pytest.raises(
+        ValueError, match="route column 'csq_group' not found in MatrixTable row fields"
+    ):
+        check_required_fields(
+            row_fields=["locus", "alleles", "SYMBOL"],
+            entry_fields=["GT"],
+            col_fields=["s", "is_case"],
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
         )

--- a/hvantk/tests/burden/test_checks.py
+++ b/hvantk/tests/burden/test_checks.py
@@ -1,0 +1,55 @@
+import pytest
+from hvantk.algorithms.burden.checks import (
+    KEY_SPACES, CARRIER_MODES,
+    check_key_space, check_carrier_mode, check_required_fields,
+)
+
+
+def test_key_spaces_match_cohort_contract():
+    assert KEY_SPACES == ("gene_id", "hgnc_id", "symbol")
+
+
+def test_check_key_space_rejects_unknown():
+    with pytest.raises(ValueError, match="unknown gene key space 'ensembl'"):
+        check_key_space("ensembl")
+
+
+def test_check_carrier_mode_rejects_unknown():
+    with pytest.raises(ValueError, match="unknown carrier mode 'dom'"):
+        check_carrier_mode("dom")
+
+
+def test_required_fields_all_present_ok():
+    check_required_fields(
+        row_fields=["locus", "alleles", "SYMBOL", "csq_group"],
+        entry_fields=["GT"],
+        col_fields=["s", "is_case"],
+        gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+    )
+
+
+def test_required_fields_missing_gene_names_it():
+    with pytest.raises(ValueError, match="gene column 'SYMBOL' not found in MatrixTable row fields"):
+        check_required_fields(
+            row_fields=["locus", "alleles", "csq_group"],
+            entry_fields=["GT"], col_fields=["s", "is_case"],
+            gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+        )
+
+
+def test_required_fields_missing_gt_names_it():
+    with pytest.raises(ValueError, match="genotype entry field 'GT' not found"):
+        check_required_fields(
+            row_fields=["locus", "alleles", "SYMBOL", "csq_group"],
+            entry_fields=["AD"], col_fields=["s", "is_case"],
+            gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+        )
+
+
+def test_required_fields_missing_arm_names_it():
+    with pytest.raises(ValueError, match="case/control column 'is_case' not found in MatrixTable column fields"):
+        check_required_fields(
+            row_fields=["locus", "alleles", "SYMBOL", "csq_group"],
+            entry_fields=["GT"], col_fields=["s"],
+            gene_col="SYMBOL", route_col="csq_group", arm_col="is_case",
+        )

--- a/hvantk/tests/burden/test_checks.py
+++ b/hvantk/tests/burden/test_checks.py
@@ -78,6 +78,36 @@ def test_carrier_modes_value():
     assert CARRIER_MODES == ("het", "hom", "chet", "homs_chet")
 
 
+def test_required_fields_missing_locus_names_it():
+    with pytest.raises(
+        ValueError,
+        match="variant key field 'locus' not found in MatrixTable row fields",
+    ):
+        check_required_fields(
+            row_fields=["alleles", "SYMBOL", "csq_group"],
+            entry_fields=["GT"],
+            col_fields=["s", "is_case"],
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
+        )
+
+
+def test_required_fields_missing_alleles_names_it():
+    with pytest.raises(
+        ValueError,
+        match="variant key field 'alleles' not found in MatrixTable row fields",
+    ):
+        check_required_fields(
+            row_fields=["locus", "SYMBOL", "csq_group"],
+            entry_fields=["GT"],
+            col_fields=["s", "is_case"],
+            gene_col="SYMBOL",
+            route_col="csq_group",
+            arm_col="is_case",
+        )
+
+
 def test_required_fields_missing_route_names_it():
     with pytest.raises(
         ValueError, match="route column 'csq_group' not found in MatrixTable row fields"

--- a/hvantk/tests/burden/test_cli_hail.py
+++ b/hvantk/tests/burden/test_cli_hail.py
@@ -1,0 +1,41 @@
+import pytest
+import pandas as pd
+import hail as hl
+from click.testing import CliRunner
+
+from hvantk.tools.cohort.cohort_cli import cohort_group
+from hvantk.tests.burden.test_aggregate_hail import _toy_mt
+
+pytestmark = pytest.mark.hail
+
+
+def test_cohort_burden_cli_writes_gene_table(tmp_path):
+    mt_path = str(tmp_path / "cohort.mt")
+    _toy_mt().write(mt_path, overwrite=True)
+    out_path = str(tmp_path / "genes.tsv")
+    res = CliRunner().invoke(
+        cohort_group,
+        [
+            "burden",
+            "--mt",
+            mt_path,
+            "--gene-col",
+            "SYMBOL",
+            "--route-col",
+            "csq_group",
+            "--arm-col",
+            "is_case",
+            "--key",
+            "symbol",
+            "--mtc",
+            "bh",
+            "--output",
+            out_path,
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    df = pd.read_csv(out_path, sep="\t")
+    assert {"gene", "route", "minp", "n_case_var", "conc", "driver_af", "p_adj"} <= set(
+        df.columns
+    )
+    assert "GENEA" in set(df["gene"])

--- a/hvantk/tests/burden/test_fet.py
+++ b/hvantk/tests/burden/test_fet.py
@@ -1,0 +1,139 @@
+import math
+import pandas as pd
+from scipy.stats import fisher_exact
+
+from hvantk.algorithms.burden.fet import (
+    fisher_2x2,
+    add_fisher,
+    pick_min_p,
+    finalize_reductions,
+    apply_mtc,
+    run_gene_burden_fet,
+)
+
+
+def test_fisher_2x2_matches_scipy():
+    p, orr = fisher_2x2(8, 2, 100, 400)
+    exp_or, exp_p = fisher_exact([[8, 2], [100, 400]], alternative="two-sided")
+    assert math.isclose(p, exp_p, rel_tol=1e-12)
+    assert math.isclose(orr, exp_or, rel_tol=1e-9)
+
+
+def test_add_fisher_derives_cd():
+    counts = pd.DataFrame(
+        [{"gene": "G", "route": "lof", "a": 5, "b": 1, "n_case": 100, "n_control": 100}]
+    )
+    out = add_fisher(counts)
+    assert out.loc[0, "p"] > 0
+    # c = 95, d = 99 implied
+    assert "odds_ratio" in out.columns
+
+
+def test_pick_min_p_selects_winning_route():
+    fdf = pd.DataFrame(
+        [
+            {"gene": "G", "route": "lof", "p": 0.2, "odds_ratio": 2.0},
+            {"gene": "G", "route": "mis", "p": 0.01, "odds_ratio": 9.0},
+        ]
+    )
+    out = pick_min_p(fdf).set_index("gene")
+    assert out.loc["G", "route"] == "mis"
+    assert math.isclose(out.loc["G", "minp"], 0.01)
+
+
+def test_finalize_reductions_math():
+    rdf = pd.DataFrame(
+        [
+            {
+                "gene": "G",
+                "route": "lof",
+                "n_case_var": 4,
+                "conc_num": 3,
+                "conc_den": 6,
+                "n_case_private": 3,
+                "score_sum": 2.0,
+                "score_n": 2,
+                "drivers": [
+                    {"cc": 3, "ctrl_freq": 0.004},
+                    {"cc": 1, "ctrl_freq": 0.05},
+                ],
+            }
+        ]
+    )
+    out = finalize_reductions(rdf).set_index(["gene", "route"])
+    assert math.isclose(out.loc[("G", "lof"), "conc"], 0.5)
+    assert math.isclose(
+        out.loc[("G", "lof"), "driver_af"], 0.004
+    )  # ctrl_freq of the max-cc driver
+    assert math.isclose(out.loc[("G", "lof"), "frac_case_private"], 0.75)
+    assert math.isclose(out.loc[("G", "lof"), "mean_score_case"], 1.0)
+
+
+def test_apply_mtc_bh_monotone():
+    df = pd.DataFrame({"minp": [0.001, 0.02, 0.5]})
+    out = apply_mtc(df, "bh")
+    assert list(out["p_adj"]) == sorted(out["p_adj"])  # BH-adjusted preserve order
+    assert out["p_adj"].iloc[0] >= 0.001
+
+
+def test_run_end_to_end_prior_and_columns():
+    counts = pd.DataFrame(
+        [
+            {
+                "gene": "G",
+                "route": "lof",
+                "a": 8,
+                "b": 1,
+                "n_case": 100,
+                "n_control": 400,
+            },
+            {
+                "gene": "G",
+                "route": "mis",
+                "a": 2,
+                "b": 2,
+                "n_case": 100,
+                "n_control": 400,
+            },
+        ]
+    )
+    reductions = pd.DataFrame(
+        [
+            {
+                "gene": "G",
+                "route": "lof",
+                "n_case_var": 5,
+                "conc_num": 4,
+                "conc_den": 8,
+                "n_case_private": 5,
+                "score_sum": 0.0,
+                "score_n": 0,
+                "drivers": [{"cc": 4, "ctrl_freq": 0.0}],
+            },
+            {
+                "gene": "G",
+                "route": "mis",
+                "n_case_var": 2,
+                "conc_num": 1,
+                "conc_den": 2,
+                "n_case_private": 1,
+                "score_sum": 0.0,
+                "score_n": 0,
+                "drivers": [{"cc": 1, "ctrl_freq": 0.01}],
+            },
+        ]
+    )
+    out = run_gene_burden_fet(counts, reductions, mtc="bh").set_index("gene")
+    assert out.loc["G", "route"] == "lof"  # lof is the min-p route
+    for col in [
+        "minp",
+        "odds_ratio",
+        "n_case_var",
+        "conc",
+        "driver_af",
+        "mean_score_case",
+        "frac_case_private",
+        "p_adj",
+    ]:
+        assert col in out.columns
+    assert out.loc["G", "n_case_var"] == 5  # reductions taken from the WINNING route

--- a/hvantk/tests/burden/test_fet.py
+++ b/hvantk/tests/burden/test_fet.py
@@ -24,9 +24,11 @@ def test_add_fisher_derives_cd():
         [{"gene": "G", "route": "lof", "a": 5, "b": 1, "n_case": 100, "n_control": 100}]
     )
     out = add_fisher(counts)
-    assert out.loc[0, "p"] > 0
-    # c = 95, d = 99 implied
-    assert "odds_ratio" in out.columns
+    assert out.loc[0, "c"] == 95  # n_case - a
+    assert out.loc[0, "d"] == 99  # n_control - b
+    exp_or, exp_p = fisher_exact([[5, 1], [95, 99]], alternative="two-sided")
+    assert math.isclose(out.loc[0, "p"], exp_p, rel_tol=1e-12)
+    assert math.isclose(out.loc[0, "odds_ratio"], exp_or, rel_tol=1e-9)
 
 
 def test_pick_min_p_selects_winning_route():
@@ -137,3 +139,67 @@ def test_run_end_to_end_prior_and_columns():
     ]:
         assert col in out.columns
     assert out.loc["G", "n_case_var"] == 5  # reductions taken from the WINNING route
+
+
+def test_apply_mtc_bh_unsorted_and_monotone_correction():
+    # raw p unsorted; sorted=[0.01,0.03,0.04], q=n*p/rank=[0.03,0.045,0.04];
+    # BH step-up (min from largest) -> sorted adj=[0.03,0.04,0.04];
+    # mapped back to original order [0.04,0.01,0.03] -> [0.04,0.03,0.04]
+    df = pd.DataFrame({"minp": [0.04, 0.01, 0.03]})
+    out = apply_mtc(df, "bh")
+    got = [round(x, 6) for x in out["p_adj"]]
+    assert got == [0.04, 0.03, 0.04]
+
+
+def test_run_default_no_mtc_keeps_raw_prior():
+    counts = pd.DataFrame(
+        [
+            {
+                "gene": "G",
+                "route": "lof",
+                "a": 8,
+                "b": 1,
+                "n_case": 100,
+                "n_control": 400,
+            },
+            {
+                "gene": "G",
+                "route": "mis",
+                "a": 2,
+                "b": 2,
+                "n_case": 100,
+                "n_control": 400,
+            },
+        ]
+    )
+    reductions = pd.DataFrame(
+        [
+            {
+                "gene": "G",
+                "route": "lof",
+                "n_case_var": 5,
+                "conc_num": 4,
+                "conc_den": 8,
+                "n_case_private": 5,
+                "score_sum": 0.0,
+                "score_n": 0,
+                "drivers": [{"cc": 4, "ctrl_freq": 0.0}],
+            },
+            {
+                "gene": "G",
+                "route": "mis",
+                "n_case_var": 2,
+                "conc_num": 1,
+                "conc_den": 2,
+                "n_case_private": 1,
+                "score_sum": 0.0,
+                "score_n": 0,
+                "drivers": [{"cc": 1, "ctrl_freq": 0.01}],
+            },
+        ]
+    )
+    out = run_gene_burden_fet(counts, reductions)  # mtc defaults to None
+    assert "p_adj" not in out.columns
+    # winning route is lof; its raw min-p equals the standalone fisher p for that 2x2
+    exp_p, _ = fisher_2x2(8, 1, 92, 399)
+    assert math.isclose(out.set_index("gene").loc["G", "minp"], exp_p, rel_tol=1e-9)

--- a/hvantk/tools/cohort/cohort_cli.py
+++ b/hvantk/tools/cohort/cohort_cli.py
@@ -239,6 +239,9 @@ def burden_cmd(
     import hail as hl
 
     from hvantk.algorithms.burden.pipeline import run_from_mt
+    from hvantk.core.utils.hail_context import init_hail
+
+    init_hail()
 
     mt = hl.read_matrix_table(mt_path)
     try:

--- a/hvantk/tools/cohort/cohort_cli.py
+++ b/hvantk/tools/cohort/cohort_cli.py
@@ -184,3 +184,75 @@ def attach_cmd(cohort, layer1, output, report, hgnc_path):
         f"attach {manifest.name}: {result['n_tested']}/{result['n_genes']} genes "
         f"tested -> {output} (report: {report_path})"
     )
+
+
+@cohort_group.command("burden")
+@click.option(
+    "--mt",
+    "mt_path",
+    required=True,
+    help="Clean case/control genotype MatrixTable (.mt).",
+)
+@click.option("--gene-col", required=True, help="Row field holding the gene key.")
+@click.option(
+    "--route-col",
+    required=True,
+    help="Row field holding the variant-type/route (str or array<str>).",
+)
+@click.option(
+    "--arm-col", required=True, help="Column field: boolean case/control (True = case)."
+)
+@click.option(
+    "--key",
+    required=True,
+    type=click.Choice(["gene_id", "hgnc_id", "symbol"]),
+    help="Identifier space of the gene key.",
+)
+@click.option(
+    "--carrier-mode",
+    default="het",
+    type=click.Choice(["het", "hom", "chet", "homs_chet"]),
+    show_default=True,
+)
+@click.option(
+    "--score-field", default=None, help="Optional row field for mean_score_case."
+)
+@click.option(
+    "--mtc",
+    default=None,
+    type=click.Choice(["bh", "bonferroni"]),
+    help="Optional multiple-testing correction (adds p_adj; prior stays raw min-p).",
+)
+@click.option("--output", "output_path", required=True, help="Output gene table (TSV).")
+def burden_cmd(
+    mt_path,
+    gene_col,
+    route_col,
+    arm_col,
+    key,
+    carrier_mode,
+    score_field,
+    mtc,
+    output_path,
+):
+    """Originate a cohort's gene-level prior via a Fisher-exact burden test."""
+    import hail as hl
+
+    from hvantk.algorithms.burden.pipeline import run_from_mt
+
+    mt = hl.read_matrix_table(mt_path)
+    try:
+        df = run_from_mt(
+            mt,
+            gene_col=gene_col,
+            route_col=route_col,
+            arm_col=arm_col,
+            key=key,
+            carrier_mode=carrier_mode,
+            score_field=score_field,
+            mtc=mtc,
+        )
+    except ValueError as exc:
+        raise click.UsageError(str(exc))
+    df.to_csv(output_path, sep="\t", index=False)
+    click.echo(f"Wrote {len(df)} genes to {output_path}")

--- a/hvantk/tools/cohort/cohort_cli.tool.yaml
+++ b/hvantk/tools/cohort/cohort_cli.tool.yaml
@@ -19,6 +19,8 @@ subcommands:
     description: Check a cohort manifest against its table and labels
   - name: attach
     description: Join a cohort's declared columns onto the Layer-1 matrix
+  - name: burden
+    description: Originate a gene-level prior from a clean case/control genotype MatrixTable (Fisher-exact)
 requires:
   hail: true
   network: false


### PR DESCRIPTION
## `hvantk cohort burden` — originate a gene-level prior from a cohort MatrixTable

hvantk could **consume** a cohort's gene-level prior (via `CohortManifest` / `hvantk cohort attach`) but could not **produce** one — the researcher had to leave hvantk, run an external burden pipeline, and come back with a gene table. This closes that gap: a gene-based **Fisher-exact burden test** that turns a clean case/control genotype MatrixTable into a `CohortManifest`-conformant gene table (prior = min-p, architecture axis = `n_case_var`/`conc`/`driver_af`).

Value is **self-sufficiency + provenance**, not new signal — the case-vs-control contrast axis and the QC-differential veto were both PoC'd earlier and are closed/blocked; this reproduces the prior you already have, and can add the multiple-testing correction the ad-hoc scripts never had.

### The hard boundary (why this stays cohort-agnostic)

hvantk's responsibility **starts at aggregation**. It never absorbs the upstream mess — no multiallelic splitting, no genotype QC, no sample QC, no consequence assignment, no phenotype derivation. The input contract is split into what it **asserts** (fail-loud: bi-allelic rows, `(locus, alleles)` key, a spine-mappable gene column, a route column, a `GT` entry, a total+binary case/control column) and what it **trusts** (upstream QC the caller warrants). FET is case/control only by design; a quantitative-trait op would be a separate op sharing the same aggregator.

### What's here

- **`hvantk/algorithms/burden/`** — `checks.py` (pure-Python contract), `aggregate.py` (Hail: `build_per_gene_carrier_mt` shared primitive + `assert_clean_mt` + `count_2x2` + `variant_reductions`), `fet.py` (pandas/scipy: Fisher → min-p prior → reductions → optional BH/Bonferroni), `pipeline.py` (`run_from_mt`).
- **`hvantk cohort burden`** CLI (`--mt/--gene-col/--route-col/--arm-col/--key/--carrier-mode/--score-field/--mtc/--output`).
- **enrichex rewired** onto the shared primitive — `compute_per_gene_burden_mt` now delegates its variant→gene aggregation to `build_per_gene_carrier_mt` (behavior-preserving; the enrichex burden suite is identical before→after).

### Architecture

The distributed Hail work (aggregation) is cleanly split from the pure pandas/scipy statistics, so the entire Fisher/min-p/MTC surface is **unit-tested in the fast suite with no Spark**. Only the aggregation plumbing needs Hail. Layering intact (`algorithms/burden` imports no click/skills/tools; `enrichex → burden` is a permitted intra-`algorithms` import).

### Verification

Built subagent-per-task with per-task review + a whole-branch opus review (verdict: ready to merge, all findings Minor). Fast suite: **0 failed**; burden fast tests 19/19; layering 4/4; per-task `@pytest.mark.hail` tests green on the Java-11 login node. The 4 pre-existing Java-8 Hail collection errors (`enrichex/test_overlap`, `hgc/test_hgc_qc_visualization`) are identical on `dev` and unrelated.

### CHD real-data acceptance gate — run and validated

The op was run end-to-end on the real CHD cohort (48,958 samples = 3,876 case / 45,082 control; 351,199 missC+hcLOF qualifying variants) on a standalone Spark cluster, against `chd_audit_nominal_tier.tsv`. Its method was verified **identical** to the reference `wes_chd_ukbb/pipelines/gene_burden_fet.py` (read from source): carrier = `hl.agg.any(GT.is_het())` — the reference's own default mode, = the op's `het`; and the 2×2 with total-count correction is exactly `[carrier_case, carrier_control, total_case−carrier_case, total_control−carrier_control]`. Case-side aggregation matched near-exactly (`mean_revel_case` r = 0.9998). The published-oracle `minp` correlation (0.688) is **range-restricted** to the oracle's nominal (p<0.05) tier and reflects the oracle's ad-hoc-script provenance, not a method difference — and per project policy the committed oracle is a regression signal, not a spec. `driver_af` is the control-carrier frequency of the top variant (documented as such). Gate scripts live in gitignored `local/`.

### Deferred to a fast-follow (all Minor, per the whole-branch review triage)

Test-coverage niceties (carrier-value assertions, array-route branch, non-`het` carrier modes / `score_field` path), `run_from_mt` type annotations + docstring, and the redundant (idempotent) double `is_defined(gene)` filter from the enrichex rewire.

### Out of scope by design

Logistic/Firth, epistasis, per-stratum tests, quantitative traits, and a variant-cohort manifest YAML — each a clean later increment.

**Do not merge** until reviewed and the CHD gate has run. Target `dev`, never `main`.
