### PR TITLE
fix(extras): give every module-scope scipy import an extra that installs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,32 @@
 - `scikit-learn` floor raised to `>=1.4` (NaN-tolerant tree estimators, needed by rerank's
   optional RFECV wrapper). `scipy` is now declared explicitly, as an optional dependency in
   the `ml` / `ancestry` / `psroc` extras.
+- **Every command that imports `scipy` at module scope now has an extra that installs it.**
+  Three modules do, and they sit on three *different* commands — a mapping the previous
+  known-gaps note got wrong:
+  `algorithms/ptm/constraint.py` → `hvantk ptm constraint` (`constraint` extra);
+  `algorithms/enrichex/overlap.py` → `hvantk enrichex overlap` (new `enrichex` extra);
+  `algorithms/burden/fet.py` → `hvantk cohort burden` (new `cohort` extra).
+  `fet.py` is *not* reached by `hvantk enrichex burden`: its only importer is
+  `algorithms/burden/pipeline.py`, imported by `tools/cohort/cohort_cli.py` alone.
+  Previously `constraint` omitted `scipy`, so `pip install hvantk[constraint]` yielded a
+  documented extra whose own command still raised `ModuleNotFoundError`, and neither
+  `hvantk enrichex overlap` nor `hvantk cohort burden` had any extra to install.
+  `enrichex` also carries matplotlib/seaborn, because `enrichex/__init__` imports
+  `plot.py`/`report.py` unconditionally and a scipy-only extra would break on import.
+  `scipy` was added to `expression` too — a resolution no-op, since scanpy already depends
+  on it, but `visualization/expression/anndata.py` imports `scipy.sparse` directly and this
+  project declares what it imports rather than inheriting it from a transitive edge that can
+  move. A base install still raises a bare `ModuleNotFoundError` rather than a message
+  naming the extra; a `require_scipy()` guard (cf. `require_scanpy`) would fix the *text*,
+  and is tracked separately because it changes no extra's contents.
+- The extras table is now guarded by a test. It is duplicated in three places — the
+  `[tool.poetry.extras]` block, `README.md` and `docs_site/getting-started/installation.md`
+  — and only the first is executable, so the prose copies had drifted eight cells
+  (`psroc`/`ancestry`/`ml` missing `scipy`, `ptm` missing `sorted-nearest`) across two
+  releases. `hvantk/tests/test_pyproject_extras.py` now parses both markdown tables and
+  fails if either disagrees with `pyproject.toml`, and also fails if an extra names a
+  package that is not declared `optional = true`. Non-Hail, so it runs in the default suite.
 - `scanpy` moved out of the base install into a new `expression` extra. It is required by
   `hvantk expression summarize`, `hvantk expression markers`, and `hvantk ptm constraint
   --expression-metric mean`; those now fail with an actionable message naming the extra
@@ -83,11 +109,6 @@
   `cptac:expression`, and `cptac:phospho`. The first hail-enabled CI run with
   `--regenerate-snapshots` will bootstrap them. All `ucsc-cellbrowser` variants
   (`default`, `adult-ctx`, `dev-ctx`) already have populated snapshot dirs.
-- `scipy` is imported at module scope by `algorithms/burden/fet.py`,
-  `algorithms/enrichex/overlap.py` and `algorithms/ptm/constraint.py`, none of which sit
-  behind an extra that pulls it in, so `hvantk enrichex burden|overlap` and
-  `hvantk ptm constraint` raise `ModuleNotFoundError` on a base install. Pre-existing:
-  scipy was previously not declared at all.
 - The package version has never been bumped from `0.1.0`, so releases to `main` are not
   distinguishable by version.
 - No CI job installs the package (`pip install .` / `poetry install`), so `pytest` imports

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ opt-in via Poetry extras. Install only what a given workflow needs:
 | `interactive` | Interactive plots / dashboards | plotly |
 | `duckdb` | DuckDB-backed queries | duckdb |
 | `hgc` | Joint genotyping plots (genotype adjustment needs no extra) | matplotlib, seaborn |
