### PR TITLE
fix(cli,packaging): make hvantk importable from a pip install, and guard it in CI

### DIFF
--- a/.github/scripts/check_wheel.py
+++ b/.github/scripts/check_wheel.py
@@ -1,0 +1,109 @@
+"""Assert the built wheel ships what it should and nothing else.
+
+Run by the `packaging-smoke` CI job after `poetry build -f wheel`. Nothing else in the
+pipeline builds a wheel, so before this existed the include/exclude globs in pyproject.toml
+were never checked and had silently rotted: the wheel carried 339 files under a tests/
+directory and 43.3 MB of fixtures (a 14.7 MB VDS zip, an 11.4 MB expression-atlas file) in a
+46.2 MB package, while the excludes that were supposed to stop it either named the wrong
+directory (`tests/data` where the skills use `tests/testdata`) or were overridden by a
+broader `include`.
+
+The size ceiling is deliberately generous. It is a tripwire for "someone added a fixture to a
+shipped path", not a byte budget -- a real regression here is an order of magnitude, not a few
+percent.
+"""
+from __future__ import annotations
+
+import glob
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+MAX_UNCOMPRESSED_MB = 10.0
+REPO = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    wheels = glob.glob(str(REPO / "dist" / "*.whl"))
+    if len(wheels) != 1:
+        print(f"FAIL expected exactly one wheel in dist/, found {len(wheels)}: {wheels}")
+        return 1
+    names = zipfile.ZipFile(wheels[0]).infolist()
+    paths = [i.filename for i in names]
+    failures: list[str] = []
+
+    def count(pred) -> int:
+        return sum(1 for p in paths if pred(p))
+
+    # --- things that must NOT ship
+    top_level_tests = count(lambda p: p.startswith("hvantk/tests/"))
+    if top_level_tests:
+        failures.append(f"{top_level_tests} files under hvantk/tests/ (expected 0)")
+
+    test_modules = count(lambda p: re.search(r"/test_[^/]*\.py$", p))
+    if test_modules:
+        failures.append(f"{test_modules} test_*.py modules (expected 0)")
+
+    # Drift fingerprints are the deliberate exception: `hvantk drift` compares a live probe
+    # against them at runtime, so they belong in the wheel. Multi-dataset providers suffix the
+    # name per dataset (drift_fingerprint_samples.json), hence the prefix match rather than an
+    # exact one.
+    def _is_fingerprint(p: str) -> bool:
+        return re.search(r"/drift_fingerprint[^/]*\.json$", p) is not None
+
+    fixtures = count(
+        lambda p: "/tests/" in p and not (_is_fingerprint(p) or p.endswith(".gitkeep"))
+    )
+    if fixtures:
+        failures.append(f"{fixtures} test fixtures under a tests/ dir (only fingerprints ship)")
+
+    mb = sum(i.file_size for i in names) / 1e6
+    if mb > MAX_UNCOMPRESSED_MB:
+        failures.append(f"wheel is {mb:.1f} MB uncompressed, ceiling is {MAX_UNCOMPRESSED_MB}")
+
+    # --- things that MUST ship. Counted against the tree, so adding a provider needs no edit
+    # here; a packaging glob that silently drops one is what this catches.
+    # Manifests alone are not enough. `hvantk plugins list` -- the CI job's other check --
+    # only reads YAML (loader Pass 1, no callables imported), so a packaging glob that dropped
+    # every builder.py would still print the right provider count and leave the job green.
+    # The skills-module count is what actually covers that, and the fingerprints are the
+    # runtime data `hvantk drift` compares against.
+    # `keep_disk` filters the TREE side so both sides count the same population. It matters for
+    # skills modules (test_*.py are excluded from the wheel on purpose, so counting them on
+    # disk would fail every run) and must NOT be applied to fingerprints, which legitimately
+    # live under tests/.
+    not_a_test = lambda p: "/tests/" not in Path(p).as_posix()  # noqa: E731
+    everything = lambda p: True                                  # noqa: E731
+
+    for label, pattern, wheel_pred, keep_disk in (
+        ("plugin.yaml manifests", "hvantk/skills/**/plugin.yaml",
+         lambda p: p.endswith("plugin.yaml"), everything),
+        ("SKILL.md files", "hvantk/skills/**/SKILL.md",
+         lambda p: p.endswith("SKILL.md"), everything),
+        ("catalog datasets.json", "hvantk/skills/**/catalog/*.json",
+         lambda p: "/catalog/" in p and p.endswith(".json"), everything),
+        ("drift fingerprints", "hvantk/skills/**/tests/drift_fingerprint*.json",
+         _is_fingerprint, everything),
+        ("skills modules", "hvantk/skills/**/*.py",
+         lambda p: p.startswith("hvantk/skills/") and p.endswith(".py"), not_a_test),
+    ):
+        on_disk = len([p for p in glob.glob(str(REPO / pattern), recursive=True)
+                       if keep_disk(p)])
+        in_wheel = count(wheel_pred)
+        if on_disk != in_wheel:
+            failures.append(f"{label}: {on_disk} in tree but {in_wheel} in wheel")
+
+    if not count(lambda p: p.endswith("entry_points.txt")):
+        failures.append("no entry_points.txt -- console script and provider plugins are unregistered")
+
+    for f in failures:
+        print(f"FAIL {f}")
+    if failures:
+        return 1
+    print(f"OK wheel is {mb:.2f} MB uncompressed, {len(paths)} files, no test payload")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,6 +2,12 @@ name: Python Package using Conda
 
 on: [push]
 
