### PR TITLE
fix(spec,docs): reject duplicate matrix atlases; document the release honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@
 
 ### Changed
 
+- **Breaking (rerank).** `ArmAssignment.unknown` is renamed `undeclared`, and an undeclared
+  predictor is now treated as *conflicted* rather than getting a bucket of its own. Arm
+  membership is otherwise unchanged. Code reading `ArmAssignment.unknown` must be updated.
+- **Rebuild your dbNSFP artifact.** `dbnsfp:variants` now parses the ~57 `*_rankscore`
+  columns to `float64` with proper missingness, instead of leaving them as raw strings
+  (`"."` for missing). `schema_id` stays `dbnsfp-v1` — the column *set* is unchanged and
+  string rankscores were always a parsing bug rather than an intended schema — so nothing
+  will warn you: an artifact built before this release carries strings where a fresh build
+  carries floats. Re-run `hvantk reprocess dbnsfp:variants` before relying on those columns.
+- Specificity features in the annotation matrix now emit a per-group **vector** by default
+  (one column per surviving atlas group, named `{atlas}_{sanitized_group}`) instead of a
+  single rolled-up scalar. A named roll-up is *additive* when `specificity.targets` is
+  given; `specificity.emit: rollup` restores the previous single-column output. Two matrix
+  axes may no longer share an `atlas` label, since their vector columns would collide.
+- `hvantk drift` comparators can now actually detect an upstream change. Previously the
+  comparison could pass regardless of source content, so drift went unreported.
+- `scikit-learn` floor raised to `>=1.4` (NaN-tolerant tree estimators, needed by rerank's
+  optional RFECV wrapper). `scipy` is now declared explicitly, as an optional dependency in
+  the `ml` / `ancestry` / `psroc` extras.
+- `scanpy` moved out of the base install into a new `expression` extra. It is required by
+  `hvantk expression summarize`, `hvantk expression markers`, and `hvantk ptm constraint
+  --expression-metric mean`; those now fail with an actionable message naming the extra
+  rather than a bare `ModuleNotFoundError`. The extra cannot be installed on Intel macOS
+  (scanpy → numba → llvmlite ships no x86_64 macOS wheel from 0.47).
 - Package restructured into 4 purpose-driven roofs: `core/` (platform models, utilities, plugin/tool runtime, streamers, transient builders), `algorithms/` (analytical computation: ptm, psroc, qtlcascade, enrichex, hgc, ancestry, annotation, visualization, expression, statistics, training_sets), `skills/` (data ingestion plugins), `tools/` (CLI surface). Inside `core/` there are now sub-packages `models/`, `utils/`, `streamers/`, `plugin/`, `tool/`, `builders/` so adding a new format helper has one obvious home. One-way dependency rule (`skills/`, `tools/` → `algorithms/` → `core/`) is enforced by `hvantk/tests/test_dependency_directions.py`. `hvantk/data/`, `hvantk/utils/`, `hvantk/tables/`, and 8 top-level algorithm dirs (`hvantk/{ptm,psroc,qtlcascade,enrichex,hgc,ancestry,annotation,visualization}/`) are gone. `ClinVarStreamer` no longer imports from `hvantk.skills.clinvar.builder` — it accepts a pre-built Hail Table via its constructor.
 - Registry keys for migrated providers use compound `provider:dataset` form. Recipe JSONs and any custom callers should update from bare names (e.g., `clinvar`) to compound (`clinvar:variants`). The legacy `hvantk mktable` / `hvantk mkmatrix` CLI surfaces have been retired; data builds now go through `hvantk reprocess <provider>:<dataset>` with `--plugin-arg key=value` for builder kwargs.
 - Plugin manifests gain an optional `catalog: <path>` field pointing at a per-plugin `catalog/datasets.json`. `unified_registry.HvantkRegistry` now aggregates per-plugin catalogs from the plugin loader in addition to the legacy `resources/registry/genomics/datasets.json`.
@@ -38,3 +62,19 @@
   `cptac:expression`, and `cptac:phospho`. The first hail-enabled CI run with
   `--regenerate-snapshots` will bootstrap them. All `ucsc-cellbrowser` variants
   (`default`, `adult-ctx`, `dev-ctx`) already have populated snapshot dirs.
+- **`poetry.lock` is stale, so `poetry install` fails on a clean checkout.** The lock pins
+  `jsonschema` 3.2.0 against a declared `jsonschema = ">=4.0"`, and its `[extras]` table is
+  missing `ancestry`, `ml`, `constraint` and `expression` entirely, so
+  `poetry install --extras expression` fails extras validation on top of the hash
+  mismatch. Regenerating it also moves `gnomad` 0.8.2 → 0.6.4 (gnomad 0.8.2 needs the
+  `hgvs`/`ga4gh-vrs` stack, which pins `jsonschema<4`), which touches HGC and so has to be
+  exercised on the cluster. Until that lands, `scanpy`'s move behind the `expression`
+  extra is *declared but not in effect* — the lock still records it as a mandatory
+  main-group package.
+- `scipy` is imported at module scope by `algorithms/burden/fet.py`,
+  `algorithms/enrichex/overlap.py` and `algorithms/ptm/constraint.py`, none of which sit
+  behind an extra that pulls it in, so `hvantk enrichex burden|overlap` and
+  `hvantk ptm constraint` raise `ModuleNotFoundError` on a base install. Pre-existing:
+  scipy was previously not declared at all.
+- The package version has never been bumped from `0.1.0`, so releases to `main` are not
+  distinguishable by version.

