### PR TITLE
feat(rerank): control for columns whose missingness predicts the label

### DIFF
--- a/hvantk/algorithms/rerank/config.py
+++ b/hvantk/algorithms/rerank/config.py
@@ -9,6 +9,7 @@ from hvantk.algorithms.cohort.spec import CohortManifest
 
 if TYPE_CHECKING:
     from hvantk.algorithms.rerank.audit import Audit
+    from hvantk.algorithms.rerank.leakage import LeakagePolicy
     from hvantk.algorithms.rerank.selection import SelectionPolicy
 
 logger = logging.getLogger(__name__)
@@ -111,6 +112,17 @@ class Config:
     selection: Optional["SelectionPolicy"] = None
     """Feature-selection policy. None (default) disables selection entirely and reproduces
     the pre-selection code path exactly."""
+    leakage: Optional["LeakagePolicy"] = None
+    """Presence-leakage control: bar columns whose MISSINGNESS predicts the label.
+
+    Independent of `selection` and of `feature_provenance`. Provenance asks what a
+    predictor was TRAINED on; this asks which units it was RUN on. A predictor can pass the
+    first and fail the second -- EVE is unsupervised on alignments, so it is correctly
+    clean on provenance, while the bare flag "was EVE computed for this gene" scored AUC
+    0.716 against a ClinGen/GenCC label in the cohort that motivated this, above the whole
+    constraint axis.
+
+    None (default) disables the control and reproduces the previous code path exactly."""
     feature_provenance: Optional[dict] = None
     """column -> frozenset of sources the predictor was trained on, or None if undeclared.
     None for the whole dict means provenance is unavailable: a single 'all' arm is run."""
@@ -136,6 +148,19 @@ class Config:
             from hvantk.algorithms.rerank.audit import NoAudit
 
             self.audit = NoAudit()
+        if self.leakage is not None:
+            from hvantk.algorithms.rerank.leakage import LeakagePolicy
+
+            # Checked rather than duck-typed: the engine reads `.q` and `.min_auc`, so a
+            # bare float or dict here would raise deep inside a per-fold selector, or worse,
+            # be swallowed and leave the control silently off while the caller believes it
+            # is on. A disabled safety control that looks enabled is the failure to avoid.
+            if not isinstance(self.leakage, LeakagePolicy):
+                raise TypeError(
+                    f"Config.leakage must be a LeakagePolicy or None; got "
+                    f"{type(self.leakage).__name__}. To use defaults, pass "
+                    f"LeakagePolicy()."
+                )
         if self.cohort is not None:
             if self.prior is None:
                 self.prior = _ManifestPrior(self.cohort)

--- a/hvantk/algorithms/rerank/config.py
+++ b/hvantk/algorithms/rerank/config.py
@@ -1,5 +1,6 @@
 # local/rerank_engine/config.py
 import logging
+import math
 from dataclasses import dataclass, field
 from typing import Callable, Optional, TYPE_CHECKING
 import pandas as pd
@@ -160,6 +161,20 @@ class Config:
                     f"Config.leakage must be a LeakagePolicy or None; got "
                     f"{type(self.leakage).__name__}. To use defaults, pass "
                     f"LeakagePolicy()."
+                )
+            # Validated here as well as in presence_leakage, because there the failure
+            # surfaces deep inside a per-fold selector -- after the matrix is assembled and
+            # scoring has begun -- rather than at the point the misconfiguration was made.
+            if not 0.0 < self.leakage.q <= 1.0:
+                raise ValueError(
+                    f"Config.leakage.q must be in (0, 1]; got {self.leakage.q}"
+                )
+            _m = self.leakage.min_auc
+            if not (
+                isinstance(_m, (int, float)) and math.isfinite(_m) and 0.0 <= _m <= 1.0
+            ):
+                raise ValueError(
+                    f"Config.leakage.min_auc must be finite and in [0, 1]; got {_m!r}"
                 )
         if self.cohort is not None:
             if self.prior is None:

--- a/hvantk/algorithms/rerank/engine.py
+++ b/hvantk/algorithms/rerank/engine.py
@@ -112,6 +112,43 @@ def _compose_selector(selection_selector, leakage_policy):
     return selector
 
 
+def _leakage_filtered_groups(df, y, groups, leakage_policy):
+    """Axis groups with presence-leaking columns removed, for the GLOBAL selection pass.
+
+    ``_selection_summary`` runs its own selection over all the data to produce the
+    human-readable "these are the features" list. That pass does not go through the per-fold
+    selector, so without this a column the folds barred can still appear in
+    ``global_features`` and be read as endorsed by a selection nobody ran.
+
+    Resolved once over the union of columns rather than per axis, so the FDR correction sees
+    every column that was tested -- filtering axis by axis would apply a laxer bar to a
+    narrow axis than the nested path does.
+
+    Returns ``groups`` unchanged (same object) when no policy is set, so the summary is
+    byte-identical for existing configurations.
+    """
+    if leakage_policy is None:
+        return groups
+
+    from hvantk.algorithms.rerank.leakage import resolve_leakage
+
+    every = list(dict.fromkeys(c for cols in groups.values() for c in cols))
+    clean = set(
+        resolve_leakage(
+            df, y, every, q=leakage_policy.q, min_auc=leakage_policy.min_auc
+        ).clean
+    )
+    out = {}
+    for axis, cols in groups.items():
+        kept = [c for c in cols if c in clean]
+        # An axis left with nothing is dropped rather than passed on empty: a zero-column
+        # axis reaching select_axis reads as measured-and-contributed-nothing, which is a
+        # different statement from barred.
+        if kept:
+            out[axis] = kept
+    return out
+
+
 def rerank(config, _allowed_columns=None, _arm="all", _n_conflicted=0,
            _n_unknown=0) -> RerankResult:
     validate(config)
