### PR TITLE
build: move scanpy behind an 'expression' extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ opt-in via Poetry extras. Install only what a given workflow needs:
 | `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn |
 | `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn |
 | `ml` | scikit-learn-backed features only | scikit-learn |
+| `expression` | `summarize_expression_ad` / `hvantk expression summarize` | scanpy |
 
 ```bash
 # One or more extras at once

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ opt-in via Poetry extras. Install only what a given workflow needs:
 | `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn |
 | `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn |
 | `ml` | scikit-learn-backed features only | scikit-learn |
-| `expression` | `hvantk expression summarize` and `markers` (scanpy aggregation / marker detection) | scanpy |
+| `expression` | `hvantk expression summarize` / `markers`, and `ptm constraint --expression-metric mean` | scanpy |
 
 ```bash
 # One or more extras at once

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ opt-in via Poetry extras. Install only what a given workflow needs:
 | `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn |
 | `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn |
 | `ml` | scikit-learn-backed features only | scikit-learn |
-| `expression` | `summarize_expression_ad` / `hvantk expression summarize` | scanpy |
+| `expression` | `hvantk expression summarize` and `markers` (scanpy aggregation / marker detection) | scanpy |
 
 ```bash
 # One or more extras at once

--- a/docs_site/getting-started/installation.md
+++ b/docs_site/getting-started/installation.md
@@ -42,6 +42,14 @@ poetry install --extras "viz hgc"      # or: poetry install --all-extras
 | `ptm` | cptac | CPTAC PTM downloads |
 | `constraint` | tspex, matplotlib, seaborn | `hvantk ptm constraint` |
 | `duckdb` | duckdb | DuckDB-backed catalog queries |
+| `expression` | scanpy | `hvantk expression summarize` aggregation |
+
+> **`expression` is unavailable on Intel macOS.** scanpy pulls `numba` →
+> `llvmlite`, which ships no x86_64 macOS wheel from 0.47 onward and fails to
+> build from source. The extra installs normally on Linux and Apple Silicon.
+> This is why scanpy is an extra rather than a base dependency: as a base dep it
+> made the whole package uninstallable on Intel Macs. Everything outside
+> `hvantk expression summarize` works there.
 
 `scikit-learn` is optional — install `ml`, `ancestry`, or `psroc` if you use
 those analyses.

--- a/docs_site/getting-started/installation.md
+++ b/docs_site/getting-started/installation.md
@@ -44,11 +44,18 @@ poetry install --extras "viz hgc"      # or: poetry install --all-extras
 | `duckdb` | duckdb | DuckDB-backed catalog queries |
 | `expression` | scanpy | `hvantk expression summarize` and `markers` |
 
-Exactly two commands need this extra — `hvantk expression summarize` (via
-`summarize_expression_ad`) and `hvantk expression markers` (scanpy's
-`rank_genes_groups`). `describe` and `summarize-ucsc` do not touch scanpy and
-work on a base install. Without the extra, both scanpy-backed commands exit with
-an actionable message naming it, not a traceback.
+Three command paths need this extra:
+
+- `hvantk expression summarize` — via `summarize_expression_ad`
+- `hvantk expression markers` — scanpy's `rank_genes_groups`
+- `hvantk ptm constraint --expression-source anndata --expression-metric mean` —
+  routes through `summarize_expression_ad` for the mean aggregation only. The
+  default metric is `median`, which uses a direct numpy path and does not need
+  scanpy.
+
+`hvantk expression describe` and `summarize-ucsc` do not touch scanpy and work on
+a base install. Without the extra, these paths exit with an actionable message
+naming it, not a traceback.
 
 > **`expression` is unavailable on Intel macOS.** scanpy pulls `numba` →
 > `llvmlite`, which ships no x86_64 macOS wheel from 0.47 onward and fails to

--- a/docs_site/getting-started/installation.md
+++ b/docs_site/getting-started/installation.md
@@ -42,14 +42,20 @@ poetry install --extras "viz hgc"      # or: poetry install --all-extras
 | `ptm` | cptac | CPTAC PTM downloads |
 | `constraint` | tspex, matplotlib, seaborn | `hvantk ptm constraint` |
 | `duckdb` | duckdb | DuckDB-backed catalog queries |
-| `expression` | scanpy | `hvantk expression summarize` aggregation |
+| `expression` | scanpy | `hvantk expression summarize` and `markers` |
+
+Exactly two commands need this extra — `hvantk expression summarize` (via
+`summarize_expression_ad`) and `hvantk expression markers` (scanpy's
+`rank_genes_groups`). `describe` and `summarize-ucsc` do not touch scanpy and
+work on a base install. Without the extra, both scanpy-backed commands exit with
+an actionable message naming it, not a traceback.
 
 > **`expression` is unavailable on Intel macOS.** scanpy pulls `numba` →
 > `llvmlite`, which ships no x86_64 macOS wheel from 0.47 onward and fails to
 > build from source. The extra installs normally on Linux and Apple Silicon.
 > This is why scanpy is an extra rather than a base dependency: as a base dep it
-> made the whole package uninstallable on Intel Macs. Everything outside
-> `hvantk expression summarize` works there.
+> made the whole package uninstallable on Intel Macs. On Intel, run those two
+> commands on the cluster; the rest of the toolkit is unaffected.
 
 `scikit-learn` is optional — install `ml`, `ancestry`, or `psroc` if you use
 those analyses.

--- a/hvantk/algorithms/expression/matrix_utils.py
+++ b/hvantk/algorithms/expression/matrix_utils.py
@@ -19,8 +19,33 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "describe_expression_ad",
     "filter_by_metadata_ad",
+    "require_scanpy",
     "summarize_expression_ad",
 ]
+
+_SCANPY_HINT = (
+    "scanpy is required for expression aggregation and marker detection, and is "
+    "not part of the base install. Install the 'expression' extra:\n"
+    "    pip install 'hvantk[expression]'\n"
+    "    poetry install --extras expression\n"
+    "Note: unavailable on Intel macOS -- scanpy pulls numba/llvmlite, which ships "
+    "no x86_64 macOS wheel. Run expression aggregation on Linux or Apple Silicon."
+)
+
+
+def require_scanpy():
+    """Return the scanpy module, or raise with the extra to install.
+
+    Public rather than underscore-private because the expression CLI imports it
+    too, so both entry points give the same guidance. Without this, dropping
+    scanpy from the base install leaves callers with a bare ModuleNotFoundError
+    and no hint that an extra exists.
+    """
+    try:
+        import scanpy as sc
+    except ModuleNotFoundError as exc:  # pragma: no cover - needs scanpy absent
+        raise ImportError(_SCANPY_HINT) from exc
+    return sc
 
 
 def describe_expression_ad(adata: ad.AnnData) -> Dict[str, Any]:
@@ -120,8 +145,13 @@ def summarize_expression_ad(
         Shape ``(n_groups, n_genes)`` with layers ``mean``, ``sum``,
         ``count_nonzero``, ``fraction_expressed``. ``obs["n_cells"]`` stores
         the per-group cell count.
+
+    Raises
+    ------
+    ImportError
+        If scanpy is not installed. It ships in the ``expression`` extra.
     """
-    import scanpy as sc
+    sc = require_scanpy()
 
     if filter_by:
         adata = filter_by_metadata_ad(adata, filter_by)

--- a/hvantk/tests/test_matrix_utils_anndata.py
+++ b/hvantk/tests/test_matrix_utils_anndata.py
@@ -1,5 +1,7 @@
 """Tests for AnnData-based expression analysis functions in matrix_utils."""
 
+import importlib.util
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,6 +13,14 @@ from hvantk.algorithms.expression.matrix_utils import (
     describe_expression_ad,
     filter_by_metadata_ad,
     summarize_expression_ad,
+)
+
+# Only summarize_expression_ad reaches for scanpy, and only at call time -- describe/
+# filter work on a base install. find_spec rather than importorskip so the rest of the
+# module still runs, and so we never pay scanpy's import cost just to decide.
+requires_scanpy = pytest.mark.skipif(
+    importlib.util.find_spec("scanpy") is None,
+    reason="summarize_expression_ad needs the 'expression' extra (scanpy)",
 )
 
 
@@ -63,6 +73,7 @@ class TestFilterByMetadataAd:
         assert filtered.n_obs > 0
 
 
+@requires_scanpy
 class TestSummarizeExpressionAd:
     def test_returns_anndata(self, test_adata):
         result = summarize_expression_ad(test_adata, group_by="cell_type")

--- a/hvantk/tools/expression/summarize_expression_cli.py
+++ b/hvantk/tools/expression/summarize_expression_cli.py
@@ -197,12 +197,17 @@ def summarize_expression_cmd(
             param_hint="--group-by",
         )
 
-    summary = summarize_expression_ad(
-        adata,
-        group_by=list(group_by),
-        filter_by=filters,
-        min_cells_per_group=min_cells,
-    )
+    # Same reasoning as `markers`: summarize_expression_ad reaches for scanpy,
+    # which is optional, so surface a missing extra as a usage error not a crash.
+    try:
+        summary = summarize_expression_ad(
+            adata,
+            group_by=list(group_by),
+            filter_by=filters,
+            min_cells_per_group=min_cells,
+        )
+    except ImportError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     if summary.n_obs == 0:
         click.echo(
@@ -318,11 +323,19 @@ def markers_cmd(
     """
     from pathlib import Path
 
-    import scanpy as sc
-
     from hvantk.core.io.anndata_io import load_anndata
-    from hvantk.algorithms.expression.matrix_utils import filter_by_metadata_ad
+    from hvantk.algorithms.expression.matrix_utils import (
+        filter_by_metadata_ad,
+        require_scanpy,
+    )
     from hvantk.core.utils.gene_sets import GeneSet, GeneSetCollection
+
+    # ClickException so a missing optional extra reads as a usage problem rather
+    # than a crash -- click prints "Error: <msg>" and exits 1, no traceback.
+    try:
+        sc = require_scanpy()
+    except ImportError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     output_path = Path(output)
     if output_path.exists() and not overwrite:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,14 @@ psutil = "*"
 pysam = ">=0.22"
 certifi = "*"
 anndata = ">=0.10.0"
-scanpy = ">=1.10.0"
+# OPTIONAL, unlike anndata: scanpy pulls numba -> llvmlite, and llvmlite ships no
+# x86_64 macOS wheel from 0.47 on, so a base-level declaration makes the whole
+# package uninstallable on Intel Macs -- including for the ~99% of the toolkit that
+# never touches expression. Both import sites (algorithms/expression/matrix_utils.py,
+# tools/expression/summarize_expression_cli.py) already import it inside the function
+# body, so nothing breaks at import time when it is absent. anndata is pure Python and
+# stays in the base install.
+scanpy = { version = ">=1.10.0", optional = true }
 gnomad = { version = "*", optional = true }
 # ^1.4, not ^1.3: rerank's opt-in RFECV step wraps RandomForestClassifier, which only
 # tolerates NaN from 1.4 onward, and these feature matrices are 20-50% missing by design.
@@ -79,6 +86,7 @@ ptm = ["cptac", "sorted-nearest"]
 constraint = ["tspex", "matplotlib", "seaborn"]
 ancestry = ["scikit-learn", "matplotlib", "seaborn", "scipy"]
 ml = ["scikit-learn", "scipy"]
+expression = ["scanpy"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## Why

`scanpy` pulls `numba` -> `llvmlite`, and llvmlite ships **no x86_64 macOS wheel** from 0.47 onward. As a *base* dependency that made the entire package uninstallable on Intel Macs — `poetry install` dies trying to build llvmlite from source — for the whole toolkit, not just the expression domain.

`scanpy` was the anomaly, not the precedent: `scikit-learn`, `matplotlib`, `cptac` and `tspex` are all already optional behind nine extras.

## What changed

- `scanpy` -> optional, behind a new `expression` extra. `anndata` is pure Python and **stays in the base install**; only scanpy moves.
- `require_scanpy()` in `algorithms/expression/matrix_utils.py` raises `ImportError` naming the extra, following the existing `_require_matplotlib` idiom in `algorithms/qtlcascade/plot.py`. The CLI converts it to `click.ClickException`, so a missing extra reads as a usage error: `Error: <msg>`, exit 1, no traceback.
- `TestSummarizeExpressionAd` skips via `find_spec` when the extra is absent, per the convention in `hvantk/tests/rerank/test_example.py`. The `describe`/`filter` tests keep running on a base install.
- Docs name **every** path that needs the extra: `hvantk expression summarize`, `hvantk expression markers`, and `hvantk ptm constraint --expression-metric mean` (which routes through `summarize_expression_ad`; the default `median` metric does not).

Both scanpy import sites were already function-local, so nothing changes at import time.

## Verification

On x86_64 macOS 26.5.2 / Python 3.10.11, in a venv that genuinely lacks scanpy:

- `summarize` and `markers` exit 1 with the install hint and **no traceback**; `describe` still exits 0.
- Full fast suite **exits 0, no failures** (previously 8, all `ModuleNotFoundError: No module named 'scanpy'` at `matrix_utils.py:124`).
- `flake8` clean (`E9,F63,F7,F82` plus `E402,F401,F821`).

## REQUIRED FOLLOW-UP: this change is inert until `poetry.lock` is regenerated

`poetry.lock` is **deliberately untouched here**, which means **merging this PR alone does not yet fix the Intel macOS install.** The lock still records `scanpy` as `optional = false, groups = ["main"]` and has no `expression` entry in its `[extras]` table, because a lock only reflects `pyproject.toml` after `poetry lock` is rerun.

This is not a regression introduced here. The lock is **already stale on both `main` and `dev`**:

- It pins `jsonschema` **3.2.0** against a declared `jsonschema = ">=4.0"`; the lock violates its own constraint.
- ~28 commits have touched `pyproject.toml` since it was last generated (`pyarrow` became a runtime dep, scikit-learn moved behind extras, `sorted-nearest` was added).
- So `poetry install` **already fails on a clean checkout of either branch today**, before this PR.

The relock is deferred because regenerating the lock also drags **`gnomad` 0.8.2 -> 0.6.4** (gnomad 0.8.2 requires the `hgvs`/`ga4gh-vrs` stack, which pins `jsonschema<4`). That downgrade touches HGC and must be exercised on the cluster, so it belongs in its own PR run there. Once that lands, the optionality declared here takes effect automatically.