--- a/hvantk/algorithms/annotation/spec.py
+++ b/hvantk/algorithms/annotation/spec.py
@@ -243,4 +243,23 @@ def load_spec(path: str | Path) -> FeatureSpec:
                 f"entry {e.source!r} has a matrix block, which requires key: symbol "
                 f"(the reduced table is symbol-keyed); got key {e.key!r}"
             )
+    # Matrix vector columns are named {atlas}_{sanitized_group} with no axis component
+    # (matrix.reduce_matrix_to_gene), so two matrix entries over the SAME atlas emit the
+    # same column names for every group they share. Since emit="vector" is the default,
+    # that is now the common case -- e.g. splitting one single-cell atlas into a
+    # cardiomyocyte axis and a fibroblast axis. compose() would catch it, but only after
+    # both sources had been read, reduced and mapped onto the spine; here it costs
+    # nothing and names the fix.
+    atlases: dict = {}
+    for e in entries:
+        if e.matrix is None:
+            continue
+        if e.matrix.atlas in atlases:
+            raise ValueError(
+                f"axes {atlases[e.matrix.atlas]!r} and {e.axis!r} both declare matrix "
+                f"atlas {e.matrix.atlas!r}; their per-group specificity columns would "
+                "collide, since a vector column is named {atlas}_{group}. Give each "
+                "matrix axis a distinct atlas label, or set emit: rollup on all but one"
+            )
+        atlases[e.matrix.atlas] = e.axis
     return FeatureSpec(name=doc["name"], layer1=entries)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,17 @@ gnomad = { version = "*", optional = true }
 # The floor stays as long as `SelectionPolicy(wrapper="rfecv")` is reachable -- it is now
 # off by default, not removed. Drop to ^1.3 only if the wrapper is deleted outright.
 scikit-learn = { version = "^1.4", optional = true }
-# scipy is a hard install_requires of scikit-learn, so it is always present wherever the
-# code that imports it is reachable -- rerank's selection and leakage filters both use
-# scipy.stats, and neither can run without sklearn anyway. Declared explicitly regardless,
-# because relying on a transitive dependency is how it silently breaks later. OPTIONAL, and
-# listed in the same extras as scikit-learn: rerank is not part of a base install, so a
-# base-level declaration would burden every user who never touches it.
+# Declared explicitly rather than leaned on as a transitive dep of scikit-learn, because
+# relying on a transitive dependency is how it silently breaks later.
+#
+# NOTE, and it is not fully true that scipy only matters where sklearn does:
+# algorithms/burden/fet.py, algorithms/enrichex/overlap.py and algorithms/ptm/constraint.py
+# all `from scipy...` at MODULE scope without sklearn anywhere nearby, so `hvantk enrichex
+# burden|overlap` and `hvantk ptm constraint` raise ModuleNotFoundError on a base install.
+# That is pre-existing -- scipy was previously not declared here at all, so those paths were
+# already broken without an extra -- and keeping scipy optional does not make it worse. The
+# real fix is either a gating extra for enrichex/ptm or call-time imports with a
+# require_scipy() guard (cf. require_scanpy in algorithms/expression/matrix_utils.py).
 scipy = { version = ">=1.8", optional = true }
 matplotlib = { version = "*", optional = true }
 seaborn = { version = "*", optional = true }


### PR DESCRIPTION
Follow-ups from the adversarial review of release PR #249. **No shipped behaviour changes** — one guard against a spec pattern that cannot occur today, plus documentation.

## 1. Reject two matrix entries sharing an `atlas`

Vector columns are named `{atlas}_{sanitized_group}` with **no axis component** (`matrix.reduce_matrix_to_gene`), so two matrix axes over one atlas emit identical column names for every group they share. Since `emit: vector` is now the default (#246), that is the common case — splitting one single-cell atlas into a cardiomyocyte axis and a fibroblast axis is the worked example in #246's own commit message.

`compose()` already catches this, but only after both sources have been read, reduced, and mapped onto the spine. `load_spec` now rejects it in pure Python at parse time, and the message names both fixes (distinct atlas labels, or `emit: rollup` on all but one).

**No committed spec is affected** — the repo contains no feature-spec YAML at all — so this closes a trap rather than repairing a break.

## 2. CHANGELOG

Recorded 3 of ~15 material changes. Added the breaking `ArmAssignment.unknown` -> `undeclared` rename, the vector-emission default, the drift-comparator fix, and the scikit-learn/scipy/scanpy packaging changes.

**dbNSFP gets an explicit entry.** ~57 `*_rankscore` columns now parse to `float64` instead of raw strings, while `schema_id` stays `dbnsfp-v1`. Not bumping is defensible — the column *set* is unchanged and string rankscores were a parsing bug rather than an intended schema — but it means nothing warns you that an artifact built before this release carries strings where a fresh build carries floats. The entry says so, and says to re-run `hvantk reprocess dbnsfp:variants`.

Three known gaps are now recorded rather than shipped silently: the stale `poetry.lock` (including that it leaves scanpy's optionality *declared but inert*), the unguarded module-scope scipy imports, and that the version has never moved off `0.1.0`.

## 3. Corrected an inaccurate comment in `pyproject.toml`

It claimed scipy "is always present wherever the code that imports it is reachable". That is false: `algorithms/burden/fet.py`, `algorithms/enrichex/overlap.py` and `algorithms/ptm/constraint.py` all import scipy at **module scope** with no sklearn nearby, so `hvantk enrichex burden|overlap` and `hvantk ptm constraint` raise `ModuleNotFoundError` on a base install. Pre-existing — scipy was previously not declared at all, so those paths were already broken without an extra — but the comment asserted otherwise.

## Verification

- Duplicate-atlas spec rejected; distinct-atlas spec accepted.
- `poetry check` parses `pyproject.toml` (emits only the known stale-lock error).
- Full fast suite **exits 0**, no failures. `flake8` clean.
