### PR TITLE
feat(annotation): emit the per-group specificity vector by default

### DIFF
--- a/hvantk/algorithms/annotation/compose.py
+++ b/hvantk/algorithms/annotation/compose.py
@@ -57,14 +57,20 @@ def compose(spine, prepared_by_axis, spec):
 
     _check_no_column_collisions(spec)
 
+    for entry in spec.layer1:
+        if entry.axis not in prepared_by_axis:
+            raise KeyError(
+                f"prepared_by_axis is missing axis {entry.axis!r}, declared in spec "
+                f"{spec.name!r}"
+            )
+    # Resolved from the prepared tables, not the spec: a matrix axis emits one column per
+    # atlas group, which the spec cannot name ahead of time. Done up front so the
+    # cross-axis collision check covers those runtime columns too.
+    columns_by_axis = _resolve_columns_by_axis(spec, prepared_by_axis)
+
     ht = spine
     for entry in spec.layer1:
         axis = entry.axis
-        if axis not in prepared_by_axis:
-            raise KeyError(
-                f"prepared_by_axis is missing axis {axis!r}, declared in spec "
-                f"{spec.name!r}"
-            )
         prepared = prepared_by_axis[axis]
         # `prepared[ht.gene_id]` is Hail's index-join idiom (Table.__getitem__ ->
         # Table.index): a StructExpression of prepared's non-key fields, missing where
@@ -73,12 +79,50 @@ def compose(spine, prepared_by_axis, spec):
         # presence flag correct regardless of whether a matched row's own column values
         # happen to be null.
         joined = prepared[ht.gene_id]
-        updates = {col: joined[col] for col in entry.columns}
+        updates = {col: joined[col] for col in columns_by_axis[axis]}
         updates[f"{axis}_present"] = hl.is_defined(joined)
         ht = ht.annotate(**updates)
 
-    manifest = _build_manifest(ht, spec)
+    manifest = _build_manifest(ht, spec, columns_by_axis)
     return ht, manifest
+
+
+def _axis_columns(prepared) -> list:
+    """The columns an axis actually contributes: the prepared table's non-key fields.
+
+    Read from the table rather than from ``entry.columns`` because a matrix source's
+    columns are only known at runtime -- ``emit="vector"`` produces one per atlas group.
+    For every other source type this is exactly ``entry.columns`` already, since prepare
+    selects/aggregates precisely those, so reading the table generalizes without changing
+    existing behaviour.
+    """
+    key = set(prepared.key)
+    return [f for f in prepared.row if f not in key]
+
+
+def _resolve_columns_by_axis(spec, prepared_by_axis) -> dict:
+    """Map axis -> contributed columns, and re-run the collision check over the real set.
+
+    ``_check_no_column_collisions`` can only see what the spec declares, which for a
+    matrix axis is a subset of what it emits. Two atlases sharing a group label would
+    therefore collide only once Hail tried to annotate the same name twice, which is a
+    far worse error than saying so here.
+    """
+    columns_by_axis: dict = {}
+    owner: dict = {}
+    for entry in spec.layer1:
+        cols = _axis_columns(prepared_by_axis[entry.axis])
+        for col in cols:
+            if col in owner:
+                raise ValueError(
+                    f"duplicate output column {col!r}: contributed by axis "
+                    f"{owner[col]!r} and axis {entry.axis!r}. For a matrix axis the "
+                    "columns come from the atlas's group labels, so give the axes "
+                    "distinct atlas prefixes or use drop_groups"
+                )
+            owner[col] = entry.axis
+        columns_by_axis[entry.axis] = cols
+    return columns_by_axis
 
 
 def _check_no_column_collisions(spec) -> None:
@@ -99,15 +143,16 @@ def _check_no_column_collisions(spec) -> None:
             owner[col] = entry.axis
 
 
-def _build_manifest(ht, spec) -> dict:
+def _build_manifest(ht, spec, columns_by_axis) -> dict:
     """Per axis+column non-null rate (over the spine) and positive rate (among non-null).
 
-    Computed with a single ``ht.aggregate`` call over every declared column, per the
-    design's manifest contract.
+    Computed with a single ``ht.aggregate`` call over every contributed column, per the
+    design's manifest contract. Driven by ``columns_by_axis`` rather than the spec so a
+    matrix axis's per-group vector is reported too, not just its declared roll-up.
     """
     import hail as hl
 
