### PR TITLE
fix(rerank)!: an undeclared predictor is conflicted, not a bucket of its own

### DIFF
--- a/hvantk/algorithms/rerank/engine.py
+++ b/hvantk/algorithms/rerank/engine.py
@@ -278,13 +278,17 @@ def rerank_arms(config) -> dict:
                headline: statistical filtering cannot detect circularity, it REWARDS it
                (REVEL correlates with the label partly because it was trained on genes
                like these).
-      all   -- clean + conflicted + unknown. Exists only so the circularity channel is a
-               measured number instead of an assumption.
+      all   -- clean + conflicted, the latter now including every undeclared column.
+               Exists only so the circularity channel is a measured number instead of an
+               assumption.
 
     Both arms use identical folds, so the delta between them is paired. An undeclared
     column is usable but never contributes to the headline, so ``all - clean`` bundles the
-    circularity channel with whatever undeclared provenance is worth; the summary keeps
-    ``n_conflicted`` and ``n_unknown`` separate so the two are not confused.
+    circularity channel with whatever undeclared provenance is worth. An undeclared column
+    is counted as conflicted, on the assumption that a predictor nobody has vouched for
+    may well have seen the label's sources; ``n_unknown`` reports how many of the
+    conflicted total are there for that reason rather than by a computed conflict, so the
+    two are not confused and the manifest gap stays visible.
     """
     from hvantk.algorithms.rerank.provenance import DEFAULT_EQUIVALENCE, resolve_arms
 
@@ -315,8 +319,12 @@ def rerank_arms(config) -> dict:
             config,
             _allowed_columns=allowed,
             _arm=name,
+            # `n_conflicted` now includes the undeclared columns, which are barred on the
+            # conservative assumption that they conflict. `n_unknown` reports how many of
+            # that total got there for want of a declaration rather than by a computed
+            # conflict -- the number to drive to zero by writing the manifest entries.
             _n_conflicted=len(assignment.conflicted),
-            _n_unknown=len(assignment.unknown),
+            _n_unknown=len(assignment.undeclared),
         )
         for name, allowed in arms.items()
     }

--- a/hvantk/algorithms/rerank/provenance.py
+++ b/hvantk/algorithms/rerank/provenance.py
@@ -22,13 +22,24 @@ DEFAULT_EQUIVALENCE: dict[str, list[str]] = {
 
 @dataclass(frozen=True)
 class ArmAssignment:
+    """Which columns may carry the headline result, for one feature/label pair.
+
+    ``conflicted`` maps a barred column to the equivalence classes it conflicts on.
+    ``undeclared`` is a *subset of* ``conflicted``'s keys: columns barred not because a
+    conflict was computed but because nobody declared what the predictor was trained on.
+    They are kept nameable so the manifest gap can be closed; without the list, an
+    undeclared column is indistinguishable from a genuinely circular one and no one can
+    tell which declaration is missing.
+    """
+
     clean: tuple[str, ...]
     conflicted: dict[str, frozenset[str]]
-    unknown: tuple[str, ...]
+    undeclared: tuple[str, ...]
 
     @property
     def all_columns(self) -> tuple[str, ...]:
-        return tuple(self.clean) + tuple(self.conflicted) + tuple(self.unknown)
+        # `undeclared` is not added: its members are already keys of `conflicted`.
+        return tuple(self.clean) + tuple(self.conflicted)
 
 
 def _classes(sources, equivalence) -> frozenset[str]:
@@ -66,16 +77,30 @@ def resolve_arms(feature_provenance, label_provenance, equivalence) -> ArmAssign
     or ``None`` when undeclared. An empty set means "trained on nothing label-derived" and
     is clean; ``None`` means "nobody said", which is NOT the same thing and must not be
     treated as clean -- a plugin author who declares nothing gets the conservative default.
+
+    That conservative default is **conflicted**, presumed to conflict on whatever classes
+    the label itself derives from: if we do not know what a predictor was trained on, the
+    assumption that costs us signal is safer than the one that inflates the headline.
+    Undeclared columns were previously reported in a third bucket of their own, which
+    barred them from the clean arm just the same but described them as merely
+    unclassified -- a column silently treated as circular ought to say so. Their names are
+    still carried, in ``undeclared``, so the missing declaration can be found and written.
+
+    Arm membership is unchanged by this: the caller builds the clean arm from
+    ``assignment.clean`` and leaves ``all`` unrestricted, so a column that moved from the
+    old ``unknown`` bucket into ``conflicted`` was excluded from clean and present in all
+    both before and after. No result computed under the previous behaviour shifts.
     """
     label_classes = _classes(label_provenance, equivalence)
