### PR TITLE
chore(packaging): migrate pyproject to PEP 621, bump to 0.2.0, unpin poetry

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -23,19 +23,23 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      # Pinned to the 2.x line rather than latest: pyproject.toml still uses the
-      # `[tool.poetry.*]` spelling of keywords/urls/plugins/extras/scripts, which 2.x
-      # reports as deprecation warnings (exit 0). A future major is entitled to promote
-      # those to errors, which would break this gate on someone else's release rather
-      # than on a change of ours.
+      # Unpinned again as of the PEP 621 migration. The `<3.0` ceiling was defensive: with
+      # the `[tool.poetry.*]` spelling of name/version/description/authors/license/readme/
+      # keywords/urls/plugins/extras/scripts, `poetry check` emitted 11 deprecation warnings,
+      # and a future major promoting those to errors would have broken this gate on someone
+      # else's release rather than on a change of ours. All eleven are gone.
+      # This does NOT make the job immune to a poetry major: [tool.poetry] still carries
+      # include/exclude and the dev dependency group, which are poetry-specific and could
+      # change again. What it removes is the specific, already-announced deprecation that
+      # the ceiling was put up for. Re-pin if a future major actually breaks this.
       - name: Install poetry
-        run: python -m pip install --upgrade pip "poetry>=2.0,<3.0"
+        run: python -m pip install --upgrade pip poetry
       - name: Check pyproject.toml is valid and poetry.lock matches it
         run: poetry check --lock
 
   # Nothing in CI installed the package, so `pytest` always imported hvantk from the checkout
   # directory and three things were never exercised: the `hvantk` console script, the
-  # [tool.poetry.plugins."hvantk.providers"] entry points, and the include/exclude packaging
+  # [project.entry-points."hvantk.providers"] entry points, and the include/exclude packaging
   # globs. All three were broken and CI was green throughout:
   #   - `hvantk --help` raised ModuleNotFoundError on a base install (the CLI eagerly imported
   #     matplotlib, which is optional),
@@ -61,7 +65,8 @@ jobs:
           java-version: "11"
       - name: Build the wheel
         run: |
-          python -m pip install --upgrade pip "poetry>=2.0,<3.0"
+          # >=2.0 is a real floor, not caution: PEP 621 [project] metadata needs poetry-core 2.x
+          python -m pip install --upgrade pip "poetry>=2.0"
           poetry build -f wheel
       - name: Check wheel contents
         run: python .github/scripts/check_wheel.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@
 
 ### Changed
 
