### PR TITLE
test(rerank): cover the _classes() duplicate-source rejection merged in #231

### DIFF
--- a/hvantk/tests/rerank/test_provenance.py
+++ b/hvantk/tests/rerank/test_provenance.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hvantk.algorithms.rerank.provenance import DEFAULT_EQUIVALENCE, resolve_arms
 
 
@@ -141,3 +143,23 @@ def test_declared_dbnsfp_scores_resolve_into_arms_against_a_clinvar_label():
     assert "phyloP100way_vertebrate_rankscore" in arms.clean
     assert "CADD_raw_rankscore" in arms.clean            # 'simulated' is not a disease db
     assert arms.unknown == ()                            # every declared score is declared
+
+
+def test_a_source_in_two_equivalence_classes_is_rejected():
+    """Ambiguous vocabulary must fail loud, not resolve by dict iteration order.
+
+    A duplicate member would otherwise be assigned to whichever class the dict happened
+    to process last, silently moving every feature trained on that source between the
+    clean and all arms. Same failure shape the CLI rejects for a repeated `--prepared`
+    axis (PR #229) -- reject the ambiguity rather than guess.
+    """
+    bad = {"curated_disease_db": ["ClinVar", "HGMD"], "other": ["ClinVar"]}
+    with pytest.raises(ValueError, match="two classes"):
+        resolve_arms({"x": frozenset({"ClinVar"})}, frozenset({"HGMD"}), bad)
+
+
+def test_a_source_repeated_within_one_class_is_fine():
+    """Only a CROSS-class duplicate is ambiguous; repeating inside one class is not."""
+    dup = {"curated_disease_db": ["ClinVar", "ClinVar", "HGMD"]}
+    arms = resolve_arms({"x": frozenset({"ClinVar"})}, frozenset({"HGMD"}), dup)
+    assert "x" in arms.conflicted


### PR DESCRIPTION
Closes a known gap: the `_classes()` duplicate-source rejection shipped in #231 (commit `14a98602`) has been live in `dev` **untested** ever since. The tests were written into the repo-root copy of `test_provenance.py` while the branch lived in a worktree, so they were never staged and never merged.

### The two tests are not the same kind of test

**`test_a_source_in_two_equivalence_classes_is_rejected` — pins the fix.**
Verified it actually fails without it, by reverting `_classes()` to the naive dict comprehension it replaced:

```
hvantk/tests/rerank/test_provenance.py:157: Failed: DID NOT RAISE <class 'ValueError'>
FAILED test_a_source_in_two_equivalence_classes_is_rejected
```

Without the guard, a source listed under two classes is assigned to whichever class the dict happens to process last. Every feature trained on that source then moves between the `clean` and `all` circularity arms — a wrong headline rather than an error, which is exactly why it needs a test rather than a comment.

**`test_a_source_repeated_within_one_class_is_fine` — pins the boundary.**
This one passes under *both* implementations, and that is intentional: it asserts the rejection is CROSS-class only, so a future tightening cannot start rejecting legitimate intra-class repeats. Recording it as a boundary test rather than letting it read as a second regression test.

### Verification

- `pytest -q` — full suite exit 0, 0 failures
- `pytest hvantk/tests/rerank/test_provenance.py` — 12 passed
- `flake8 hvantk --select=E9,F63,F7,F82` — 0
- `provenance.py` confirmed byte-identical to `dev` after the revert experiment; the diff is test-only

`black` is not run on this file: it was already non-compliant on `dev`, and reformatting would bury a two-test diff under pre-existing churn. The added lines are within 88 columns.