-    clean, conflicted, unknown = [], {}, []
+    clean, conflicted, undeclared = [], {}, []
     for column, sources in feature_provenance.items():
         if sources is None:
-            unknown.append(column)
+            conflicted[column] = label_classes
+            undeclared.append(column)
             continue
         overlap = _classes(sources, equivalence) & label_classes
         if overlap:
             conflicted[column] = overlap
         else:
             clean.append(column)
-    return ArmAssignment(tuple(clean), conflicted, tuple(unknown))
+    return ArmAssignment(tuple(clean), conflicted, tuple(undeclared))

--- a/hvantk/algorithms/rerank/provenance.py
+++ b/hvantk/algorithms/rerank/provenance.py
@@ -71,7 +71,7 @@ def _classes(sources, equivalence) -> frozenset[str]:
 
 
 def resolve_arms(feature_provenance, label_provenance, equivalence) -> ArmAssignment:
-    """Split feature columns into clean / conflicted / unknown for a given label source.
+    """Split feature columns into clean / conflicted for a given label source.
 
     ``feature_provenance`` maps column -> the set of sources the predictor was trained on,
     or ``None`` when undeclared. An empty set means "trained on nothing label-derived" and

--- a/hvantk/tests/rerank/test_provenance.py
+++ b/hvantk/tests/rerank/test_provenance.py
@@ -8,7 +8,7 @@ def test_empty_trained_on_is_clean():
     a = resolve_arms({"phyloP": frozenset()}, frozenset({"GenCC"}), DEFAULT_EQUIVALENCE)
     assert a.clean == ("phyloP",)
     assert a.conflicted == {}
-    assert a.unknown == ()
+    assert a.undeclared == ()
 
 
 def test_shared_equivalence_class_conflicts():
@@ -46,15 +46,47 @@ def test_unrecognised_source_conflicts_with_matching_unrecognised_source():
     assert a.conflicted == {"toy_score": frozenset({"simulated"})}
 
 
-def test_undeclared_is_unknown_and_not_clean():
-    """Absent provenance must fail safe: usable, but never in the headline arm."""
+def test_undeclared_is_conflicted_and_not_clean():
+    """Absent provenance must fail safe: usable, but never in the headline arm.
+
+    The bar is recorded as a conflict rather than as a third neutral-sounding bucket. A
+    column nobody has vouched for is presumed to have seen whatever the label derives
+    from, so the presumed conflict is the label's own classes.
+    """
     a = resolve_arms({"mystery": None}, frozenset({"GenCC"}), DEFAULT_EQUIVALENCE)
     assert a.clean == ()