+- **Version bumped to `0.2.0`, and `pyproject.toml` migrated to PEP 621 `[project]`.** The
+  package shipped to `main` twice at `0.1.0`, so releases were not distinguishable by
+  version. Separately, `name`, `version`, `description`, `authors`, `license`, `readme`,
+  `keywords`, `urls`, `plugins`, `extras` and `scripts` all used the deprecated
+  `[tool.poetry.*]` spelling — 11 warnings on every `poetry check`. They now live under
+  `[project]`, `[project.optional-dependencies]`, `[project.entry-points]`,
+  `[project.scripts]` and `[project.urls]`; only genuinely Poetry-specific keys
+  (`include`/`exclude`, dependency groups) remain under `[tool.poetry]`.
+  **The migration is resolution-neutral**: the lock resolves to the same 187 packages,
+  name-for-name and version-for-version, before and after. Poetry's caret shorthand is
+  spelled out as the PEP 508 equivalent it always meant (`^8.1.3` → `>=8.1.3,<9.0.0`), not
+  re-pinned. With nothing deprecated left, the defensive `poetry>=2.0,<3.0` pin in the
+  `poetry.lock in sync` CI job is unpinned again.
+  One consequence is new: PEP 621 puts the full specifier in each extra, so `scipy>=1.8`
+  is written six times and `scikit-learn>=1.4,<2.0` three times, and one could be re-pinned
+  with the others left behind — resolving differently depending on which extra a user
+  installs. `test_pyproject_extras.py` now asserts every extra spells a shared package
+  identically, alongside a check that no extra re-declares a base dependency.
 - **`gnomad` is no longer a dependency.** hvantk used exactly one function from it,
   `annotate_adj`, which is ~15 lines of Hail expression with no gnomAD data behind it.
   It is now ported into `hvantk/algorithms/hgc/adj.py` (gnomad_methods is MIT; the port
@@ -142,8 +160,8 @@
   `cptac:expression`, and `cptac:phospho`. The first hail-enabled CI run with
   `--regenerate-snapshots` will bootstrap them. All `ucsc-cellbrowser` variants
   (`default`, `adult-ctx`, `dev-ctx`) already have populated snapshot dirs.
-- The package version has never been bumped from `0.1.0`, so releases to `main` are not
-  distinguishable by version.
+- (Resolved: version bumped to 0.2.0 — see Changed.) Releases are still not git-tagged, so
+  a release is identifiable by version but not by a tag.
   (The three CI gaps previously listed here — no install job, the version matrix running
   only on `main`, and `hvantk/tests/hgc/` running in no job — are resolved; see the
   packaging and CI entries under Changed.)

--- a/docs_site/guide/hpc-migration.md
+++ b/docs_site/guide/hpc-migration.md
@@ -147,7 +147,8 @@ From: python:3.10-slim-bookworm
         zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libdeflate-dev \
         libopenblas-dev liblapack-dev liblz4-dev libhdf5-dev git
     # --- hvantk via Poetry, from the committed lock (reproducible) ---
-    pip install --no-cache-dir "poetry==1.8.*"
+    # >=2.0: pyproject.toml uses PEP 621 [project] metadata, which poetry 1.8 cannot read.
+    pip install --no-cache-dir "poetry>=2.0"
     cd /opt/hvantk
     poetry config virtualenvs.create false
     # install the locked deps + the extras you actually run (trim as needed):
@@ -179,8 +180,9 @@ From: python:3.10-slim-bookworm
 > Trim `--extras` to what you run. The core install omits scikit-learn / scipy / viz /
 > cptac / tspex / duckdb / scanpy — they live behind extras (`hgc`, `ptm`,
 > `ancestry`, `psroc`, `constraint`, `enrichex`, `cohort`, `ml`, `viz`, `duckdb`,
-> `interactive`, `expression`). The authoritative list is `[tool.poetry.extras]` in
-> `pyproject.toml`; this one is prose and is not machine-checked.
+> `interactive`, `expression`). The authoritative list is
+> `[project.optional-dependencies]` in `pyproject.toml`; this one is prose and is not
+> machine-checked.
 > `pyBigWig` is **not** a hvantk dependency — include it only for experiments that
 > query bigWig tracks. Genotype adjustment needs **no** extra: `annotate_adj` is
 > ported in-tree, so `gnomad` is no longer a dependency at all.

--- a/hvantk/tests/test_plugin_loader.py
+++ b/hvantk/tests/test_plugin_loader.py
@@ -83,7 +83,7 @@ def test_loading_same_directory_twice_is_idempotent():
 
     The skills-root scan and the entry-point scan can both surface the same
     in-tree plugin once it is listed in pyproject.toml's