-    columns = [col for entry in spec.layer1 for col in entry.columns]
+    columns = [col for cols in columns_by_axis.values() for col in cols]
     n_genes = ht.count()
 
     if not columns:
@@ -128,7 +173,7 @@ def _build_manifest(ht, spec) -> dict:
     axes: dict = {}
     for entry in spec.layer1:
         axis_manifest = {}
-        for col in entry.columns:
+        for col in columns_by_axis[entry.axis]:
             col_stats = stats[col]
             nn = col_stats["nn"]
             pos = col_stats["pos"]

--- a/hvantk/algorithms/annotation/matrix.py
+++ b/hvantk/algorithms/annotation/matrix.py
@@ -89,29 +89,55 @@ def reduce_matrix_to_gene(adata, mspec):
     if mspec.specificity is not None:
         spec_gg = ewce_specificity(mean_gg)
         targets = [t.strip() for t in mspec.specificity.targets]
-        # Require EXACT coverage: a partially-present target set would silently pool the
-        # cell-class specificity over only the surviving subtypes (e.g. combine='sum' summing
-        # 1 of 3 cardiomyocyte subtypes), under-reporting every pan-class gene with no error.
-        missing = [t for t in targets if t not in spec_gg.columns]
-        if missing:
-            raise ValueError(
-                f"specificity targets {missing} absent from groups {list(spec_gg.columns)} "
-                f"(after strip/drop_groups); a partial target set would under-pool the "
-                f"cell-class specificity -- fix the spec or the atlas"
-            )
-        tgt = spec_gg[targets]
-        combine = mspec.specificity.combine
-        if combine == "sum":
-            # Cell-CLASS specificity (EWCE level 1): the targets are subtypes of one class
-            # (e.g. atrial/ventricular/Myoz2 cardiomyocytes), so pool their fractions ->
-            # fraction of the gene's expression that is in the class. A pan-class gene
-            # (split across subtypes) reads high, which 'max' (peak single subtype) misses.
-            combined = tgt.sum(axis=1)
-        elif combine == "mean":
-            combined = tgt.mean(axis=1)
-        else:  # 'max' -- peak specificity to any single target
-            combined = tgt.max(axis=1)
-        cols[f"{mspec.atlas}_{mspec.specificity.name}"] = combined
+
+        # The VECTOR: one column per surviving group. Emitted before any roll-up so that a
+        # roll-up name colliding with a group name is caught by the same col_origin check.
+        if mspec.specificity.emit == "vector":
+            for g in spec_gg.columns:
+                key = f"{mspec.atlas}_{_san(g)}"
+                if key in col_origin:
+                    raise ValueError(
+                        f"group labels {col_origin[key]!r} and {g!r} both sanitize to "
+                        f"column {key!r}; rename a group or use drop_groups to disambiguate"
+                    )
+                col_origin[key] = g
+                cols[key] = spec_gg[g]
+
+        # THE ROLL-UP, additive and optional: emitted only when targets were named. Guarded,
+        # because an empty target set makes spec_gg[[]] sum to an all-zero column -- a silent
+        # dead feature rather than an error.
+        if targets:
+            # Require EXACT coverage: a partially-present target set would silently pool the
+            # cell-class specificity over only the surviving subtypes (e.g. combine='sum'
+            # summing 1 of 3 cardiomyocyte subtypes), under-reporting every pan-class gene.
+            missing = [t for t in targets if t not in spec_gg.columns]
+            if missing:
+                raise ValueError(
+                    f"specificity targets {missing} absent from groups "
+                    f"{list(spec_gg.columns)} (after strip/drop_groups); a partial target "
+                    f"set would under-pool the cell-class specificity -- fix the spec or "
+                    f"the atlas"
+                )
+            tgt = spec_gg[targets]
+            combine = mspec.specificity.combine
+            if combine == "sum":
+                # Cell-CLASS specificity (EWCE level 1): the targets are subtypes of one
+                # class (e.g. atrial/ventricular/Myoz2 cardiomyocytes), so pool their
+                # fractions -> fraction of the gene's expression that is in the class. A
+                # pan-class gene (split across subtypes) reads high, which 'max' (peak
+                # single subtype) misses.
+                combined = tgt.sum(axis=1)
+            elif combine == "mean":
+                combined = tgt.mean(axis=1)
+            else:  # 'max' -- peak specificity to any single target
+                combined = tgt.max(axis=1)
+            key = f"{mspec.atlas}_{mspec.specificity.name}"
+            if key in col_origin:
+                raise ValueError(
+                    f"roll-up name {key!r} collides with the group column from "
+                    f"{col_origin[key]!r}; rename the roll-up"
+                )
+            cols[key] = combined
 
     out = pd.DataFrame(cols)
     out.index.name = "symbol"