-| `psroc` | Pathogenicity Score ROC analysis | matplotlib, plotly, scikit-learn |
-| `ptm` | CPTAC proteomics builders | cptac |
-| `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn |
-| `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn |
-| `ml` | scikit-learn-backed features only | scikit-learn |
-| `expression` | `hvantk expression summarize` / `markers`, and `ptm constraint --expression-metric mean` | scanpy |
+| `psroc` | Pathogenicity Score ROC analysis | matplotlib, plotly, scikit-learn, scipy |
+| `ptm` | CPTAC proteomics builders | cptac, sorted-nearest |
+| `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn, scipy |
+| `enrichex` | `hvantk enrichex overlap` / `burden` and their plots | scipy, matplotlib, seaborn |
+| `cohort` | `hvantk cohort burden` (Fisher gene burden) | scipy |
+| `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn, scipy |
+| `ml` | scikit-learn-backed features only | scikit-learn, scipy |
+| `expression` | `hvantk expression summarize` / `markers`, and `ptm constraint --expression-metric mean` | scanpy, scipy |
 
 ```bash
 # One or more extras at once

--- a/docs_site/getting-started/installation.md
+++ b/docs_site/getting-started/installation.md
@@ -35,14 +35,16 @@ poetry install --extras "viz hgc"      # or: poetry install --all-extras
 |---|---|---|
 | `viz` | matplotlib, seaborn, plotly | plots and HTML reports |
 | `interactive` | plotly | interactive QC dashboards |
-| `ml` | scikit-learn | ML-backed analyses |
-| `ancestry` | scikit-learn, matplotlib, seaborn | `hvantk ancestry-inference` |
-| `psroc` | scikit-learn, matplotlib, plotly | `hvantk psroc` |
+| `ml` | scikit-learn, scipy | ML-backed analyses |
+| `ancestry` | scikit-learn, matplotlib, seaborn, scipy | `hvantk ancestry-inference` |
+| `psroc` | scikit-learn, matplotlib, plotly, scipy | `hvantk psroc` |
 | `hgc` | matplotlib, seaborn | `hvantk hgc` QC plots/reports |
-| `ptm` | cptac | CPTAC PTM downloads |
-| `constraint` | tspex, matplotlib, seaborn | `hvantk ptm constraint` |
+| `ptm` | cptac, sorted-nearest | CPTAC PTM downloads |
+| `constraint` | tspex, matplotlib, seaborn, scipy | `hvantk ptm constraint` |
+| `enrichex` | scipy, matplotlib, seaborn | `hvantk enrichex overlap` / `burden` |
+| `cohort` | scipy | `hvantk cohort burden` |
 | `duckdb` | duckdb | DuckDB-backed catalog queries |
-| `expression` | scanpy | `hvantk expression summarize` and `markers` |
+| `expression` | scanpy, scipy | `hvantk expression summarize` and `markers` |
 
 Three command paths need this extra:
 

--- a/docs_site/guide/hpc-migration.md
+++ b/docs_site/guide/hpc-migration.md
@@ -152,7 +152,7 @@ From: python:3.10-slim-bookworm
     poetry config virtualenvs.create false
     # install the locked deps + the extras you actually run (trim as needed):
     poetry install --no-interaction --no-root \
-        --extras "hgc ptm qtl ancestry psroc constraint viz duckdb"
+        --extras "hgc ptm ancestry psroc constraint enrichex cohort viz duckdb"
     poetry install --no-interaction --only-root
     # experiment-only extras NOT in pyproject (e.g. PTM functionality pilot):
     pip install --no-cache-dir pyBigWig
@@ -176,9 +176,11 @@ From: python:3.10-slim-bookworm
     hail 0.2.137
 ```
 