+# Every job here only reads the repo -- builds, installs, runs tests. The default token grants
+# write scopes none of them need. Flagged in review on #249 and not applied at the time; set
+# now at workflow level so new jobs inherit it rather than each having to remember.
+permissions:
+  contents: read
+
 jobs:
   # Runs in seconds and needs no environment, so it sits in the workflow that triggers on
   # every push rather than only on main-targeted PRs. Its absence is why poetry.lock drifted
@@ -14,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       # Pinned to the 2.x line rather than latest: pyproject.toml still uses the
@@ -26,6 +32,60 @@ jobs:
         run: python -m pip install --upgrade pip "poetry>=2.0,<3.0"
       - name: Check pyproject.toml is valid and poetry.lock matches it
         run: poetry check --lock
+
+  # Nothing in CI installed the package, so `pytest` always imported hvantk from the checkout
+  # directory and three things were never exercised: the `hvantk` console script, the
+  # [tool.poetry.plugins."hvantk.providers"] entry points, and the include/exclude packaging
+  # globs. All three were broken and CI was green throughout:
+  #   - `hvantk --help` raised ModuleNotFoundError on a base install (the CLI eagerly imported
+  #     matplotlib, which is optional),
+  #   - the wheel shipped 43.3 MB of test data in a 46.2 MB wheel, because `hvantk/tests/**`
+  #     was absent from `exclude` and the skills excludes were overridden by an `include`.
+  # This job is the guard: it builds the wheel, checks its contents, installs it into a clean
+  # environment with NO extras, and runs the CLI from a directory where the checkout is not
+  # importable -- so it tests the installed copy rather than the source tree.
+  packaging-smoke:
+    name: Installed package smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      # hail is a hard dependency and needs Java 11 to import; the CLI imports it eagerly.
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip "poetry>=2.0,<3.0"
+          poetry build -f wheel
+      - name: Check wheel contents
+        run: python .github/scripts/check_wheel.py
+      - name: Install the wheel into a clean environment, without extras
+        run: |
+          python -m venv /tmp/venv
+          /tmp/venv/bin/pip install --upgrade pip
+          /tmp/venv/bin/pip install dist/*.whl
+      # `working-directory` is load-bearing: run this from the repo root and Python would
+      # import ./hvantk from the checkout, which is exactly what this job exists to avoid.
+      - name: Smoke-check the installed CLI
+        working-directory: /tmp
+        run: |
+          /tmp/venv/bin/python -c "import hvantk, os; p = os.path.dirname(hvantk.__file__); assert 'site-packages' in p, p; print('importing installed copy:', p)"
+          /tmp/venv/bin/hvantk --help
+          /tmp/venv/bin/hvantk plugins list
+      # A packaging glob that drops manifests would still let `plugins list` exit 0 with a
+      # short list, so assert the count instead of just the exit code.
+      - name: Every plugin manifest survived packaging
+        run: |
+          expected=$(find hvantk/skills -name plugin.yaml | wc -l | tr -d ' ')
+          actual=$(cd /tmp && /tmp/venv/bin/hvantk plugins list | tail -n +2 | grep -c '[^[:space:]]')
+          echo "manifests in tree: $expected / providers from installed copy: $actual"
+          test "$expected" = "$actual"
 
   build-linux:
     runs-on: ubuntu-latest
@@ -39,7 +99,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libopenblas-dev
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Add conda to system path
@@ -83,7 +143,7 @@ jobs:
           distribution: temurin
           java-version: "11"
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Add conda to system path
@@ -104,3 +164,42 @@ jobs:
                  hvantk/tests/test_hail_helpers.py \
                  hvantk/skills \
                  -m hail -rA
+
+  # hvantk/tests/hgc/ ran in NO CI job: pytest.ini deselects `hail`, and the job above is
+  # path-scoped to the contract tests. So test_convert_vds_to_mt -- the only end-to-end
+  # exercise of the `adj` code ported out of the gnomad dependency in #252 -- ran only under a
+  # manual `pytest -m hail`.
+  #
+  # Deliberately a SEPARATE job rather than more paths on plugin-contract. Appending would
+  # push that job from ~6 to ~12 min and delay the contract signal behind unrelated HGC work;
+  # as its own job it runs concurrently, so wall-clock to first failure is unchanged.
+  hgc-hail:
+    name: HGC pipeline (hail)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Add conda to system path
+        run: |
+          echo $CONDA/bin >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          conda env update --file environment.yml --name base
+      - name: Install test dependencies
+        run: |
+          python -m pip install pytest requests-mock
+      - name: Run HGC tests
+        run: |
+          pytest hvantk/tests/hgc -m hail -rA

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,11 +3,19 @@
 
 name: Python package
 
+# `dev` is included deliberately. With main-only triggers the 3.10/3.11/3.12 matrix ran for
+# the first time at the release gate, so a version incompatibility introduced on a dev PR was
+# discovered with a whole release to bisect instead of a single commit. The cost is three jobs
+# per dev PR; the alternative is finding out later, on a bigger diff.
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
+
+# lint + test only; no write scopes needed
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -20,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,39 @@
   move. A base install still raises a bare `ModuleNotFoundError` rather than a message
   naming the extra; a `require_scipy()` guard (cf. `require_scanpy`) would fix the *text*,
   and is tracked separately because it changes no extra's contents.
+- **`hvantk` was unusable from a `pip install`.** The console script imported
+  `hvantk.tools.enrichex` at module scope, which ran `algorithms/enrichex/__init__.py`,
+  which eagerly imported `enrichex/plot.py`, `enrichex/report.py` and
+  `visualization/base.py` — all three import `matplotlib` at module scope. matplotlib is
+  optional, so on a base install **every** command including `hvantk --help` raised
+  `ModuleNotFoundError`. Those three imports are now resolved on attribute access (PEP 562
+  `__getattr__`), so the package imports without matplotlib and the CLI runs. The eight
+  plotting/reporting names stay in `__all__` and stay importable; touching one without
+  matplotlib now raises an `ImportError` naming the `enrichex` extra, matching
+  `require_scanpy` and `_require_matplotlib`. No plotting behaviour changed — the enrichex
+  CLIs already imported `generate_report` inside the functions that use it.
+- **The wheel shipped 43.3 MB of test data.** `hvantk/tests/**` was absent from `exclude`
+  (190 files, including a 14.7 MB VDS zip and an 11.4 MB expression-atlas fixture); the
+  skills excludes were overridden by `include = "hvantk/skills/**/*.py"`, since a path named
+  by `include` wins; and the excludes named `tests/data/**` where the skills actually use
+  `tests/testdata/**`. Fixed all three: the wheel goes from **46.2 MB to 2.86 MB**
+  uncompressed (28 MB to 897 KB on disk) with every manifest, skills module, catalog and
+  drift fingerprint intact.
+- **CI now installs the package.** New `packaging-smoke` job builds the wheel, checks its
+  contents with `.github/scripts/check_wheel.py`, installs it into a clean environment with
+  no extras, and runs `hvantk --help` / `hvantk plugins list` from a directory where the
+  checkout is not importable — so the console script, the entry-point registrations and the
+  packaging globs are exercised against the installed copy. It also asserts the provider
+  count matches the tree, since a dropped manifest would otherwise still exit 0. Both bugs
+  above were found by writing this job.
+- **`hvantk/tests/hgc/` now runs in CI** as a new `hgc-hail` job — separate from
+  `Plugin contract (hail)` rather than appended to it, so the contract signal is not delayed
+  behind ~6 min of unrelated HGC work. This is the first automatic run of
+  `test_convert_vds_to_mt`, the end-to-end exercise of the `adj` code ported in #252.
+- **The Python version matrix now runs on `dev` PRs**, not only `main`, so an incompatibility
+  is caught on one commit instead of at the release gate with a whole release to bisect.
+  `actions/setup-python` moved v3 → v5 and both workflows now declare
+  `permissions: contents: read` (both raised in review on #249).
 - The extras table is now guarded by a test. It is duplicated in three places — the
   `[tool.poetry.extras]` block, `README.md` and `docs_site/getting-started/installation.md`
   — and only the first is executable, so the prose copies had drifted eight cells
@@ -111,17 +144,6 @@
   (`default`, `adult-ctx`, `dev-ctx`) already have populated snapshot dirs.
 - The package version has never been bumped from `0.1.0`, so releases to `main` are not
   distinguishable by version.
-- No CI job installs the package (`pip install .` / `poetry install`), so `pytest` imports
-  `hvantk` from the checkout directory. Packaging — the `include`/`exclude` globs, the
-  console-script entry point, and the `[tool.poetry.plugins."hvantk.providers"]`
-  entry-point registrations — is therefore never exercised in CI, and the plugin loader's
-  entry-point discovery path is only ever tested via its filesystem fallback. (The lock
-  itself *is* now validated on every push — see the `poetry.lock in sync` job.)
-- The `build` and `build (3.10/3.11/3.12)` jobs run only on pull requests targeting
-  `main`, so a Python-version incompatibility introduced on a `dev` PR is not caught until
-  the release gate, with the whole release to bisect rather than one commit.
-- No CI job runs `hvantk/tests/hgc/`. `hail`-marked tests are deselected by `pytest.ini`'s
-  `addopts`, and the one hail-enabled job (`Plugin contract (hail)`) is path-scoped to the
-  plugin-contract tests. So the HGC integration suite — including `test_convert_vds_to_mt`,
-  which is the end-to-end exercise of `adj` — runs only when someone invokes `pytest -m hail`
-  locally. Unskipping that test made it *runnable*, not *automatically run*.
+  (The three CI gaps previously listed here — no install job, the version matrix running
+  only on `main`, and `hvantk/tests/hgc/` running in no job — are resolved; see the
+  packaging and CI entries under Changed.)

--- a/hvantk/algorithms/enrichex/__init__.py
+++ b/hvantk/algorithms/enrichex/__init__.py
@@ -79,15 +79,6 @@ from hvantk.core.utils.gene_sets import (
     load_gene_sets_from_dict,
     load_marker_genes,
 )
-from hvantk.algorithms.visualization.base import encode_figure_to_base64
-from hvantk.algorithms.enrichex.plot import (
-    plot_burden_forest,
-    plot_burden_volcano,
-    plot_celltype_burden_heatmap,
-    plot_celltype_forest,
-    plot_enrichment_barplot,
-    plot_enrichment_dotplot,
-)
 from hvantk.algorithms.enrichex.overlap import (
     OverlapResult,
     compute_overlap_enrichment,
@@ -98,8 +89,65 @@ from hvantk.algorithms.enrichex.pipeline import (
     BurdenPipeline,
     BurdenRunResult,
 )
-from hvantk.algorithms.enrichex.report import generate_report
 from hvantk.algorithms.enrichex.simulation import check_type_i_error
+
+# Plotting and reporting are resolved on ATTRIBUTE ACCESS, not at package import (PEP 562).
+#
+# They used to be plain `from ... import` lines here, and that broke `hvantk` outright: the
+# CLI imports hvantk.algorithms.enrichex.constants, which runs this module, which pulled in
+# enrichex.plot / enrichex.report / visualization.base -- all three import matplotlib at
+# module scope. matplotlib is optional, so on a base install `pip install hvantk` produced a
+# console script where even `hvantk --help` raised ModuleNotFoundError. Every command paid
+# for plotting whether or not it plotted.
+#
+# The names below stay importable and stay in __all__, so this is not an API change; the
+# import simply happens on first use. The CLI never trips it -- overlap_cli and burden_cli
+# already import `generate_report` inside the functions that need it -- so a base install
+# now runs, and the `enrichex` extra (which carries matplotlib) is what a plotting caller
+# installs.
+_LAZY = {
+    "encode_figure_to_base64": "hvantk.algorithms.visualization.base",
+    "generate_report": "hvantk.algorithms.enrichex.report",
+    "plot_burden_forest": "hvantk.algorithms.enrichex.plot",
+    "plot_burden_volcano": "hvantk.algorithms.enrichex.plot",
+    "plot_celltype_burden_heatmap": "hvantk.algorithms.enrichex.plot",
+    "plot_celltype_forest": "hvantk.algorithms.enrichex.plot",
+    "plot_enrichment_barplot": "hvantk.algorithms.enrichex.plot",
+    "plot_enrichment_dotplot": "hvantk.algorithms.enrichex.plot",
+}
+
+
+_PLOTTING_HINT = (
+    "matplotlib is required for EnrichEx plotting and reporting, and is not part of the "
+    "base install. Install the 'enrichex' extra:\n"
+    "    pip install 'hvantk[enrichex]'\n"
+    "    poetry install --extras enrichex"
+)
+
+
+def __getattr__(name: str):
+    """Resolve the plotting/reporting exports on first access."""
+    module = _LAZY.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    try:
+        value = getattr(importlib.import_module(module), name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - needs matplotlib absent
+        # Same contract as require_scanpy (algorithms/expression/matrix_utils.py) and
+        # _require_matplotlib (algorithms/qtlcascade/plot.py): name the extra rather than
+        # leave the caller a bare ModuleNotFoundError. Deferring the import must not also
+        # degrade the message -- that was the review finding on the scanpy extra in #248.
+        if exc.name and exc.name.split(".")[0] in {"matplotlib", "seaborn"}:
+            raise ImportError(_PLOTTING_HINT) from exc
+        raise
+    globals()[name] = value  # cache, so the import cost is paid once
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY))
 
 try:
     from hvantk.algorithms.enrichex.simulation import generate_synthetic_burden_cohort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,19 +16,37 @@ keywords = [
 ]
 include = [
   { path = "hvantk/skills/**/plugin.yaml", format = ["sdist", "wheel"] },
-  { path = "hvantk/skills/**/*.py", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/SKILL.md", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/catalog/*.json", format = ["sdist", "wheel"] },
-  { path = "hvantk/skills/**/tests/drift_fingerprint.json", format = ["sdist", "wheel"] },
+  # multi-dataset providers suffix this per dataset (drift_fingerprint_samples.json)
+  { path = "hvantk/skills/**/tests/drift_fingerprint*.json", format = ["sdist", "wheel"] },
 ]
+# These excludes were previously defeated and shipped 43.3 MB of test data in a 46.2 MB
+# wheel -- 339 files under a tests/ dir, including a 14.7 MB VDS zip and an 11.4 MB
+# expression-atlas fixture. Two causes, both fixed here:
+#   1. `hvantk/tests/**` was never listed at all (190 of those files), so the top-level test
+#      suite and its testdata/ shipped to every user in full.
+#   2. The skills excludes were overridden by the explicit `include` of
+#      "hvantk/skills/**/*.py" above: a path named by `include` wins, so test_*.py under a
+#      skill came back in regardless of being excluded. The include is now narrowed to the
+#      non-.py data files it exists for -- ordinary package modules under hvantk/ need no
+#      include, since `packages` already carries them.
+# Nothing in CI built a wheel, so none of this was visible. The packaging-smoke job added in
+# this change asserts wheel hygiene so it cannot regress silently again.
 exclude = [
+    "hvantk/tests/**",
     "hvantk/skills/**/tests/test_*.py",
     "hvantk/skills/**/tests/conftest.py",
     "hvantk/skills/**/tests/__init__.py",
     "hvantk/skills/**/tests/data/**",
+    "hvantk/skills/**/tests/testdata/**",
     "hvantk/skills/**/tests/snapshots/**",
     "hvantk/skills/**/tests/fixtures/**",
 ]
+# `testdata` (above) was the name actually used by the skills; the pre-existing list named
+# only data/, snapshots/ and fixtures/, so per-skill fixture VCF/TSV/parquet files shipped.
+# drift_fingerprint.json stays -- it is included on purpose, being what `hvantk drift`
+# compares a live probe against.
 
 [tool.poetry.dependencies]
 python = ">=3.10.0,<4.0.0"
@@ -101,10 +119,12 @@ hgc = ["matplotlib", "seaborn"]
 psroc = ["matplotlib", "plotly", "scikit-learn", "scipy"]
 ptm = ["cptac", "sorted-nearest"]
 constraint = ["tspex", "matplotlib", "seaborn", "scipy"]
-# enrichex needs matplotlib as well as scipy: overlap.py imports scipy.stats and
-# plot.py / report.py import matplotlib, all at module scope, and enrichex/__init__ pulls
-# both in unconditionally -- so a scipy-only extra would break the moment `hvantk enrichex`
-# drew anything.
+# enrichex needs matplotlib as well as scipy. scipy is eager -- overlap.py imports
+# scipy.stats at module scope, so `hvantk enrichex overlap` needs it to import at all.
+# matplotlib is no longer eager: enrichex/__init__ resolves plot.py / report.py through a
+# PEP 562 __getattr__, so a base install can run the CLI. It is still in this extra because
+# the plotting and --generate-report paths need it at call time, and accessing a plotting
+# name without it raises an ImportError naming this extra.
 enrichex = ["scipy", "matplotlib", "seaborn"]
 # cohort covers `hvantk cohort burden`, whose pipeline reaches algorithms/burden/fet.py and
 # its module-scope `from scipy.stats import fisher_exact`. scipy alone: nothing on that path


### PR DESCRIPTION
Tier 2 of the packaging/CI hardening plan. Adding the install job the release checks were missing turned up two bugs it was designed to catch — both live on `dev`, both invisible to every existing job because nothing in CI has ever installed the package.

## 1. `hvantk` did not run from a pip install

The console script imports `hvantk.tools.enrichex` at module scope, which runs `algorithms/enrichex/__init__.py`, which eagerly imported `enrichex/plot.py`, `enrichex/report.py` and `visualization/base.py`. All three import matplotlib at module scope, and matplotlib is optional — so on a base install **every** command, including `hvantk --help`, raised `ModuleNotFoundError`.

```
$ pip install hvantk && hvantk --help
  ...
  File ".../hvantk/algorithms/visualization/base.py", line 14
    import matplotlib.pyplot as plt
ModuleNotFoundError: No module named 'matplotlib'
```

Those imports now resolve on attribute access (PEP 562 `__getattr__`). The eight plotting/reporting names stay in `__all__` and stay importable — the import just happens on first use. Touching one without matplotlib raises an `ImportError` naming the `enrichex` extra, matching `require_scanpy` and `_require_matplotlib`; deferring an import must not also degrade the message, which was the review finding on the scanpy extra in #248.

No plotting behaviour changes: `overlap_cli` and `burden_cli` already imported `generate_report` inside the functions that use it.

## 2. The wheel shipped 43.3 MB of test data in a 46.2 MB package

Three independent causes:

- `hvantk/tests/**` was never in `exclude` at all — 190 files, including a 14.7 MB VDS zip and an 11.4 MB expression-atlas fixture
- the skills excludes were overridden by `include = "hvantk/skills/**/*.py"`, because a path named by `include` wins
- the excludes named `tests/data/**` where the skills actually use `tests/testdata/**`

| | before | after |
|---|---|---|
| uncompressed | 46.2 MB | **2.86 MB** |
| on disk | 28 MB | **897 KB** |
| files under `tests/` | 339 | 18 (fingerprints only) |

Every manifest, skills module, catalog file and drift fingerprint verified still present. `include` also widened to `drift_fingerprint*.json` — multi-dataset providers suffix it per dataset (`onek-genomes` ships `_samples` and `_variants`).

## CI

- **`packaging-smoke`** — builds the wheel, checks contents via `.github/scripts/check_wheel.py`, installs into a clean env with **no extras**, and runs `hvantk --help` / `plugins list` from `/tmp` so the checkout is not importable (asserted via `site-packages` in the module path). Compares the provider count against the tree, since a dropped manifest would still exit 0.
- **`check_wheel.py`** asserts both directions: nothing from `hvantk/tests`, no `test_*.py`, no fixtures, under a 10 MB ceiling; and manifests / SKILL.md / catalog / fingerprints / skills modules all match the tree. The skills-module count matters because `plugins list` only reads YAML (loader Pass 1, no callables imported), so a glob dropping every `builder.py` would still print the right count and stay green.
- **`hgc-hail`** — a *separate* job, not more paths on `plugin-contract`. Appending would take that job from ~6 to ~12 min and delay the contract signal behind unrelated HGC work; concurrent, wall-clock to first failure is unchanged. First automatic run of `test_convert_vds_to_mt`, the end-to-end exercise of the `adj` code ported in #252.
- **Version matrix on `dev` PRs** — catches an incompatibility on one commit instead of at the release gate with a whole release to bisect. Cost: three extra jobs per dev PR.
- **`actions/setup-python` v3 → v5** and `permissions: contents: read` on both workflows. Both raised in review on #249 and never applied; without this the change would have propagated v3 into two more jobs.

Three "Known gaps" bullets in CHANGELOG.md are resolved here and replaced with a pointer rather than left describing fixed problems.

## Adversarial-review fixes folded in

- `check_wheel.py` asserted only that stray fixtures must *not* ship, never that fingerprints and skills modules *must* — the one packaged-data category the guard did not guard. Added, with the tree-side count filtered so both sides count the same population.
- The `enrichex` extra comment in `pyproject.toml`, written one commit earlier in #254, claimed `enrichex/__init__` "pulls both in unconditionally". This change makes that false; rewritten.
- The `__getattr__` raised a bare `ModuleNotFoundError`, inconsistent with the two existing `require_*` guards. Now raises `ImportError` naming the extra.

## Verification

- **1,429 passed, 11 skipped** — unchanged from baseline
- `check_wheel.py` passes on the real wheel **and fails when a manifest is removed from it** (negative control: `21 in tree but 20 in wheel`)
- `hvantk --help` and `plugins list` exit 0 on a genuinely matplotlib-free install, reporting **21/21 providers**
- Lazy names resolve with matplotlib present; without it they raise the named-extra `ImportError`
- All five workflow files parse

## Scope note

This is wider than "add a CI job". The CLI fix and the packaging fix are here because the job goes red without them — landing the job alone would mean knowingly merging a failing check. Reviewers may prefer the CLI import change reviewed on its own; happy to split if so.