@@ -180,7 +217,9 @@ def rerank(config, _allowed_columns=None, _arm="all", _n_conflicted=0,
         )
         scores = reranker.score(df, feat_cols, y, selector=recording)
         summary = _selection_summary(
-            config, df, y, groups, scores, frequency, _arm, _n_conflicted, _n_unknown
+            config, df, y,
+            _leakage_filtered_groups(df, y, groups, leakage_policy),
+            scores, frequency, _arm, _n_conflicted, _n_unknown
         )
     else:
         # Leakage control is independent of SelectionPolicy: one asks whether a column's

--- a/hvantk/algorithms/rerank/engine.py
+++ b/hvantk/algorithms/rerank/engine.py
@@ -79,6 +79,39 @@ def _axis_selector(policy, groups, frequency=None):
     return selector
 
 
+def _compose_selector(selection_selector, leakage_policy):
+    """Chain the presence-leakage control in FRONT of within-axis selection.
+
+    Order is not cosmetic. The univariate filter scores ``|AUC - 0.5|`` on a column's
+    VALUES, and a column whose missingness tracks the label scores well on exactly that --
+    statistical selection rewards the defect rather than detecting it, which is the argument
+    ``provenance.py`` makes for circularity and which transposes here. So a leaking column
+    must be removed before selection ever sees it.
+
+    Returns ``None`` when neither control is configured, rather than an identity function:
+    ``ReRanker.score`` takes a different and cheaper path for ``selector=None``, and
+    wrapping it would silently move every existing run onto the other path.
+    """
+    if leakage_policy is None:
+        return selection_selector
+
+    from hvantk.algorithms.rerank.leakage import resolve_leakage
+
+    def selector(X_train, y_train, columns):
+        kept = resolve_leakage(
+            X_train,
+            y_train,
+            list(columns),
+            q=leakage_policy.q,
+            min_auc=leakage_policy.min_auc,
+        ).clean
+        if selection_selector is None:
+            return list(kept)
+        return selection_selector(X_train, y_train, list(kept))
+
+    return selector
+
+
 def rerank(config, _allowed_columns=None, _arm="all", _n_conflicted=0,
            _n_unknown=0) -> RerankResult:
     validate(config)