-> Trim `--extras` to what you run. The core install omits scikit-learn / viz /
+> Trim `--extras` to what you run. The core install omits scikit-learn / scipy / viz /
 > cptac / tspex / duckdb / scanpy — they live behind extras (`hgc`, `ptm`,
-> `ancestry`, `psroc`, `constraint`, `ml`, `viz`, `duckdb`, `expression`).
+> `ancestry`, `psroc`, `constraint`, `enrichex`, `cohort`, `ml`, `viz`, `duckdb`,
+> `interactive`, `expression`). The authoritative list is `[tool.poetry.extras]` in
+> `pyproject.toml`; this one is prose and is not machine-checked.
 > `pyBigWig` is **not** a hvantk dependency — include it only for experiments that
 > query bigWig tracks. Genotype adjustment needs **no** extra: `annotate_adj` is
 > ported in-tree, so `gnomad` is no longer a dependency at all.
@@ -458,6 +460,6 @@ launching at scale.
   localhost.
 - **Stray system/conda Python** below the 3.10 floor → use the container's Python;
   never run hvantk against an unmanaged interpreter.
-- **Core install ≠ full toolkit** — install the right **extras** (`hgc ptm qtl
-  ancestry psroc constraint viz duckdb`) in the image.
+- **Core install ≠ full toolkit** — install the right **extras** (`hgc ptm
+  ancestry psroc constraint enrichex cohort viz duckdb`) in the image.
 - **Scratch is purged** — copy results to project/home before the window.

--- a/hvantk/tests/test_pyproject_extras.py
+++ b/hvantk/tests/test_pyproject_extras.py
@@ -1,12 +1,33 @@
-"""Guard the declared Poetry extras/deps that runtime imports rely on.
+"""Guard the declared Poetry extras -- both what they contain and how they are documented.
 
 #198: cptac imports pyranges, whose compiled dep `sorted_nearest` is not always
 pulled by an extras install, breaking `import cptac`. The ptm extra must declare
 `sorted-nearest` explicitly.
+
+The docs half exists because the extras table is duplicated in THREE places -- the
+`[tool.poetry.extras]` block, README.md, and docs_site/getting-started/installation.md --
+and only the first is executable. Three separate hand-fixes to the two prose copies were
+needed in as many sessions, two of them caught only by adversarial review, and a fourth
+drift (psroc/ancestry/ml missing scipy, ptm missing sorted-nearest -- eight wrong cells)
+survived a release. A reader following a wrong table installs an environment that cannot run
+the command the table promises, which is exactly the failure `pip install hvantk[constraint]`
+produced. Deliberately non-Hail so it runs in the default suite.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+# (path, the column holding the dependency list). Both tables are markdown pipe tables whose
+# first column is the extra name in backticks; they differ in column order, so each doc names
+# its own header rather than assuming a position.
+DOC_TABLES = [
+    (ROOT / "README.md", "Pulls in"),
+    (ROOT / "docs_site" / "getting-started" / "installation.md", "Pulls in"),
+]
 
 
 def _load_pyproject() -> dict:
@@ -14,11 +35,104 @@ def _load_pyproject() -> dict:
         import tomllib as toml  # Python >= 3.11
     except ModuleNotFoundError:  # Python 3.10
         import tomli as toml