--- a/hvantk/algorithms/annotation/matrix.py
+++ b/hvantk/algorithms/annotation/matrix.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import logging
 import re
 
+from hvantk.algorithms.annotation.spec import COMBINE_REDUCERS
+
 logger = logging.getLogger(__name__)
 
 
@@ -119,23 +121,21 @@ def reduce_matrix_to_gene(adata, mspec):
                     f"the atlas"
                 )
             tgt = spec_gg[targets]
-            combine = mspec.specificity.combine
-            if combine == "sum":
-                # Cell-CLASS specificity (EWCE level 1): the targets are subtypes of one
-                # class (e.g. atrial/ventricular/Myoz2 cardiomyocytes), so pool their
-                # fractions -> fraction of the gene's expression that is in the class. A
-                # pan-class gene (split across subtypes) reads high, which 'max' (peak
-                # single subtype) misses.
-                combined = tgt.sum(axis=1)
-            elif combine == "mean":
-                combined = tgt.mean(axis=1)
-            else:  # 'max' -- peak specificity to any single target
-                combined = tgt.max(axis=1)
+            # Table dispatch, not if/elif/else: the old chain fell through to max
+            # for any unrecognised value, so a typo silently produced peak-subtype
+            # specificity where the spec asked for the pooled class fraction.
+            # SpecificitySpec validates against these same keys, so an unknown
+            # value cannot reach here.
+            combined = COMBINE_REDUCERS[mspec.specificity.combine](tgt)
             key = f"{mspec.atlas}_{mspec.specificity.name}"
             if key in col_origin:
+                # col_origin holds BOTH the per-group specificity columns and the
+                # per-group stat columns ({atlas}_{group}_{stat}), so name the colliding
+                # column rather than asserting which kind it was -- a roll-up named
+                # 'cm_mean' collides with a stat column, not a group column.
                 raise ValueError(
-                    f"roll-up name {key!r} collides with the group column from "
-                    f"{col_origin[key]!r}; rename the roll-up"
+                    f"roll-up name {key!r} collides with an existing column "
+                    f"derived from group {col_origin[key]!r}; rename the roll-up"
                 )
             cols[key] = combined
 

--- a/hvantk/algorithms/annotation/prepare.py
+++ b/hvantk/algorithms/annotation/prepare.py
@@ -214,13 +214,30 @@ def prepare_matrix_source(matrix_ad, spine_gene_ids, entry, *, hgnc=None):
     df = matrix_mod.reduce_matrix_to_gene(
         matrix_ad, entry.matrix
     )  # 'symbol' + feature cols