@@ -135,17 +168,30 @@ def rerank(config, _allowed_columns=None, _arm="all", _n_conflicted=0,
     groups = {k: v for k, v in groups.items() if v}
     baseline = next(iter(groups))
     reranker = ReRanker(config.calibration, config.folds)
+    leakage_policy = getattr(config, "leakage", None)
     selector = summary = None
     if config.selection is not None:
         frequency: dict = {}
-        selector = _axis_selector(config.selection, groups)
-        recording = _axis_selector(config.selection, groups, frequency)
+        selector = _compose_selector(
+            _axis_selector(config.selection, groups), leakage_policy
+        )
+        recording = _compose_selector(
+            _axis_selector(config.selection, groups, frequency), leakage_policy
+        )
         scores = reranker.score(df, feat_cols, y, selector=recording)
         summary = _selection_summary(
             config, df, y, groups, scores, frequency, _arm, _n_conflicted, _n_unknown
         )
     else:
-        scores = reranker.score(df, feat_cols, y)
+        # Leakage control is independent of SelectionPolicy: one asks whether a column's
+        # values are worth keeping, the other whether its missingness carries the label.
+        # Requiring a selection policy to get the leakage control would couple them.
+        selector = _compose_selector(None, leakage_policy)
+        scores = (
+            reranker.score(df, feat_cols, y, selector=selector)
+            if selector is not None
+            else reranker.score(df, feat_cols, y)
+        )
     audit_table = df
     if config.cohort is not None:
         # The prior column was already consumed above (as `prior_stat`), so it is

--- a/hvantk/algorithms/rerank/leakage.py
+++ b/hvantk/algorithms/rerank/leakage.py
@@ -113,9 +113,15 @@ def presence_leakage(
 
     if not 0.0 < q <= 1.0:
         raise ValueError(f"q must be in (0, 1]; got {q}")
+    # NaN would pass silently and disable the effect floor entirely: max(0.0, nan) is 0.0,
+    # so every FDR-significant column would be barred with no effect-size protection --
+    # exactly the over-correction the floor exists to prevent, and invisible in the output.
+    _m = float(min_auc)
+    if not np.isfinite(_m) or not 0.0 <= _m <= 1.0:
+        raise ValueError(f"min_auc must be finite and in [0, 1]; got {min_auc!r}")
 
     y = np.asarray(y)
-    min_effect = max(0.0, float(min_auc) - 0.5)
+    min_effect = max(0.0, _m - 0.5)
     stats: dict[str, LeakageStat] = {}
 
     for col in columns:

--- a/hvantk/algorithms/rerank/leakage.py
+++ b/hvantk/algorithms/rerank/leakage.py
@@ -1,0 +1,196 @@
+"""Bar feature columns whose MISSINGNESS predicts the label.
+
+Circularity, handled in ``provenance.py``, asks what a predictor was TRAINED on. This asks
+which genes it was RUN on. They are independent, and only the first had a control.
+
+The measurement that motivated this module: in a 1,362-gene CHD cohort, the bare flag "was
+EVE computed for this gene" scores AUC 0.716 against a ClinGen/GenCC-derived label -- higher
+than the entire nine-feature gnomAD constraint axis (0.693). EVE is computed from deep
+multiple-sequence alignments for a curated subset of proteins; that subset is enriched for
+well-studied genes; well-studied genes are disease genes. Gradient-boosted trees learn a
+default branch direction for NaN, so "not computed" reaches the model as a usable feature.
+EVE is unsupervised on alignments and so passes every circularity check correctly.
+
+Note what is NOT the defect. Sparsity is not: on a 19,448-gene spine GTEx eQTL is sparser
+than EVE (21% against 15% coverage) and its presence indicator is inert (AUC 0.47-0.51),
+while EVE reaches 0.64-0.78. A coverage threshold cannot separate them, and one set at 90%
+would delete four whole axes for the wrong reason. What matters is missingness that
+CORRELATES WITH THE LABEL -- which, exactly like circularity, makes this a property of the
+feature/LABEL pair rather than of the feature. The same column scores 0.78 against one
+disease label and 0.64 against another.
+
+Statistical selection cannot find this on its own; it rewards it. A univariate filter ranks
+EVE highly BECAUSE its missingness tracks the label, which is the argument
+``provenance.py`` already makes about circular predictors, transposed.
+
+Two conditions are required to bar a column, because either alone fails at one end of the
+sample-size range:
+
+* an FDR-significant presence/label association -- effect size alone flags noise in a small
+  cohort;
+* a minimum effect -- significance alone flags a 1.5-point coverage difference once n is
+  large enough, and in the motivating cohort the reference axes sit at presence AUC
+  0.503-0.530 and must never be barred, or the control deletes the baseline it exists to
+  protect.
+
+Dropping is the bluntest available remedy and deliberately not the only one. A column whose
+presence predicts the label can also be handled by restricting the universe to where it is
+measured, or by admitting the presence indicator as an explicit feature and requiring the
+score to beat it -- which separates "the score is informative" from "having the score is
+informative". This module implements the blunt one because it is what a headline result can
+be defended with.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from hvantk.algorithms.rerank.selection import _null_se, univariate_auc
+
+# Presence AUC at or beyond 0.5 +/- this is "material". Anchored on measurement, not taste:
+# in the motivating cohort the near-fully-covered reference axes (constraint, gevir,
+# expression, tolerance) span 0.503-0.530, so 0.05 sits just above what a non-leaking column
+# reaches, while EVE (0.716) and ptm_density (0.617) are far outside it.
+DEFAULT_MIN_EFFECT = 0.05
+
+# Presence AUC threshold in the same units callers think in.
+DEFAULT_MIN_AUC = 0.5 + DEFAULT_MIN_EFFECT
+
+
+@dataclass(frozen=True)
+class LeakagePolicy:
+    """How aggressively to bar columns whose missingness predicts the label.
+
+    An all-defaults instance is the recommended policy. Both knobs must be cleared for a
+    column to be barred -- see the module docstring for why either alone is wrong at one
+    end of the sample-size range.
+    """
+
+    q: float = 0.10
+    """BH-FDR level for the presence/label association, across the columns supplied."""
+
+    min_auc: float = DEFAULT_MIN_AUC
+    """Presence AUC beyond which the association is material. Two-sided about 0.5."""
+
+
+@dataclass(frozen=True)
+class LeakageStat:
+    """Presence/label association for one column.
+
+    ``auc`` is ``nan`` when the test is undefined -- a fully observed column, a fully
+    missing one, or a single-class label. Undefined is not the same as null: consumers must
+    gate on ``.leaking``, never on ``auc`` alone.
+    """
+
+    coverage: float
+    auc: float
+    z: float
+    p: float
+    leaking: bool
+    n_pos: int
+    n_neg: int
+
+
+@dataclass(frozen=True)
+class LeakageReport:
+    """A partition of the supplied columns. ``clean`` and ``leaking`` are disjoint and
+    together account for every column asked about."""
+
+    clean: tuple[str, ...]
+    leaking: dict[str, float]
+    stats: dict[str, LeakageStat]
+
+
+def presence_leakage(
+    X, y, columns, q: float = 0.10, min_auc: float = DEFAULT_MIN_AUC
+) -> dict[str, LeakageStat]:
+    """Score every column by how well its presence indicator alone predicts ``y``.
+
+    No score VALUES are used -- only whether each cell is observed.
+    """
+    from scipy.stats import norm
+
+    if not 0.0 < q <= 1.0:
+        raise ValueError(f"q must be in (0, 1]; got {q}")
+
+    y = np.asarray(y)
+    min_effect = max(0.0, float(min_auc) - 0.5)
+    stats: dict[str, LeakageStat] = {}
+
+    for col in columns:
+        present = X[col].notna().to_numpy()
+        coverage = float(present.mean()) if len(present) else 0.0
+        # A column with no missingness has no indicator, and one with nothing but
+        # missingness has no contrast. Neither can leak; both are undefined, not null.
+        if coverage in (0.0, 1.0):
+            stats[col] = LeakageStat(
+                coverage,
+                float("nan"),
+                float("nan"),
+                1.0,
+                False,
+                int((y == 1).sum()),
+                int((y == 0).sum()),
+            )
+            continue
+        auc, n_pos, n_neg = univariate_auc(present.astype(float), y)
+        if np.isnan(auc) or n_pos == 0 or n_neg == 0:
+            stats[col] = LeakageStat(
+                coverage, float("nan"), float("nan"), 1.0, False, n_pos, n_neg
+            )
+            continue
+        z = (auc - 0.5) / _null_se(n_pos, n_neg)
+        # Two-sided: presence predicting the NEGATIVE class is informative missingness too.
+        # A column measured only on controls leaks exactly as hard as one measured only on
+        # cases, and a one-sided test would wave it through.
+        p = 2.0 * norm.sf(abs(z))
+        stats[col] = LeakageStat(
+            coverage, float(auc), float(z), float(p), False, n_pos, n_neg
+        )
+
+    # BH-FDR across the columns actually supplied, mirroring univariate_filter: a 115-column
+    # axis gets more chances at a spurious hit than a 1-column axis, so the correction has
+    # to see how many were tried.
+    testable = [c for c in columns if np.isfinite(stats[c].z)]
+    if not testable:
+        return stats
+    order = sorted(testable, key=lambda c: stats[c].p)
+    m = len(order)
+    significant: set[str] = set()
+    for rank, col in enumerate(order, start=1):
+        if stats[col].p <= q * rank / m:
+            significant.update(order[:rank])
+
+    for col in significant:
+        s = stats[col]
+        if abs(s.auc - 0.5) >= min_effect:
+            stats[col] = LeakageStat(
+                s.coverage, s.auc, s.z, s.p, True, s.n_pos, s.n_neg
+            )
+    return stats
+
+
+def resolve_leakage(
+    X, y, columns, q: float = 0.10, min_auc: float = DEFAULT_MIN_AUC
+) -> LeakageReport:
+    """Split columns into those safe to use and those whose missingness carries the label."""
+    stats = presence_leakage(X, y, columns, q=q, min_auc=min_auc)
+    clean = tuple(c for c in columns if not stats[c].leaking)
+    leaking = {c: stats[c].auc for c in columns if stats[c].leaking}
+    return LeakageReport(clean=clean, leaking=leaking, stats=stats)
+
+
+def leakage_selector(q: float = 0.10, min_auc: float = DEFAULT_MIN_AUC):
+    """A selector for ``_raw_oof(..., selector=...)``, so the control runs PER FOLD.
+
+    Computing leakage once over all rows and then filtering would let held-out labels choose
+    the feature set -- the error ``selection.py``'s module docstring exists to prevent, and
+    the reported delta-AUC is the scientific claim. Returned columns keep the caller's
+    order, since downstream code indexes matrices positionally.
+    """
+
+    def _select(X_tr, y_tr, cols):
+        return resolve_leakage(X_tr, y_tr, list(cols), q=q, min_auc=min_auc).clean
+
+    return _select

--- a/hvantk/tests/rerank/test_leakage.py
+++ b/hvantk/tests/rerank/test_leakage.py
@@ -1,0 +1,242 @@
+"""Presence-leakage control: a column whose MISSINGNESS predicts the label.
+
+Motivating measurement (CHD cohort, 1,362 genes): the bare flag "was EVE computed for this
+gene" scores AUC 0.716 against a ClinGen/GenCC-derived label -- higher than the entire
+nine-feature gnomAD constraint axis. EVE is computed from deep alignments for a curated
+subset of proteins, that subset is enriched for well-studied genes, and well-studied genes
+are disease genes. A gradient-boosted tree learns a default direction for NaN, so
+"not computed" is available to it as a feature.
+
+Critically, EVE is unsupervised on multiple-sequence alignments and therefore PASSES the
+existing circularity check in provenance.py: that machinery asks what a predictor was
+TRAINED on. This asks which genes it was RUN on. The two are independent, and the second
+had no control.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hvantk.algorithms.rerank.leakage import (
+    LeakageStat,
+    presence_leakage,
+    resolve_leakage,
+)
+
+
+def _frame(n=600, seed=0):
+    rng = np.random.default_rng(seed)
+    y = np.zeros(n, dtype=int)
+    y[: n // 6] = 1  # ~17% prevalence
+    rng.shuffle(y)
+    return rng, y
+
+
+def test_column_present_only_for_positives_is_flagged_as_leaking():
+    """The EVE case: a column measured mostly on labelled genes."""
+    rng, y = _frame()
+    x = rng.normal(size=len(y))
+    # present for 90% of positives but only 20% of negatives
+    keep = np.where(y == 1, rng.random(len(y)) < 0.9, rng.random(len(y)) < 0.2)
+    x[~keep] = np.nan
+    X = pd.DataFrame({"eve_mean": x})
+
+    report = resolve_leakage(X, y, ["eve_mean"])
+
+    assert report.leaking, "a column present mainly on positives must be flagged"
+    assert "eve_mean" in report.leaking
+    assert "eve_mean" not in report.clean
+    assert report.stats["eve_mean"].auc > 0.6
+
+
+def test_column_missing_at_random_is_clean():
+    """Sparsity alone is not the defect. GTEx eQTL is sparser than EVE and inert."""
+    rng, y = _frame()
+    x = rng.normal(size=len(y))
+    x[rng.random(len(y)) < 0.8] = np.nan  # 20% coverage, unrelated to y
+    X = pd.DataFrame({"eqtl_beta": x})
+
+    report = resolve_leakage(X, y, ["eqtl_beta"])
+
+    assert "eqtl_beta" in report.clean
+    assert not report.leaking
+
+
+def test_fully_observed_column_cannot_leak():
+    """With no missingness there is no indicator, so the test is undefined, not failed."""
+    rng, y = _frame()
+    X = pd.DataFrame({"pLI": rng.normal(size=len(y))})
+
+    report = resolve_leakage(X, y, ["pLI"])
+
+    assert "pLI" in report.clean
+    assert report.stats["pLI"].coverage == 1.0
+    assert np.isnan(report.stats["pLI"].auc)
+
+
+def test_fully_missing_column_cannot_leak_either():
+    rng, y = _frame()
+    X = pd.DataFrame({"empty": np.full(len(y), np.nan)})
+
+    report = resolve_leakage(X, y, ["empty"])
+
+    assert "empty" in report.clean
+    assert report.stats["empty"].coverage == 0.0
+
+
+def test_leakage_is_detected_in_both_directions():
+    """Presence predicting the NEGATIVE class is equally informative missingness.
+
+    A one-sided test would wave through a column measured only on controls, which leaks
+    just as hard as one measured only on cases.
+    """
+    rng, y = _frame()
+    x = rng.normal(size=len(y))
+    keep = np.where(y == 0, rng.random(len(y)) < 0.9, rng.random(len(y)) < 0.2)
+    x[~keep] = np.nan
+    X = pd.DataFrame({"inverted": x})
+
+    report = resolve_leakage(X, y, ["inverted"])
+
+    assert "inverted" in report.leaking
+    assert report.stats["inverted"].auc < 0.4
+
+
+def test_small_effect_is_not_flagged_even_when_significant():
+    """Significance is not sufficient. At large n a trivial imbalance reaches p<0.05.
+
+    The reference axes in the motivating cohort (constraint, expression) sit at presence
+    AUC 0.503-0.530 and must never be barred, or the control would delete the baseline it
+    exists to protect.
+    """
+    rng = np.random.default_rng(7)
+    n = 200_000
+    y = (rng.random(n) < 0.2).astype(int)
+    x = rng.normal(size=n)
+    # a 1.5-point coverage difference: overwhelming p, negligible effect
+    keep = np.where(y == 1, rng.random(n) < 0.815, rng.random(n) < 0.80)
+    x[~keep] = np.nan
+    X = pd.DataFrame({"barely": x})
+
+    report = resolve_leakage(X, y, ["barely"])
+
+    assert abs(report.stats["barely"].auc - 0.5) < 0.05
+    assert "barely" in report.clean, "effect-size floor must protect near-null columns"
+
+
+def test_large_effect_is_not_flagged_when_it_could_be_chance():
+    """Effect size is not sufficient either. At tiny n a big AUC is unremarkable.
+
+    Requiring BOTH an FDR-significant test and an effect floor is the point: either alone
+    is wrong at one end of the sample-size range.
+    """
+    rng = np.random.default_rng(3)
+    n, y = 24, np.array([1] * 6 + [0] * 18)
+    x = rng.normal(size=n)
+    x[[0, 1, 7, 8, 9, 10]] = np.nan
+    X = pd.DataFrame({"tiny": x})
+
+    report = resolve_leakage(X, y, ["tiny"], min_auc=0.0)  # effect floor disabled
+
+    # With 6 positives nothing should clear BH-FDR on its own.
+    assert "tiny" in report.clean
+
+
+def test_fdr_is_computed_across_the_supplied_columns():
+    """Testing 50 columns and testing 1 must not use the same bar.
+
+    Same argument univariate_filter already makes for within-axis FDR: a wide axis gets
+    more chances to throw a spurious hit, so the correction has to see how many were tried.
+    """
+    rng, y = _frame(n=800)
+    cols, data = [], {}
+    for i in range(50):
+        x = rng.normal(size=len(y))
+        x[rng.random(len(y)) < 0.5] = np.nan  # all missing-at-random
+        data[f"noise{i}"] = x
+        cols.append(f"noise{i}")
+    X = pd.DataFrame(data)
+
+    report = resolve_leakage(X, y, cols)
+
+    assert not report.leaking, f"MAR columns must not be flagged: {report.leaking}"
+
+
+def test_presence_leakage_returns_a_stat_for_every_column():
+    rng, y = _frame()
+    X = pd.DataFrame({"a": rng.normal(size=len(y)), "b": rng.normal(size=len(y))})
+
+    stats = presence_leakage(X, y, ["a", "b"])
+
+    assert set(stats) == {"a", "b"}
+    assert all(isinstance(v, LeakageStat) for v in stats.values())
+
+
+def test_report_partitions_the_columns_exactly():
+    """clean and leaking must together account for every column, with no overlap."""
+    rng, y = _frame()
+    x_leak = rng.normal(size=len(y))
+    x_leak[
+        np.where(y == 1, rng.random(len(y)) < 0.1, rng.random(len(y)) < 0.9)
+    ] = np.nan
+    X = pd.DataFrame({"leaky": x_leak, "fine": rng.normal(size=len(y))})
+
+    report = resolve_leakage(X, y, ["leaky", "fine"])
+
+    assert set(report.clean) | set(report.leaking) == {"leaky", "fine"}
+    assert not (set(report.clean) & set(report.leaking))
+
+
+def test_selector_is_usable_as_a_nested_selection_step():
+    """The control must be runnable per fold on a training slice.
+
+    Computing it once on all rows would let held-out labels choose the feature set, the
+    error selection.py's module docstring exists to prevent. The selector signature matches
+    what _raw_oof already accepts.
+    """
+    from hvantk.algorithms.rerank.leakage import leakage_selector
+
+    rng, y = _frame()
+    x = rng.normal(size=len(y))
+    x[np.where(y == 1, rng.random(len(y)) < 0.1, rng.random(len(y)) < 0.9)] = np.nan
+    X = pd.DataFrame({"leaky": x, "fine": rng.normal(size=len(y))})
+
+    sel = leakage_selector()
+    kept = list(sel(X, y, ["leaky", "fine"]))
+
+    assert kept == ["fine"]
+
+
+def test_selector_preserves_input_order_of_kept_columns():
+    rng, y = _frame()
+    X = pd.DataFrame({c: rng.normal(size=len(y)) for c in ("c", "a", "b")})
+
+    from hvantk.algorithms.rerank.leakage import leakage_selector
+
+    assert list(leakage_selector()(X, y, ["c", "a", "b"])) == ["c", "a", "b"]
+
+
+def test_empty_column_list_is_not_an_error():
+    rng, y = _frame()
+    report = resolve_leakage(pd.DataFrame({"a": rng.normal(size=len(y))}), y, [])
+    assert report.clean == ()
+    assert report.leaking == {}
+
+
+def test_single_class_label_is_untestable_not_leaking():
+    """A degenerate label cannot be predicted by anything, including missingness."""
+    rng = np.random.default_rng(1)
+    y = np.ones(300, dtype=int)
+    x = rng.normal(size=300)
+    x[rng.random(300) < 0.5] = np.nan
+    report = resolve_leakage(pd.DataFrame({"a": x}), y, ["a"])
+    assert "a" in report.clean
+
+
+@pytest.mark.parametrize("bad_q", [-0.1, 0.0, 1.5])
+def test_invalid_fdr_level_is_rejected(bad_q):
+    """A q outside (0, 1] silently disables or inverts the filter; refuse it."""
+    rng, y = _frame()
+    with pytest.raises(ValueError, match="q"):
+        resolve_leakage(pd.DataFrame({"a": rng.normal(size=len(y))}), y, ["a"], q=bad_q)

--- a/hvantk/tests/rerank/test_leakage_wiring.py
+++ b/hvantk/tests/rerank/test_leakage_wiring.py
@@ -116,3 +116,67 @@ def test_config_rejects_an_invalid_policy_type():
     """A bare float or dict here would be silently ignored by the engine."""
     with pytest.raises((TypeError, ValueError)):
         Config(name="x", features=[], labels=None, leakage=0.55).__post_init__()
+
+
+def test_global_selection_summary_excludes_leaking_columns():
+    """The global summary must not report a column the nested folds barred.
+
+    `_selection_summary` runs its own selection over ALL the data to produce the
+    human-readable "these are the features" list. That pass is separate from the per-fold
+    selector, so without explicit filtering a leaking column can appear in
+    `global_features` -- and be read as endorsed -- while no fold ever used it.
+    """
+    from hvantk.algorithms.rerank.engine import _leakage_filtered_groups
+
+    X, y = _leaky_frame()
+    groups = {"constraint": ["pLI"], "dbnsfp": ["eve_mean"], "expression": ["expr"]}
+
+    filtered = _leakage_filtered_groups(X, y, groups, LeakagePolicy())
+
+    assert "eve_mean" not in filtered.get("dbnsfp", [])
+    assert filtered["constraint"] == ["pLI"]
+    assert filtered["expression"] == ["expr"]
+
+
+def test_leakage_filtered_groups_drops_an_axis_left_empty():
+    """An axis whose every column leaks must disappear, not survive as an empty list.
+
+    A zero-column axis reaching select_axis is reported as present-but-contributing-
+    nothing, which reads as a measured null rather than a barred axis.
+    """
+    from hvantk.algorithms.rerank.engine import _leakage_filtered_groups
+
+    X, y = _leaky_frame()
+    filtered = _leakage_filtered_groups(
+        X, y, {"only_leaky": ["eve_mean"], "fine": ["expr"]}, LeakagePolicy()
+    )
+
+    assert "only_leaky" not in filtered
+    assert filtered["fine"] == ["expr"]
+
+
+def test_leakage_filtered_groups_is_identity_without_a_policy():
+    from hvantk.algorithms.rerank.engine import _leakage_filtered_groups
+
+    X, y = _leaky_frame()
+    groups = {"a": ["pLI"], "b": ["eve_mean"]}
+    assert _leakage_filtered_groups(X, y, groups, None) is groups
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), -0.2, 1.4])
+def test_policy_rejects_non_finite_or_out_of_range_min_auc(bad):
+    """NaN silently disables the effect floor: max(0.0, nan) is 0.0, so every
+    FDR-significant column would be barred with no effect-size protection at all."""
+    with pytest.raises(ValueError, match="min_auc"):
+        Config(
+            name="x", features=[], labels=None, leakage=LeakagePolicy(min_auc=bad)
+        ).__post_init__()
+
+
+@pytest.mark.parametrize("bad", [0.0, -0.1, 1.5])
+def test_config_rejects_invalid_policy_q(bad):
+    """presence_leakage raises for these, but only once a per-fold selector reaches it."""
+    with pytest.raises(ValueError, match="q"):
+        Config(
+            name="x", features=[], labels=None, leakage=LeakagePolicy(q=bad)
+        ).__post_init__()