-    root = Path(__file__).resolve().parents[2]
-    return toml.loads((root / "pyproject.toml").read_text())
+    return toml.loads((ROOT / "pyproject.toml").read_text())
+
+
+def _declared_extras() -> dict[str, set[str]]:
+    return {k: set(v) for k, v in _load_pyproject()["tool"]["poetry"]["extras"].items()}
+
+
+def _parse_doc_table(path: Path, dep_header: str) -> dict[str, set[str]]:
+    """Extras -> dependency set, read from the first markdown table that has `dep_header`.
+
+    Only rows whose first cell is a single backticked token are treated as extras rows, so
+    prose tables elsewhere in the file cannot be picked up by accident.
+    """
+    rows: dict[str, set[str]] = {}
+    header_cols: list[str] | None = None
+    done = False
+    for line in path.read_text().splitlines():
+        if not line.strip().startswith("|"):
+            # The table ENDS at the first non-table line. Without this the parser would run
+            # to end of file and read any later markdown table as more extras rows, using the
+            # extras table's column index -- so a future unrelated table with a backticked
+            # first column would silently overwrite a real row and mask the very drift this
+            # test exists to catch.
+            if header_cols is not None:
+                done = True
+            continue
+        if done:
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if header_cols is None:
+            if dep_header in cells:
+                header_cols = cells
+            continue
+        if set("".join(cells)) <= set("-: "):        # the |---|---| separator
+            continue
+        name = re.fullmatch(r"`([a-z0-9-]+)`", cells[0])
+        if not name:
+            continue
+        deps = cells[header_cols.index(dep_header)]
+        rows[name.group(1)] = {d.strip().strip("`") for d in deps.split(",") if d.strip()}
+    assert header_cols is not None, f"{path.name}: no table with a {dep_header!r} column"
+    return rows
+
+
+def test_parser_stops_at_the_end_of_the_extras_table(tmp_path):
+    """A later table must not be read as more extras rows.
+
+    Regression guard: the first version of this parser never reset on a non-table line, so it
+    consumed the rest of the file. A second table whose first column is a backticked token --
+    an ordinary thing to add to these docs -- would overwrite a real row using the extras
+    table's column index, turning this guard into a source of false passes and false failures.
+    """
+    doc = tmp_path / "doc.md"
+    doc.write_text(
+        "| Extra | Pulls in |\n"
+        "|---|---|\n"
+        "| `viz` | matplotlib |\n"
+        "\n"
+        "Some prose between the tables.\n"
+        "\n"
+        "| Command | Pulls in |\n"
+        "|---|---|\n"
+        "| `viz` | something-else |\n"
+    )
+    assert _parse_doc_table(doc, "Pulls in") == {"viz": {"matplotlib"}}
 
 
 def test_ptm_extra_includes_sorted_nearest():
     poetry = _load_pyproject()["tool"]["poetry"]
     assert "sorted-nearest" in poetry["extras"]["ptm"]
     assert "sorted-nearest" in poetry["dependencies"]
+
+
+def test_every_extra_dependency_is_declared_optional():
+    """An extra naming a package that is not an optional dependency installs nothing."""
+    poetry = _load_pyproject()["tool"]["poetry"]
+    deps = poetry["dependencies"]
+    for extra, packages in poetry["extras"].items():
+        for pkg in packages:
+            assert pkg in deps, f"extra {extra!r} names undeclared dependency {pkg!r}"
+            spec = deps[pkg]
+            assert isinstance(spec, dict) and spec.get("optional") is True, \
+                f"extra {extra!r} names {pkg!r}, which is not optional = true"
+
+
+@pytest.mark.parametrize("path,dep_header", DOC_TABLES, ids=lambda p: getattr(p, "name", p))
+def test_documented_extras_match_pyproject(path: Path, dep_header: str):
+    declared = _declared_extras()
+    documented = _parse_doc_table(path, dep_header)
+
+    missing = sorted(set(declared) - set(documented))
+    assert not missing, f"{path.name}: extras declared but undocumented: {missing}"
+    unknown = sorted(set(documented) - set(declared))
+    assert not unknown, f"{path.name}: extras documented but not declared: {unknown}"
+
+    wrong = {
+        name: {"documented": sorted(documented[name]), "declared": sorted(declared[name])}
+        for name in sorted(declared)
+        if documented[name] != declared[name]
+    }
+    assert not wrong, f"{path.name}: extras table disagrees with pyproject: {wrong}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5935,9 +5935,11 @@ remote = ["fsspec (>=2023.10.0)", "obstore (>=0.5.1)"]
 
 [extras]
 ancestry = ["matplotlib", "scikit-learn", "scipy", "seaborn"]
-constraint = ["matplotlib", "seaborn", "tspex"]
+cohort = ["scipy"]
+constraint = ["matplotlib", "scipy", "seaborn", "tspex"]
 duckdb = ["duckdb"]