-    assert a.unknown == ("mystery",)
-    assert a.conflicted == {}
+    assert a.conflicted == {"mystery": frozenset({"curated_disease_db"})}
+    assert a.undeclared == ("mystery",)
 
 
-def test_all_columns_is_clean_plus_conflicted_plus_unknown():
+def test_undeclared_columns_are_nameable_for_review():
+    """`undeclared` is a subset of `conflicted`, not a parallel bucket.
+
+    Without the list an undeclared column is indistinguishable from a genuinely circular
+    one, and nobody can tell which manifest entry is missing -- which is how four dbNSFP
+    columns (MutFormer, PHACTboost) sat unnoticed outside the clean arm.
+    """
+    a = resolve_arms(
+        {"REVEL": frozenset({"ClinVar"}), "mystery": None},
+        frozenset({"GenCC"}),
+        DEFAULT_EQUIVALENCE,
+    )
+    assert set(a.undeclared) <= set(a.conflicted)
+    assert "REVEL" in a.conflicted and "REVEL" not in a.undeclared
+
+
+def test_all_columns_does_not_double_count_undeclared():
+    """`undeclared` members are already `conflicted` keys; counting both duplicates them."""
+    a = resolve_arms(
+        {"phyloP": frozenset(), "mystery": None},
+        frozenset({"GenCC"}),
+        DEFAULT_EQUIVALENCE,
+    )
+    assert sorted(a.all_columns) == ["mystery", "phyloP"]
+    assert len(a.all_columns) == len(set(a.all_columns))
+
+
+def test_all_columns_is_clean_plus_conflicted():
     a = resolve_arms(
         {"phyloP": frozenset(), "REVEL": frozenset({"ClinVar"}), "mystery": None},
         frozenset({"GenCC"}),
@@ -142,7 +174,7 @@ def test_declared_dbnsfp_scores_resolve_into_arms_against_a_clinvar_label():
     assert "REVEL_rankscore" in arms.conflicted          # HGMD/ClinVar vs a ClinGen label
     assert "phyloP100way_vertebrate_rankscore" in arms.clean
     assert "CADD_raw_rankscore" in arms.clean            # 'simulated' is not a disease db
-    assert arms.unknown == ()                            # every declared score is declared
+    assert arms.undeclared == ()                         # every declared score is declared
 
 
 def test_a_source_in_two_equivalence_classes_is_rejected():

--- a/hvantk/tests/rerank/test_selection_arms.py
+++ b/hvantk/tests/rerank/test_selection_arms.py
@@ -67,7 +67,8 @@ def test_arms_split_on_provenance_and_delta_is_reported(tmp_path):
     assert "REVEL_rankscore" not in arms["clean"].selection.global_features.get("trained", ())
 
 
-def test_undeclared_column_is_unknown_and_excluded_from_clean(tmp_path):
+def test_undeclared_column_is_conflicted_and_excluded_from_clean(tmp_path):
+    """`n_unknown` counts the undeclared subset of the conflicted total, not a third bucket."""
     from hvantk.algorithms.rerank.engine import rerank_arms
     from hvantk.algorithms.rerank.selection import SelectionPolicy
 
@@ -151,7 +152,7 @@ def test_clean_arm_refuses_to_run_when_every_column_conflicts(tmp_path):
 
 
 def test_column_missing_from_the_provenance_map_is_undeclared_not_deleted(tmp_path):
-    """An axis nobody declared must land in `all` as unknown -- never silently vanish.
+    """An axis nobody declared must land in `all` as conflicted -- never silently vanish.
 
     Omission and an explicit None mean the same thing per the plugin contract: usable,
     never clean. If an undeclared column were dropped from both arms instead, adding an


### PR DESCRIPTION
A column whose provenance nobody declared used to land in a third bucket, `unknown`. It was barred from the clean arm just the same — but "unknown" describes it as *merely unclassified*, when the engine was in fact already treating it as circular. This names the treatment.

Undeclared now resolves to **`conflicted`**, presumed to conflict on whatever classes the label itself derives from. If we do not know what a predictor saw, the assumption that costs signal is safer than the one that inflates the headline.

## No number moves

`arms = {"clean": set(assignment.clean), "all": None}` — the clean arm is built from `assignment.clean` and `all` is unrestricted, so a column shifting from `unknown` into `conflicted` was excluded from clean and present in all **both before and after**.

Verified against the real rerank-v2 matrix rather than argued:

```
columns        115
clean           61
conflicted      54   (was 50)
undeclared       4   (was reported as n_unknown=4)

recorded artifacts: conflicted=50, unknown=4  ->  clean was 115-50-4 = 61
now:                clean=61                  ->  UNCHANGED
```

So the clean-arm ΔAUC figures for the dbNSFP wide-axis result stand as measured.

## The four columns this surfaced

`undeclared` is now a **subset of** `conflicted`'s keys rather than a parallel bucket, so `all_columns` no longer adds it (that would double-count). Keeping the names is the whole point: without the list, an undeclared column is indistinguishable from a genuinely circular one and nobody can tell which manifest entry is missing.

That is exactly how these went unnoticed — the axis uses 57 dbNSFP rankscores, `hvantk/skills/dbnsfp/plugin.yaml` declares 55:

```
mutformer_mean     mutformer_frac_gt_0.9
phactboost_mean    phactboost_frac_gt_0.9
```

## Points for review

1. **The presumed conflict is the label's own classes.** Where the label declares no curated provenance at all (`frozenset()`), an undeclared column gets an empty conflict set — barred from clean, but conflicting with nothing in particular. Arguably it should be clean in that case, since nothing can be circular against a label derived from nothing. I implemented the literal conservative rule; say the word if you want the exception.
2. **`ArmAssignment.unknown` → `.undeclared`** is a breaking rename. No reader outside the tests exists in tracked code, and the local rerank-v2 drivers compute their own counts, so nothing else needed touching.
3. **`n_unknown` survives in the run summary**, re-defined as "how many of the conflicted total are there for want of a declaration" — the number to drive to zero by writing the two missing manifest entries.

## Verification

- `pytest -q` full suite exit 0, 0 failures; `hvantk/tests/rerank/` 108 passed
- `flake8 hvantk --select=E9,F63,F7,F82` — 0
- no remaining `.unknown` readers anywhere in `hvantk/` or `local/`

Follow-up, deliberately not in this PR: establishing what MutFormer and PHACTboost were actually trained on and declaring them. Until then they are conservatively barred, which is the behaviour this PR makes legible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provenance classification for columns with missing training information.
  * Undeclared columns are now consistently reported as conflicted while remaining identifiable for review.
  * Updated reranking audit counts to accurately reflect undeclared columns.
  * Prevented duplicate counting of undeclared columns in the complete column set.

* **Tests**
  * Expanded coverage for undeclared and conflicted provenance scenarios.
  * Updated integration checks to reflect the revised provenance reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->