--- a/hvantk/tests/rerank/test_leakage_wiring.py
+++ b/hvantk/tests/rerank/test_leakage_wiring.py
@@ -1,0 +1,118 @@
+"""Wiring the presence-leakage control into Config and the engine's selector chain.
+
+The unit behaviour lives in test_leakage.py. This covers the part that makes it reachable:
+a control nobody can switch on does not close the gap it was written for.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hvantk.algorithms.rerank.config import Config
+from hvantk.algorithms.rerank.engine import _compose_selector
+from hvantk.algorithms.rerank.leakage import LeakagePolicy
+
+
+def _leaky_frame(n=600, seed=0):
+    """A matrix with one leaking column, one clean column, and a baseline axis."""
+    rng = np.random.default_rng(seed)
+    y = np.zeros(n, dtype=int)
+    y[: n // 5] = 1
+    rng.shuffle(y)
+    leaky = rng.normal(size=n)
+    keep = np.where(y == 1, rng.random(n) < 0.9, rng.random(n) < 0.15)
+    leaky[~keep] = np.nan
+    X = pd.DataFrame(
+        {
+            "pLI": rng.normal(size=n),
+            "eve_mean": leaky,
+            "expr": rng.normal(size=n),
+        }
+    )
+    return X, y
+
+
+def test_config_defaults_to_no_leakage_control():
+    """Default must reproduce the pre-existing code path exactly, like `selection`."""
+    assert Config.__dataclass_fields__["leakage"].default is None
+
+
+def test_compose_selector_returns_none_when_nothing_is_configured():
+    """No selection and no leakage means no selector at all -- not an identity wrapper.
+
+    ReRanker.score takes a different, cheaper path when selector is None, and an identity
+    selector would silently change which code path every existing run takes.
+    """
+    assert _compose_selector(selection_selector=None, leakage_policy=None) is None
+
+
+def test_leakage_alone_produces_a_working_selector():
+    """Leakage control must not require a SelectionPolicy.
+
+    They are independent controls: one asks whether a column's VALUES are worth keeping,
+    the other whether its MISSINGNESS carries the label.
+    """
+    X, y = _leaky_frame()
+    sel = _compose_selector(selection_selector=None, leakage_policy=LeakagePolicy())
+
+    kept = list(sel(X, y, ["pLI", "eve_mean", "expr"]))
+
+    assert "eve_mean" not in kept
+    assert kept == ["pLI", "expr"]
+
+
+def test_leakage_runs_before_axis_selection():
+    """Order matters: a leaking column must never reach the univariate filter.
+
+    That filter scores |AUC-0.5| on the column's VALUES and would rank a leaking column
+    highly -- it rewards the defect, which is the whole reason the control cannot be left
+    to statistics.
+    """
+    X, y = _leaky_frame()
+    seen: list[list[str]] = []
+
+    def spy(X_tr, y_tr, columns):
+        seen.append(list(columns))
+        return list(columns)
+
+    sel = _compose_selector(selection_selector=spy, leakage_policy=LeakagePolicy())
+    sel(X, y, ["pLI", "eve_mean", "expr"])
+
+    assert seen, "the downstream selector must still be called"
+    assert "eve_mean" not in seen[0], "leaking column reached axis selection"
+
+
+def test_selection_alone_is_unchanged_by_this_feature():
+    """With no leakage policy the composed selector must be the original object.
+
+    Wrapping it would change behaviour for every existing caller for no reason.
+    """
+
+    def spy(X_tr, y_tr, columns):
+        return list(columns)
+
+    assert _compose_selector(selection_selector=spy, leakage_policy=None) is spy
+
+
+def test_composed_selector_keeps_caller_column_order():
+    X, y = _leaky_frame()
+    sel = _compose_selector(selection_selector=None, leakage_policy=LeakagePolicy())
+    assert list(sel(X, y, ["expr", "pLI"])) == ["expr", "pLI"]
+
+
+def test_policy_thresholds_are_honoured():
+    """A permissive effect floor must let a mildly-leaking column through, so the knob is
+    demonstrably wired rather than merely present."""
+    X, y = _leaky_frame()
+    strict = _compose_selector(None, LeakagePolicy(min_auc=0.55))
+    permissive = _compose_selector(None, LeakagePolicy(min_auc=0.99))
+
+    assert "eve_mean" not in list(strict(X, y, ["pLI", "eve_mean", "expr"]))
+    assert "eve_mean" in list(permissive(X, y, ["pLI", "eve_mean", "expr"]))
+
+
+def test_config_rejects_an_invalid_policy_type():
+    """A bare float or dict here would be silently ignored by the engine."""
+    with pytest.raises((TypeError, ValueError)):
+        Config(name="x", features=[], labels=None, leakage=0.55).__post_init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,13 @@ gnomad = { version = "*", optional = true }
 # The floor stays as long as `SelectionPolicy(wrapper="rfecv")` is reachable -- it is now
 # off by default, not removed. Drop to ^1.3 only if the wrapper is deleted outright.
 scikit-learn = { version = "^1.4", optional = true }
+# scipy is a hard install_requires of scikit-learn, so it is always present wherever the
+# code that imports it is reachable -- rerank's selection and leakage filters both use
+# scipy.stats, and neither can run without sklearn anyway. Declared explicitly regardless,
+# because relying on a transitive dependency is how it silently breaks later. OPTIONAL, and
+# listed in the same extras as scikit-learn: rerank is not part of a base install, so a
+# base-level declaration would burden every user who never touches it.
+scipy = { version = ">=1.8", optional = true }
 matplotlib = { version = "*", optional = true }
 seaborn = { version = "*", optional = true }
 plotly = { version = "*", optional = true }
@@ -67,11 +74,11 @@ viz = ["matplotlib", "seaborn", "plotly"]
 duckdb = ["duckdb"]
 interactive = ["plotly"]
 hgc = ["matplotlib", "seaborn", "gnomad"]
-psroc = ["matplotlib", "plotly", "scikit-learn"]
+psroc = ["matplotlib", "plotly", "scikit-learn", "scipy"]
 ptm = ["cptac", "sorted-nearest"]
 constraint = ["tspex", "matplotlib", "seaborn"]
-ancestry = ["scikit-learn", "matplotlib", "seaborn"]
-ml = ["scikit-learn"]
+ancestry = ["scikit-learn", "matplotlib", "seaborn", "scipy"]
+ml = ["scikit-learn", "scipy"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## What this adds

A control for feature columns whose **missingness** predicts the label.

`provenance.py` asks what a predictor was **trained** on. Nothing asked which units it was
**run** on, and the two are independent.

## Why

Measured in a 1,362-gene CHD cohort: the bare flag *"was EVE computed for this gene"* scores
**AUC 0.716** against a ClinGen/GenCC-derived label — above the entire nine-feature gnomAD
constraint axis (0.693). EVE is computed from deep alignments for a curated subset of
proteins; that subset is enriched for well-studied genes; well-studied genes are disease
genes. Gradient-boosted trees learn a default branch direction for NaN, so *"not computed"*
reaches the model as a usable feature.

EVE is unsupervised on alignments, so it **passes every circularity check correctly**. The
existing control cannot see this.

Consequence when the control is applied: the `missense_severity` axis's entire add-one gain
over constraint in CHD (+0.045) goes to **−0.001**, and removing the two offending columns
costs 30% of the model's AUPRC. In three other diseases the same axis is unaffected — so
this is not a blanket correction, it is a per-configuration one.

## Design notes worth reviewing

**A coverage floor is the wrong instrument, and this deliberately isn't one.** On a
19,448-gene spine GTEx eQTL is *sparser* than EVE (21% vs 15% coverage) and completely inert
(presence AUC 0.47–0.51) while EVE reaches 0.64–0.78. A 90% floor would delete four whole
axes for the wrong reason. Sparsity is not the defect; sparsity **correlated with the label**
is — which makes this, exactly like circularity, a property of the feature/**label** pair.
The same column scores 0.78 against epilepsy-DEE and 0.64 against CHD-NDD.

**Statistical selection cannot find it; it rewards it.** A univariate `|AUC−0.5|` filter
ranks EVE highly *because* its missingness tracks the label. That is `provenance.py`'s own
argument transposed, and it is why the control chains **in front of** within-axis selection
rather than after it.

**Two conditions are required to bar a column**, because either alone fails at one end of the
sample-size range: an FDR-significant presence/label association (effect size alone flags
noise in a small cohort) **and** a minimum effect (significance alone flags a 1.5-point
coverage difference at n=200k). The 0.05 effect floor is anchored on measurement — the
reference axes in that cohort span presence AUC 0.503–0.530 and must never be barred, or the
control deletes the baseline it exists to protect.

## Changes

- `algorithms/rerank/leakage.py` — `LeakagePolicy`, `LeakageStat`, `LeakageReport`,
  `presence_leakage`, `resolve_leakage`, `leakage_selector`. Reuses `selection.py`'s
  `univariate_auc` and Bamber-bound `_null_se` so the two filters agree on what a null is.
- `engine.py` — `_compose_selector` chains leakage ahead of within-axis selection. Returns
  `None` when neither control is set rather than an identity wrapper, because
  `ReRanker.score` takes a different path for `selector=None`. Works with `selection=None`:
  the two controls are independent.
- `config.py` — `Config.leakage`, defaulting to `None` so **existing runs are byte-identical**.
  Type-checked in `__post_init__`; a bare float would leave the control silently off while
  the caller believed it was on.

## Tests

25 new, TDD throughout (each watched fail first). Covers both leak directions, the
small-effect-at-large-n and large-effect-at-small-n boundaries, fully-observed and
fully-missing columns, single-class labels, FDR across the supplied columns, per-fold
nesting, and column-order preservation. **Full rerank suite: 133 passed.** flake8 clean.

New files are black-formatted. `engine.py` was hand-matched to black style on the new lines
only — the file has pre-existing formatting drift, and reformatting it wholesale would bury
this change in churn.

## Deliberately not included

Dropping is the bluntest remedy. Restricting the universe to where a column is measured, or
admitting the presence indicator as an explicit feature and requiring the score to beat it,
are both better and belong in separate changes. The latter separates *"the score is
informative"* from *"having the score is informative"*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional presence-leakage detection for reranking workflows.
  * Automatically identifies feature columns whose missingness is associated with labels and excludes them from scoring.
  * Added configurable significance and effect-size thresholds.
  * Leakage controls can be used independently or alongside existing feature selection.

* **Validation**
  * Added coverage for detection accuracy, edge cases, threshold handling, selector ordering, and invalid configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->