+    # A matrix source's column set is decided at RUNTIME by the atlas's groups -- with
+    # specificity emit="vector" (the default) there is one column per surviving group,
+    # whose names come from _san() over labels the spec author cannot enumerate ahead of
+    # time. So carry everything the reducer produced, rather than the static
+    # entry.columns: restricting to the declared list here silently dropped the whole
+    # vector on the floor, leaving emit="vector" a no-op through the real pipeline.
+    produced = [c for c in df.columns if c != "symbol"]
+    # entry.columns stays meaningful as an assertion: whatever the spec explicitly names
+    # MUST be produced. That catches a typo, a renamed group, or an atlas swapped under
+    # the spec -- all of which would otherwise surface as a silently absent feature.
+    missing = [c for c in entry.columns if c not in produced]
+    if missing:
+        raise ValueError(
+            f"entry {entry.source!r} declares column(s) {missing} that the matrix "
+            f"reducer did not produce; it emitted {produced}. Check the spec's "
+            f"specificity.name / stats against the atlas's group labels"
+        )
     grouped = hl.Table.from_pandas(df, key=["symbol"])
     mapper = GeneIdMapper(hgnc, set(spine_gene_ids))
     resolved, report = _resolve_to_gene_id(
         grouped.symbol.collect(), "symbol", entry.source, mapper
     )
     prepared = _collapse_matrix_onto_gene_id(
-        grouped, "symbol", resolved, entry.columns, entry.source
+        grouped, "symbol", resolved, produced, entry.source
     )
     logger.info(report.summary())
     return prepared, report

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -49,10 +49,35 @@ class AggregateSpec:
 
 @dataclass(frozen=True)
 class SpecificitySpec:
+    """How a genes x groups specificity matrix becomes feature columns.
+
+    ``emit`` controls the reduction, and defaults to the VECTOR -- one column per group.
+    Reducing an atlas to a single summed scalar throws away the cross-group contrast: the
+    non-target groups are computed, used as the denominator of the fraction, and discarded.
+    Measured on real cohorts, that reduction cost an epilepsy axis +0.061 AUC and the
+    difference between significant and not, while keeping the vector raised the
+    selected-maximum null by +0.0009. So the vector is the default and a named roll-up is
+    additive: give ``targets`` and you get the roll-up column IN ADDITION to the vector.
+
+    emit
+        ``"vector"`` (default) one column per group, plus the roll-up when ``targets`` is
+        non-empty; ``"rollup"`` the roll-up only, which requires ``targets``.
+    """
+
     method: str
-    targets: tuple[str, ...]
+    targets: tuple[str, ...] = ()
     combine: str = "max"
     name: str = "spec"
+    emit: str = "vector"
+
+    def __post_init__(self):
+        if self.emit not in ("vector", "rollup"):
+            raise ValueError(
+                f"emit must be 'vector' or 'rollup'; got {self.emit!r}")
+        if self.emit == "rollup" and not self.targets:
+            raise ValueError(
+                "emit='rollup' needs targets; with none there is nothing to roll up "
+                "(an empty target set would silently sum to an all-zero column)")
 
 
 @dataclass(frozen=True)

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -26,6 +26,25 @@ def _schema() -> dict:
     return json.loads(_SCHEMA_PATH.read_text())
 
 
+# The `combine` vocabulary, as a dispatch table rather than a name list, so that
+# SpecificitySpec's validation and reduce_matrix_to_gene's dispatch read from ONE
+# definition and cannot drift into disagreement. Consumed by matrix.py; kept here
+# because it is spec vocabulary, and because matrix.py already depends on this
+# module's types while nothing here depends on matrix.py.
+#
+#   sum  -- cell-CLASS specificity (EWCE level 1): targets are subtypes of one class
+#           (atrial/ventricular/Myoz2 cardiomyocytes), so pool their fractions into the
+#           fraction of the gene's expression sitting in the class. A pan-class gene,
+#           split across subtypes, reads high here and is missed by max.
+#   mean -- average specificity across targets.
+#   max  -- peak specificity to any single target.
+COMBINE_REDUCERS = {
+    "sum": lambda df: df.sum(axis=1),
+    "mean": lambda df: df.mean(axis=1),
+    "max": lambda df: df.max(axis=1),
+}
+
+
 @dataclass(frozen=True)
 class ScoreSpec:
     name: str
@@ -78,6 +97,16 @@ class SpecificitySpec:
             raise ValueError(
                 "emit='rollup' needs targets; with none there is nothing to roll up "
                 "(an empty target set would silently sum to an all-zero column)")