-    `[tool.poetry.plugins."hvantk.providers"]` table. The loader must dedupe
+    `[project.entry-points."hvantk.providers"]` table. The loader must dedupe
     so this discovery overlap does not crash every CLI invocation.
     """
     reg = PluginRegistry()

--- a/hvantk/tests/test_pyproject_extras.py
+++ b/hvantk/tests/test_pyproject_extras.py
@@ -5,7 +5,8 @@ pulled by an extras install, breaking `import cptac`. The ptm extra must declare
 `sorted-nearest` explicitly.
 
 The docs half exists because the extras table is duplicated in THREE places -- the
-`[tool.poetry.extras]` block, README.md, and docs_site/getting-started/installation.md --
+`[project.optional-dependencies]` table, README.md, and
+docs_site/getting-started/installation.md --
 and only the first is executable. Three separate hand-fixes to the two prose copies were
 needed in as many sessions, two of them caught only by adversarial review, and a fourth
 drift (psroc/ancestry/ml missing scipy, ptm missing sorted-nearest -- eight wrong cells)
@@ -38,8 +39,20 @@ def _load_pyproject() -> dict:
     return toml.loads((ROOT / "pyproject.toml").read_text())
 
 
+def _optional_dependencies() -> dict[str, list[str]]:
+    """Extras as PEP 621 declares them: name -> list of full requirement specifiers."""
+    return _load_pyproject()["project"]["optional-dependencies"]
+
+
+def _requirement_name(spec: str) -> str:
+    """`scikit-learn>=1.4,<2.0` -> `scikit-learn`. Bare names pass through unchanged."""
+    return re.split(r"[<>=!~;@\[\s]", spec, maxsplit=1)[0].strip()
+
+
 def _declared_extras() -> dict[str, set[str]]:
-    return {k: set(v) for k, v in _load_pyproject()["tool"]["poetry"]["extras"].items()}
+    """Extras as bare package names, for comparison against the prose tables."""
+    return {k: {_requirement_name(s) for s in v}
+            for k, v in _optional_dependencies().items()}
 
 
 def _parse_doc_table(path: Path, dep_header: str) -> dict[str, set[str]]:
@@ -103,21 +116,31 @@ def test_parser_stops_at_the_end_of_the_extras_table(tmp_path):
 
 
 def test_ptm_extra_includes_sorted_nearest():
-    poetry = _load_pyproject()["tool"]["poetry"]
-    assert "sorted-nearest" in poetry["extras"]["ptm"]
-    assert "sorted-nearest" in poetry["dependencies"]
+    assert "sorted-nearest" in _declared_extras()["ptm"]
 
 
-def test_every_extra_dependency_is_declared_optional():
-    """An extra naming a package that is not an optional dependency installs nothing."""
-    poetry = _load_pyproject()["tool"]["poetry"]
-    deps = poetry["dependencies"]
-    for extra, packages in poetry["extras"].items():
-        for pkg in packages:
-            assert pkg in deps, f"extra {extra!r} names undeclared dependency {pkg!r}"
-            spec = deps[pkg]
-            assert isinstance(spec, dict) and spec.get("optional") is True, \
-                f"extra {extra!r} names {pkg!r}, which is not optional = true"
+def test_no_extra_duplicates_a_base_dependency():
+    """A package in [project.dependencies] is always installed; gating it behind an extra
+    would advertise a choice that does not exist."""
+    base = {_requirement_name(s) for s in _load_pyproject()["project"]["dependencies"]}
+    for extra, packages in _declared_extras().items():
+        overlap = sorted(packages & base)
+        assert not overlap, f"extra {extra!r} re-declares base dependencies {overlap}"
+
+
+def test_extras_agree_on_every_shared_constraint():
+    """PEP 621 puts the full specifier in each extra, so `scipy>=1.8` is written six times
+    and `scikit-learn>=1.4,<2.0` three times. Nothing stops one from being re-pinned and the
+    rest left behind -- an inconsistency that would resolve differently depending on which
+    extra a user installed. This is the drift the old [tool.poetry.dependencies] split could
+    not have, and it arrived with the migration, so it is guarded here."""
+    seen: dict[str, dict[str, str]] = {}
+    for extra, specs in _optional_dependencies().items():
+        for spec in specs:
+            seen.setdefault(_requirement_name(spec), {})[extra] = spec
+    for pkg, by_extra in sorted(seen.items()):
+        distinct = set(by_extra.values())
+        assert len(distinct) == 1, f"{pkg} is spelled inconsistently across extras: {by_extra}"
 
 
 @pytest.mark.parametrize("path,dep_header", DOC_TABLES, ids=lambda p: getattr(p, "name", p))

--- a/poetry.lock
+++ b/poetry.lock
@@ -3352,7 +3352,7 @@ description = "A Python package for describing statistical models and for buildi
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"expression\" or extra == \"ptm\""
+markers = "extra == \"ptm\" or extra == \"expression\""
 files = [
     {file = "patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a"},
     {file = "patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0"},
@@ -5259,7 +5259,7 @@ description = "Statistical computations and models for Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"expression\" or extra == \"ptm\""
+markers = "extra == \"ptm\" or extra == \"expression\""
 files = [
     {file = "statsmodels-0.14.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9fc2b5cdc0c95cba894849651fec1fa1511d365e3eb72b0cc75caac44077cd48"},
     {file = "statsmodels-0.14.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b8d96b0bbaeabd3a557c35cc7249baa9cfbc6dd305c32a9f2cbdd7f46c037e7f"},
@@ -5950,4 +5950,4 @@ viz = ["matplotlib", "plotly", "seaborn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0.0"
-content-hash = "399feafeb18269ff1e3ecabd1bad77ccd0bb574fc5c526883616927b3d13d8ca"
+content-hash = "94b316d095fa5bea930c0d19d88f0db71d2be966cf85d5e492795b86f66a5593"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,20 @@
-[tool.poetry]
+# PEP 621 metadata. Migrated off the `[tool.poetry.*]` spelling 2026-08-04, which poetry 2.x
+# reported as 13 deprecation warnings on every `poetry check`. The migration had to come
+# first: the `poetry>=2.0,<3.0` pin in the lockfile CI job was defensive against a future
+# major promoting those warnings to errors, and that pin can only be relaxed once nothing
+# deprecated is left. Poetry-specific keys (packages/include/exclude, dependency groups)
+# stay under [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
+[project]
 name = "hvantk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hail-based toolkit for multi-omics variant annotation and analysis"
-authors = ["Yasset Perez-Riverol <ypriverol@gmail.com>",
-           "Enrique Audain <enrique.audain@uni-oldenburg.de>"]
+authors = [
+    { name = "Yasset Perez-Riverol", email = "ypriverol@gmail.com" },
+    { name = "Enrique Audain", email = "enrique.audain@uni-oldenburg.de" },
+]
 license = "MIT"
 readme = "README.md"
+requires-python = ">=3.10.0,<4.0.0"
 keywords = [
     "multiomics",
     "annotation-toolkit",
@@ -14,6 +23,36 @@ keywords = [
     "genotype-combining",
     "joint-genotyping"
 ]
+# PEP 508 specifiers, so poetry's caret shorthand is spelled out. These are exact
+# equivalents, not re-pins: ^8.1.3 == >=8.1.3,<9.0.0 and ^2.0.0 == >=2.0.0,<3.0.0. The lock
+# resolves to the same 187 packages as before the migration.
+dependencies = [
+    "hail>=0.2.137",
+    "click>=8.1.3,<9.0.0",
+    "requests",
+    "tqdm",
+    "pandas>=2.0.0,<3.0.0",
+    # Imported at module scope in ~68 modules. It has always arrived transitively via
+    # pandas/hail, but code that imports a package directly should declare it -- otherwise
+    # the day pandas drops or re-pins numpy, the break surfaces somewhere unrelated.
+    "numpy>=1.23",
+    "pyarrow>=14.0",
+    "PyYAML",
+    "jsonschema>=4.0",
+    "psutil",
+    "pysam>=0.22",
+    "certifi",
+    "anndata>=0.10.0",
+]
+
+[project.urls]
+GitHub = "https://github.com/bigbio/hvantk/"
+LICENSE = "https://github.com/bigbio/hvantk/blob/main/LICENSE"
+
+[project.scripts]
+hvantk = "hvantk.hvantk:main"
+
+[tool.poetry]
 include = [
   { path = "hvantk/skills/**/plugin.yaml", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/SKILL.md", format = ["sdist", "wheel"] },
@@ -48,39 +87,11 @@ exclude = [
 # drift_fingerprint.json stays -- it is included on purpose, being what `hvantk drift`
 # compares a live probe against.
 
-[tool.poetry.dependencies]
-python = ">=3.10.0,<4.0.0"
-hail = ">=0.2.137"
-click = "^8.1.3"
-requests = "*"
-tqdm = "*"
-pandas = "^2.0.0"
-# Imported at module scope in ~68 modules. It has always arrived transitively via
-# pandas/hail, but code that imports a package directly should declare it -- otherwise the
-# day pandas drops or re-pins numpy, the break surfaces somewhere unrelated.
-numpy = ">=1.23"
-pyarrow = ">=14.0"
-PyYAML = "*"
-jsonschema = ">=4.0"
-psutil = "*"
-pysam = ">=0.22"
-certifi = "*"
-anndata = ">=0.10.0"
-# OPTIONAL, unlike anndata: scanpy pulls numba -> llvmlite, and llvmlite ships no
-# x86_64 macOS wheel from 0.47 on, so a base-level declaration makes the whole
-# package uninstallable on Intel Macs -- including for the ~99% of the toolkit that
-# never touches expression. Both import sites (algorithms/expression/matrix_utils.py,
-# tools/expression/summarize_expression_cli.py) already import it inside the function
-# body, so nothing breaks at import time when it is absent. anndata is pure Python and
-# stays in the base install.
-scanpy = { version = ">=1.10.0", optional = true }
-# ^1.4, not ^1.3: rerank's opt-in RFECV step wraps RandomForestClassifier, which only
-# tolerates NaN from 1.4 onward, and these feature matrices are 20-50% missing by design.
-# The floor stays as long as `SelectionPolicy(wrapper="rfecv")` is reachable -- it is now
-# off by default, not removed. Drop to ^1.3 only if the wrapper is deleted outright.
-scikit-learn = { version = "^1.4", optional = true }
-# Declared explicitly rather than leaned on as a transitive dep of scikit-learn, because
-# relying on a transitive dependency is how it silently breaks later.
+# Optional dependencies. In PEP 621 an extra carries the full specifier, so a constraint
+# repeated across extras (scipy in six, scikit-learn in three) is a drift surface that the
+# old [tool.poetry.dependencies] + [tool.poetry.extras] split did not have -- one extra could
+# be re-pinned and the others left behind, silently. test_pyproject_extras.py asserts every
+# extra spells the same package identically, so that divergence fails the build.
 #
 # scipy is NOT only needed where sklearn is. Three modules `from scipy...` at MODULE scope
 # with no sklearn nearby, and they sit on three DIFFERENT commands -- check the call graph
@@ -90,52 +101,42 @@ scikit-learn = { version = "^1.4", optional = true }
 #   algorithms/burden/fet.py         -> `hvantk cohort burden`       -> cohort extra
 # fet.py is NOT reached by `hvantk enrichex burden`: its only importer is
 # algorithms/burden/pipeline.py, which is imported by tools/cohort/cohort_cli.py alone.
-# (algorithms/enrichex/burden.py imports scipy at CALL time only, so it does not gate import.)
-# Until 2026-08-03 `constraint` omitted scipy, so `pip install hvantk[constraint]` produced a
-# documented extra whose own command still raised ModuleNotFoundError, and enrichex and cohort
-# had no extra at all.
 #
-# A call-time require_scipy() guard (cf. require_scanpy in algorithms/expression/matrix_utils)
-# would additionally turn a BASE install's bare ModuleNotFoundError into a message naming the
-# extra. That is a separate improvement: it changes the error text, not what any extra
-# installs, so it is not needed to make these extras correct.
-scipy = { version = ">=1.8", optional = true }
-matplotlib = { version = "*", optional = true }
-seaborn = { version = "*", optional = true }
-plotly = { version = "*", optional = true }
-duckdb = { version = ">=0.9.0", optional = true }
-cptac = { version = "*", optional = true }
-# sorted-nearest is a compiled runtime dep of pyranges (imported by cptac); an
-# extras install doesn't reliably pull it, so declare it explicitly. Import name
-# is `sorted_nearest`. Already resolved in poetry.lock (0.0.41).
-sorted-nearest = { version = "*", optional = true }
-tspex = { version = ">=0.6.0", optional = true }
-
-[tool.poetry.extras]
+# scikit-learn floor is >=1.4, not >=1.3: rerank's opt-in RFECV step wraps
+# RandomForestClassifier, which only tolerates NaN from 1.4 onward, and these feature
+# matrices are 20-50% missing by design.
+#
+# scanpy is optional, unlike anndata: it pulls numba -> llvmlite, which ships no x86_64 macOS
+# wheel from 0.47 on, so a base-level declaration would make the package uninstallable on
+# Intel Macs -- including for the ~99% of the toolkit that never touches expression.
+#
+# sorted-nearest is a compiled runtime dep of pyranges (imported by cptac); an extras install
+# doesn't reliably pull it, so it is declared explicitly. Import name is `sorted_nearest`.
+[project.optional-dependencies]
 viz = ["matplotlib", "seaborn", "plotly"]
-duckdb = ["duckdb"]
+duckdb = ["duckdb>=0.9.0"]
 interactive = ["plotly"]
 hgc = ["matplotlib", "seaborn"]
-psroc = ["matplotlib", "plotly", "scikit-learn", "scipy"]
+psroc = ["matplotlib", "plotly", "scikit-learn>=1.4,<2.0", "scipy>=1.8"]
 ptm = ["cptac", "sorted-nearest"]
-constraint = ["tspex", "matplotlib", "seaborn", "scipy"]
+constraint = ["tspex>=0.6.0", "matplotlib", "seaborn", "scipy>=1.8"]
 # enrichex needs matplotlib as well as scipy. scipy is eager -- overlap.py imports
 # scipy.stats at module scope, so `hvantk enrichex overlap` needs it to import at all.
 # matplotlib is no longer eager: enrichex/__init__ resolves plot.py / report.py through a
 # PEP 562 __getattr__, so a base install can run the CLI. It is still in this extra because
 # the plotting and --generate-report paths need it at call time, and accessing a plotting
 # name without it raises an ImportError naming this extra.
-enrichex = ["scipy", "matplotlib", "seaborn"]
+enrichex = ["scipy>=1.8", "matplotlib", "seaborn"]
 # cohort covers `hvantk cohort burden`, whose pipeline reaches algorithms/burden/fet.py and
 # its module-scope `from scipy.stats import fisher_exact`. scipy alone: nothing on that path
 # imports matplotlib.
-cohort = ["scipy"]
-ancestry = ["scikit-learn", "matplotlib", "seaborn", "scipy"]
-ml = ["scikit-learn", "scipy"]
+cohort = ["scipy>=1.8"]
+ancestry = ["scikit-learn>=1.4,<2.0", "matplotlib", "seaborn", "scipy>=1.8"]
+ml = ["scikit-learn>=1.4,<2.0", "scipy>=1.8"]
 # scanpy already depends on scipy, so listing it changes no resolution -- but
 # visualization/expression/anndata.py imports scipy.sparse directly, and this file's rule is
 # to declare what is imported rather than inherit it from a transitive edge that can move.
-expression = ["scanpy", "scipy"]
+expression = ["scanpy>=1.10.0", "scipy>=1.8"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
@@ -152,7 +153,7 @@ mkdocs = "*"
 mkdocs-material = "*"
 ipykernel = "^7.2.0"
 
-[tool.poetry.plugins."hvantk.providers"]
+[project.entry-points."hvantk.providers"]
 # In-tree plugins register themselves the same way as external ones.
 # Only providers migrated to the plugin layout appear here.
 hgnc = "hvantk.skills.hgnc"
@@ -173,12 +174,11 @@ uniprot-ptm = "hvantk.skills.uniprot_ptm"
 testpaths = ["hvantk/tests", "hvantk/skills"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+# >=2.0, not >=1.0: PEP 621 `[project]` metadata is only read by poetry-core 2.x, and the
+# `license = "MIT"` SPDX expression needs its PEP 639 support. Against an older poetry-core
+# this file's name/version/dependencies would simply not be found, since [tool.poetry] no
+# longer carries them -- a build that fails, or worse produces a wheel with empty metadata.
+# The floor was left at 1.0.0 through the migration and only caught in review; CI masked it
+# because the packaging-smoke job installs a modern poetry explicitly.
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.urls]
-GitHub = "https://github.com/bigbio/hvantk/"
-LICENSE = "https://github.com/bigbio/hvantk/blob/main/LICENSE"
-
-[tool.poetry.scripts]
-hvantk = "hvantk.hvantk:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # run still goes green -- which is exactly how the rerank tests came to be skipped on this
 # path while passing under conda.
 
-# --- base runtime, mirroring [tool.poetry.dependencies] ---
+# --- base runtime, mirroring [project.dependencies] ---
 hail>=0.2.137
 click>=8.1.3,<9
 requests


### PR DESCRIPTION
Tier 3 of the packaging/CI hardening plan: the PEP 621 migration, the version bump, and the poetry unpin the migration was a prerequisite for.

## The migration

`name`, `version`, `description`, `authors`, `license`, `readme`, `keywords`, `urls`, `plugins`, `extras` and `scripts` all used the deprecated `[tool.poetry.*]` spelling — **11 warnings on every `poetry check`**. They now live under `[project]`, `[project.optional-dependencies]`, `[project.entry-points]`, `[project.scripts]` and `[project.urls]`. `poetry check` now reports **"All set!"**.

Only genuinely Poetry-specific keys (`include`/`exclude`, dependency groups) remain under `[tool.poetry]` — they have no PEP 621 equivalent and are not deprecated.

**The migration is resolution-neutral**, verified by name+version set rather than by count: the lock resolves to the same **187 packages** before and after, none added, none removed. Poetry's caret shorthand is spelled out as the PEP 508 equivalent it always meant (`^8.1.3` → `>=8.1.3,<9.0.0`), not re-pinned. Entry points survive intact — console script plus all 13 providers, confirmed in the built wheel's `entry_points.txt`.

## Version

`0.1.0` → **`0.2.0`**. The package shipped to `main` twice at `0.1.0`, so releases were not distinguishable by version.

Note this only half-solves it: releases are still **not git-tagged** (there are no tags in the repo at all), so a release is identifiable by version but not locatable in history. The known-gaps entry now says that rather than claiming the bump closed it.

## Unpin

With nothing deprecated left, the defensive `poetry>=2.0,<3.0` pin in the `poetry.lock in sync` job is unpinned — the sequencing the plan called for (migration *before or with* the unpin, never after).

## A new drift surface, and its guard

PEP 621 puts the full specifier in each extra, so `scipy>=1.8` is now written six times and `scikit-learn>=1.4,<2.0` three times. Nothing stops one being re-pinned with the others left behind — resolving differently depending on which extra a user installs. That's a maintainability regression the old `[tool.poetry.dependencies]` + `[tool.poetry.extras]` split did not have, and it arrived *with* this change, so `test_extras_agree_on_every_shared_constraint` guards it.

`test_pyproject_extras.py` is otherwise reworked for the new schema. `test_every_extra_dependency_is_declared_optional` is replaced by `test_no_extra_duplicates_a_base_dependency`, since "named in an extra but never declared" is structurally impossible under PEP 621.

## Adversarial-review fixes folded in

**Two would have broken builds:**

- `build-system.requires` was left at `poetry-core>=1.0.0`. PEP 621 `[project]` metadata is only read by poetry-core 2.x — against an older one this file's name/version/dependencies are simply not found, since `[tool.poetry]` no longer carries them. CI masked it because `packaging-smoke` installs a modern poetry explicitly. Now `>=2.0.0`.
- `docs_site/guide/hpc-migration.md` pinned `poetry==1.8.*` in the Apptainer recipe, which cannot read PEP 621 at all — the project's own container build would have failed on the next image build. Now `>=2.0`.

**Two were overstatements of mine:**

- "13 deprecation warnings" was a miscount from a loose grep that counted continuation lines. The real number is **11**, measured against the pre-migration file. Corrected in the CHANGELOG and the CI comment.
- The unpin comment claimed "nothing left to promote". Untrue — `[tool.poetry]` still carries `include`/`exclude` and the dev group, which a future poetry major could change. The comment now states what the unpin actually removes, and that re-pinning is the answer if a major does break it.

Plus four stale `[tool.poetry.*]` references (workflow comment, test docstring, `requirements.txt`, hpc guide), the inconsistent poetry pin still sitting in `packaging-smoke`, and `_requirement_name` not splitting a whitespace-free `pkg@url`.

## Verification

- **1,430 passed, 11 skipped**
- `poetry check` → "All set!" (was 11 warnings)
- Lock: 187 packages before and after, name-for-name and version-for-version
- Wheel builds at 2.86 MB, `check_wheel.py` passes, entry points intact
- Installed 0.2.0 runs `hvantk --help` and reports 21/21 providers on a matplotlib-free env
- All five workflows parse

## Not included

Codacy. It has never been green, so it carries no signal — but there is no `.codacy.yml` in the repo, meaning it is configured entirely server-side. Narrowing it to rules worth enforcing, or disabling the check, is a repo-settings decision rather than a code change.