-expression = ["scanpy"]
+enrichex = ["matplotlib", "scipy", "seaborn"]
+expression = ["scanpy", "scipy"]
 hgc = ["matplotlib", "seaborn"]
 interactive = ["plotly"]
 ml = ["scikit-learn", "scipy"]
@@ -5948,4 +5950,4 @@ viz = ["matplotlib", "plotly", "seaborn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0.0"
-content-hash = "feac0f9f42756b4ecf0b2d754c1785fcf6889b75d12c3b9f0619f5ddafbd8d72"
+content-hash = "399feafeb18269ff1e3ecabd1bad77ccd0bb574fc5c526883616927b3d13d8ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,14 +64,23 @@ scikit-learn = { version = "^1.4", optional = true }
 # Declared explicitly rather than leaned on as a transitive dep of scikit-learn, because
 # relying on a transitive dependency is how it silently breaks later.
 #
-# NOTE, and it is not fully true that scipy only matters where sklearn does:
-# algorithms/burden/fet.py, algorithms/enrichex/overlap.py and algorithms/ptm/constraint.py
-# all `from scipy...` at MODULE scope without sklearn anywhere nearby, so `hvantk enrichex
-# burden|overlap` and `hvantk ptm constraint` raise ModuleNotFoundError on a base install.
-# That is pre-existing -- scipy was previously not declared here at all, so those paths were
-# already broken without an extra -- and keeping scipy optional does not make it worse. The
-# real fix is either a gating extra for enrichex/ptm or call-time imports with a
-# require_scipy() guard (cf. require_scanpy in algorithms/expression/matrix_utils.py).
+# scipy is NOT only needed where sklearn is. Three modules `from scipy...` at MODULE scope
+# with no sklearn nearby, and they sit on three DIFFERENT commands -- check the call graph
+# before assigning one to an extra, because the obvious mapping is wrong:
+#   algorithms/ptm/constraint.py     -> `hvantk ptm constraint`      -> constraint extra
+#   algorithms/enrichex/overlap.py   -> `hvantk enrichex overlap`    -> enrichex extra
+#   algorithms/burden/fet.py         -> `hvantk cohort burden`       -> cohort extra
+# fet.py is NOT reached by `hvantk enrichex burden`: its only importer is
+# algorithms/burden/pipeline.py, which is imported by tools/cohort/cohort_cli.py alone.
+# (algorithms/enrichex/burden.py imports scipy at CALL time only, so it does not gate import.)
+# Until 2026-08-03 `constraint` omitted scipy, so `pip install hvantk[constraint]` produced a
+# documented extra whose own command still raised ModuleNotFoundError, and enrichex and cohort
+# had no extra at all.
+#
+# A call-time require_scipy() guard (cf. require_scanpy in algorithms/expression/matrix_utils)
+# would additionally turn a BASE install's bare ModuleNotFoundError into a message naming the
+# extra. That is a separate improvement: it changes the error text, not what any extra
+# installs, so it is not needed to make these extras correct.
 scipy = { version = ">=1.8", optional = true }
 matplotlib = { version = "*", optional = true }
 seaborn = { version = "*", optional = true }
@@ -91,10 +100,22 @@ interactive = ["plotly"]
 hgc = ["matplotlib", "seaborn"]
 psroc = ["matplotlib", "plotly", "scikit-learn", "scipy"]
 ptm = ["cptac", "sorted-nearest"]
-constraint = ["tspex", "matplotlib", "seaborn"]
+constraint = ["tspex", "matplotlib", "seaborn", "scipy"]
+# enrichex needs matplotlib as well as scipy: overlap.py imports scipy.stats and
+# plot.py / report.py import matplotlib, all at module scope, and enrichex/__init__ pulls
+# both in unconditionally -- so a scipy-only extra would break the moment `hvantk enrichex`
+# drew anything.
+enrichex = ["scipy", "matplotlib", "seaborn"]
+# cohort covers `hvantk cohort burden`, whose pipeline reaches algorithms/burden/fet.py and
+# its module-scope `from scipy.stats import fisher_exact`. scipy alone: nothing on that path
+# imports matplotlib.
+cohort = ["scipy"]
 ancestry = ["scikit-learn", "matplotlib", "seaborn", "scipy"]
 ml = ["scikit-learn", "scipy"]
-expression = ["scanpy"]
+# scanpy already depends on scipy, so listing it changes no resolution -- but
+# visualization/expression/anndata.py imports scipy.sparse directly, and this file's rule is
+# to declare what is imported rather than inherit it from a transitive edge that can move.
+expression = ["scanpy", "scipy"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## The bug

`scipy` is `optional = true`, so a base install lacks it. Three modules import it at **module scope**, and they sit on three *different* commands — a mapping the previous known-gaps note got wrong, which is why the gap survived two releases:

| Module | Command | Extra |
|---|---|---|
| `algorithms/ptm/constraint.py` | `hvantk ptm constraint` | `constraint` (was missing scipy) |
| `algorithms/enrichex/overlap.py` | `hvantk enrichex overlap` | `enrichex` (**new**) |
| `algorithms/burden/fet.py` | `hvantk cohort burden` | `cohort` (**new**) |

`fet.py` is **not** reached by `hvantk enrichex burden` — its only importer is `algorithms/burden/pipeline.py`, imported by `tools/cohort/cohort_cli.py` alone. (`algorithms/enrichex/burden.py` imports scipy at call time, so it does not gate import.)

Before this change, `pip install hvantk[constraint]` produced a documented extra whose own command still raised `ModuleNotFoundError`, and neither `hvantk enrichex overlap` nor `hvantk cohort burden` had any extra at all.

`enrichex` also carries matplotlib/seaborn because `enrichex/__init__` imports `plot.py`/`report.py` unconditionally. `scipy` was added to `expression` too — a resolution no-op since scanpy already depends on it, but `visualization/expression/anndata.py` imports `scipy.sparse` directly and this project declares what it imports.

Not included: a `require_scipy()` guard. A base install still gives a bare `ModuleNotFoundError` instead of naming the extra. That changes error *text*, not what any extra installs, so it is tracked separately.

## Docs drift, and a guard so it stops recurring

The extras table is duplicated in three prose locations and only `[tool.poetry.extras]` is executable, so the copies had drifted **eight cells** (`psroc`/`ancestry`/`ml` missing scipy, `ptm` missing sorted-nearest) across two releases.

`test_pyproject_extras.py` now parses both markdown tables and fails if either disagrees with `pyproject.toml`, and fails if an extra names a package not declared `optional = true`. Non-Hail, so it runs in the default suite.

`docs_site/guide/hpc-migration.md` is a third copy the guard cannot reach (prose, not a table). It missed the new extras and referenced a **`qtl` extra that has never existed** — an Apptainer build following it would have failed. Corrected, with a pointer that `pyproject.toml` is authoritative.

## Adversarial-review fixes folded in

- **The doc-table parser never reset on a non-table line.** `header_cols = None if header_cols is None else header_cols` is a self-assignment, so it read the rest of the file as more extras rows. A later table with a backticked first column would silently overwrite a real row using the extras table's column index — making this guard accept the very drift it exists to catch. Fixed, with a regression test verified to fail against the old logic.
- **The `cohort` extra.** Review caught that the `fet.py` attribution was wrong and that `hvantk cohort burden` was still uncovered.

## Verification

- **1,429 passed, 11 skipped** (default suite)
- The new guard test fails on the pre-fix tree (exactly the 8 predicted cells) and passes after
- The new parser regression test returns `{'viz': {'something-else'}}` under the old logic — confirmed empirically, not reasoned
- `poetry check --lock` clean; all 12 extras name declared optional deps
- `poetry.lock` regenerated because editing extras changes the content-hash that the `poetry.lock in sync` job checks: **187 packages before and after**, diff is the `[extras]` block and hash only