+        # Validated for the same reason as emit, and it matters more: the old
+        # reduce_matrix_to_gene dispatched sum/mean/else-max, so an unrecognised
+        # value did not raise -- it silently became 'max'. A spec author writing
+        # combine: 'sm' would get peak single-target specificity where they asked
+        # for the pooled class fraction: a different feature, not a degraded one.
+        if self.combine not in COMBINE_REDUCERS:
+            raise ValueError(
+                f"combine must be one of {sorted(COMBINE_REDUCERS)}; "
+                f"got {self.combine!r}"
+            )
 
 
 @dataclass(frozen=True)
@@ -144,9 +173,16 @@ def _build_matrix(raw: dict | None) -> MatrixSpec | None:
         if specificity_raw is None
         else SpecificitySpec(
             method=specificity_raw["method"],
-            targets=tuple(specificity_raw["targets"]),
+            # Optional in the schema: with no targets you get the vector alone.
+            # Defaulting here rather than indexing keeps YAML able to express
+            # vector-only, which is the point of the roll-up being additive.
+            targets=tuple(specificity_raw.get("targets", ())),
             combine=specificity_raw.get("combine", "max"),
             name=specificity_raw.get("name", "spec"),
+            # Without this, emit was Python-API-only: every YAML-driven spec
+            # silently took the "vector" default and could not opt back into the
+            # roll-up-only output the docstring advertises.
+            emit=specificity_raw.get("emit", "vector"),
         )
     )
     return MatrixSpec(

--- a/hvantk/resources/schemas/feature_spec.schema.json
+++ b/hvantk/resources/schemas/feature_spec.schema.json
@@ -161,8 +161,7 @@
         "specificity": {
           "type": "object",
           "required": [
-            "method",
-            "targets"
+            "method"
           ],
           "additionalProperties": false,
           "properties": {
@@ -170,6 +169,13 @@
               "type": "string",
               "enum": [
                 "ewce_fraction"
+              ]
+            },
+            "emit": {
+              "type": "string",
+              "enum": [
+                "vector",
+                "rollup"
               ]
             },
             "targets": {

--- a/hvantk/tests/annotation/test_compose.py
+++ b/hvantk/tests/annotation/test_compose.py
@@ -157,3 +157,46 @@ def test_compose_raises_on_duplicate_output_column_across_axes():
 
     with pytest.raises(ValueError, match="mis_z"):
         compose(spine=None, prepared_by_axis={}, spec=spec)
+
+
+@pytest.mark.hail
+def test_compose_carries_matrix_vector_columns_not_just_declared(hail_session):
+    """A matrix axis contributes every column its prepared table holds.
+
+    Regression: compose annotated only ``entry.columns``, so a matrix source's per-group
+    specificity vector -- whose names come from the atlas's group labels at runtime and
+    so cannot be enumerated in the spec -- was silently dropped. That made
+    ``emit="vector"``, the documented default, a no-op end to end.
+    """
+    import hail as hl
+
+    from hvantk.algorithms.annotation.compose import compose
+
+    entry = SourceEntry(
+        axis="expr",
+        source="ucsc-cellbrowser:asp_2019",
+        key="symbol",
+        columns=("asp_cm_spec",),  # the spec names ONLY the roll-up
+    )
+    # ...while the prepared table also carries the per-group vector.
+    prepared = _axis(
+        [
+            {"gene_id": "ENSG1", "asp_cm_spec": 1.0, "asp_cm": 1.0, "asp_other": 0.0},
+            {"gene_id": "ENSG2", "asp_cm_spec": 0.5, "asp_cm": 0.5, "asp_other": 0.5},
+        ],
+        hl.tstruct(
+            gene_id=hl.tstr,
+            asp_cm_spec=hl.tfloat64,
+            asp_cm=hl.tfloat64,
+            asp_other=hl.tfloat64,
+        ),
+    )
+    spec = FeatureSpec(name="test-spec", layer1=(entry,))
+    composed, manifest = compose(_spine(), {"expr": prepared}, spec)
+
+    assert {"asp_cm_spec", "asp_cm", "asp_other"} <= set(composed.row)
+    assert set(manifest["axes"]["expr"]) == {"asp_cm_spec", "asp_cm", "asp_other"}
+    rows = {r.gene_id: r for r in composed.collect()}
+    assert rows["ENSG1"].asp_other == pytest.approx(0.0)
+    assert rows["ENSG2"].asp_other == pytest.approx(0.5)
+    assert rows["ENSG3"].asp_cm is None  # absent from the axis, left missing

--- a/hvantk/tests/annotation/test_matrix.py
+++ b/hvantk/tests/annotation/test_matrix.py
@@ -53,7 +53,8 @@ def test_reduce_emits_specificity_and_strips_group_whitespace():
     from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
 
     df = reduce_matrix_to_gene(_summary_adata(), _mspec())
-    assert list(df.columns) == ["symbol", "asp_cm_spec"]
+    # vector-by-default: naming targets adds the roll-up, it does not replace the vector.
+    assert sorted(df.columns) == ["asp_cm", "asp_cm_spec", "asp_other", "symbol"]
     row = df.set_index("symbol")
     # TNNT2: mean 10 in CM, 0 in Other -> spec 1.0. ACTB: 5/5 -> 0.5.
     assert row.loc["TNNT2", "asp_cm_spec"] == pytest.approx(1.0)
@@ -148,3 +149,69 @@ def test_reduce_emits_per_group_stats_when_declared():
     # per-group mean columns, group label sanitized (' CM ' -> 'cm'); plus the specificity col
     assert "asp_cm_mean" in df.columns and "asp_other_mean" in df.columns
     assert df.loc["TNNT2", "asp_cm_mean"] == pytest.approx(10.0)
+
+
+# --- vector emission -------------------------------------------------------------------
+# Reducing an atlas to one summed scalar discards the cross-cell-type contrast entirely: the
+# non-target groups are computed, used as the denominator, then thrown away. Measured cost on
+# real data (analysis/rerank-homogenised): collapsing 33 cortical cell types to one number
+# took an epilepsy axis from +0.0795 to +0.0187 and from significant to not, while the
+# multiplicity penalty for keeping the vector was +0.0009. So the vector is the default and
+# the roll-up is additive.
+
+
+def test_specificity_emits_one_column_per_group_by_default():
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+    from hvantk.algorithms.annotation.spec import MatrixSpec, SpecificitySpec
+
+    mspec = MatrixSpec(
+        group_axis="celltype",
+        atlas="asp",
+        specificity=SpecificitySpec(method="ewce_fraction", targets=()),
+    )
+    df = reduce_matrix_to_gene(_summary_adata(), mspec).set_index("symbol")
+
+    # one column per surviving group, sanitized, atlas-prefixed -- and NO roll-up, because
+    # no targets were named.
+    assert sorted(df.columns) == ["asp_cm", "asp_other"]
+    # TNNT2 is 10 in CM, 0 in Other -> the vector carries the contrast the scalar hid.
+    assert df.loc["TNNT2", "asp_cm"] == pytest.approx(1.0)
+    assert df.loc["TNNT2", "asp_other"] == pytest.approx(0.0)
+    assert df.loc["ACTB", "asp_cm"] == pytest.approx(0.5)
+    assert df.loc["ACTB", "asp_other"] == pytest.approx(0.5)
+
+
+def test_emit_rollup_suppresses_the_vector():
+    """The old single-column behaviour stays reachable for callers that want only the class.
+
+    Vector-by-default changes what you get without asking; it must not remove the ability to
+    ask for the scalar. `emit="rollup"` is that opt-out.
+    """
+    from hvantk.algorithms.annotation.matrix import reduce_matrix_to_gene
+    from hvantk.algorithms.annotation.spec import MatrixSpec, SpecificitySpec
+
+    mspec = MatrixSpec(
+        group_axis="celltype",
+        atlas="asp",
+        specificity=SpecificitySpec(
+            method="ewce_fraction", targets=("CM",), combine="max",
+            name="cm_spec", emit="rollup",
+        ),
+    )
+    df = reduce_matrix_to_gene(_summary_adata(), mspec)
+    assert list(df.columns) == ["symbol", "asp_cm_spec"]
+
+
+def test_emit_rollup_without_targets_is_rejected():
+    """An empty target set summed to a silent all-zero column before this change."""
+    from hvantk.algorithms.annotation.spec import SpecificitySpec
+
+    with pytest.raises(ValueError, match="needs targets"):
+        SpecificitySpec(method="ewce_fraction", targets=(), emit="rollup")
+
+
+def test_unknown_emit_is_rejected():
+    from hvantk.algorithms.annotation.spec import SpecificitySpec
+
+    with pytest.raises(ValueError, match="emit must be"):
+        SpecificitySpec(method="ewce_fraction", targets=("CM",), emit="scalar")

--- a/hvantk/tests/annotation/test_prepare.py
+++ b/hvantk/tests/annotation/test_prepare.py
@@ -301,11 +301,63 @@ def test_prepare_matrix_source_reduces_and_maps_onto_spine(hail_session):
     )
     prepared, report = prepare_matrix_source(a, {"ENSG_T", "ENSG_A"}, entry, hgnc=fake)
     assert list(prepared.key) == ["gene_id"]
-    assert set(prepared.row) == {"gene_id", "asp_cm_spec"}
+    # The per-group VECTOR survives prepare alongside the declared roll-up. It used to be
+    # dropped here -- entry.columns gated the collapse, so emit="vector" (the default) was
+    # a no-op through the real pipeline no matter what the reducer emitted.
+    assert set(prepared.row) == {"gene_id", "asp_cm", "asp_other", "asp_cm_spec"}
     assert sorted(prepared.gene_id.collect()) == ["ENSG_A", "ENSG_T"]  # OFFGENE dropped
-    d = {r.gene_id: r.asp_cm_spec for r in prepared.collect()}
-    assert d["ENSG_T"] == pytest.approx(1.0)  # TNNT2: CM-specific
-    assert d["ENSG_A"] == pytest.approx(0.5)  # ACTB: ubiquitous
+    rows = {r.gene_id: r for r in prepared.collect()}
+    assert rows["ENSG_T"].asp_cm_spec == pytest.approx(1.0)  # TNNT2: CM-specific
+    assert rows["ENSG_A"].asp_cm_spec == pytest.approx(0.5)  # ACTB: ubiquitous
+    # Vector columns carry the same EWCE fractions, per group rather than rolled up.
+    assert rows["ENSG_T"].asp_cm == pytest.approx(1.0)
+    assert rows["ENSG_T"].asp_other == pytest.approx(0.0)
+    assert rows["ENSG_A"].asp_cm == pytest.approx(0.5)
+    assert rows["ENSG_A"].asp_other == pytest.approx(0.5)
+
+
+@pytest.mark.hail
+def test_prepare_matrix_source_rejects_undeclared_column(hail_session):
+    """A declared column the reducer never produces is an error, not a silent absence.
+
+    entry.columns no longer gates which columns survive, so its remaining job is to catch
+    a typo or an atlas whose group labels moved out from under the spec.
+    """
+    import anndata as ad
+    import numpy as np
+    import pandas as pd
+
+    from hvantk.algorithms.annotation.prepare import prepare_matrix_source
+    from hvantk.algorithms.annotation.spec import (
+        MatrixSpec,
+        SpecificitySpec,
+        SourceEntry,
+    )
+
+    a = ad.AnnData(
+        X=None,
+        obs=pd.DataFrame({"celltype": ["CM", "Other"]}, index=["CM", "Other"]),
+        var=pd.DataFrame(index=["TNNT2"]),
+        layers={"mean": np.array([[10.0], [0.0]])},
+    )
+    entry = SourceEntry(
+        axis="expr",
+        source="ucsc-cellbrowser:asp_2019",
+        key="symbol",
+        columns=("asp_typo_spec",),  # reducer emits asp_cm_spec, not this
+        matrix=MatrixSpec(
+            group_axis="celltype",
+            atlas="asp",
+            specificity=SpecificitySpec("ewce_fraction", ("CM",), "max", "cm_spec"),
+        ),
+    )
+    fake = _FakeHGNC(
+        canonical={"TNNT2": "TNNT2"},
+        symbol_to_hgnc={"TNNT2": "HGNC:T"},
+        hgnc_to_ensembl={"HGNC:T": "ENSG_T"},
+    )
+    with pytest.raises(ValueError, match="did not produce"):
+        prepare_matrix_source(a, {"ENSG_T"}, entry, hgnc=fake)
 
 
 @pytest.mark.hail


### PR DESCRIPTION
## What this changes

`SpecificitySpec.emit` now defaults to `"vector"`: one column per surviving group, atlas-prefixed
and sanitized. A named roll-up becomes **additive** — pass `targets` and you get the class column
*in addition to* the vector. `emit="rollup"` restores the old single-column output.

Previously `targets` + `combine` were **mandatory**, so the vector was not merely non-default —
it was unreachable. The non-target groups were computed, used as the denominator of the EWCE
fraction, and then discarded.

## Why

Measured, not assumed. On a homogenised cohort × panel grid (`hvantk-research
analysis/rerank-homogenised`) with 200-permutation selected-maximum nulls:

| Epi25 DEE, `expression_neuro` axis | ΔAUC over Z4 | p (selected-max) |
|---|---:|---:|
| scalar roll-up (33 cortical cell types → 1 column) | +0.0187 | 0.662 |
| per-group vector | **+0.0795** | **0.030** |

The reduction did not merely weaken the signal. Under the scalar, the cohort's **only** surviving
expression axis sat on a biologically *unrelated* control panel (retinal/hearing/skeletal); under
the vector, the disease panel gains a survivor and the control panel loses one. The
representation moved *which panel the signal appeared on* — the difference between a finding and
an artifact.

The obvious objection is multiplicity: more columns, more chances. Measured cost of the vector on
the selected-maximum null median is **+0.0009** (range −0.0001 to +0.0015 across four cohorts) —
negligible against the +0.061 it recovers.

That was checked against a same-cohort control rather than argued: an arm that **adds a whole
18th axis** (+116 columns) instead of widening an existing one costs **+0.0004 to +0.0009** —
the same. So the vector isn't getting a free pass its extra columns should have to pay for.
Both interventions move the selected-maximum null by about a thousandth of an AUC.

Where it doesn't pay it is cheap: in CHD the organ-level axis already carries the cardiac signal,
and the vector changes little. Cell-type resolution pays where the organ is heterogeneous
(cortex), and organ-level suffices where it is not (heart).

## A latent bug this closes

With empty `targets`, the old code evaluated `spec_gg[[]].sum(axis=1)` and emitted a **silent
all-zero column** — a dead feature, no error. `emit="rollup"` without targets is now rejected in
`__post_init__`, and the roll-up path is guarded on `targets`.

The roll-up's column name is also now checked against the vector's group columns, so a collision
raises instead of silently overwriting.

## Compatibility

Existing YAML specs declare `columns:` explicitly, so the new vector columns are **emitted but not
consumed** until a spec opts in. Nothing downstream changes shape today. Callers that want only
the class column set `emit="rollup"`.

## Changes

- `algorithms/annotation/spec.py` — `SpecificitySpec.emit`, `targets` defaults to `()`,
  `__post_init__` validation
- `algorithms/annotation/matrix.py` — vector emission in `reduce_matrix_to_gene`, guarded
  additive roll-up, collision check
- `tests/annotation/test_matrix.py` — 4 tests added

## Testing

TDD. The vector test was written first and failed with
`assert ['asp_spec'] == ['asp_cm', 'asp_other']` — missing feature, not a typo.

New: vector-by-default; roll-up still emitted alongside the vector; `emit="rollup"` without
targets rejected; unknown `emit` rejected.

One existing test asserted the old exact column set and was updated to the new intended behaviour
(`["asp_cm", "asp_cm_spec", "asp_other", "symbol"]`) — extended, not weakened.

57 annotation tests pass. Full fast suite exits 0. The 4 errors in `enrichex`/`hgc` reproduce
identically on unmodified `dev`, so they are pre-existing and unrelated. flake8 clean.
