### PR TITLE
docs(packaging): correct three inaccurate claims left by the PEP 621 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 ### Changed
 
 - **Version bumped to `0.2.0`, and `pyproject.toml` migrated to PEP 621 `[project]`.** The
-  package shipped to `main` twice at `0.1.0`, so releases were not distinguishable by
-  version. Separately, `name`, `version`, `description`, `authors`, `license`, `readme`,
+  version had been `0.1.0` since 2025-05-04, across 61 merges into `main` — so no release in
+  fifteen months was distinguishable from any other by version. Separately, `name`,
+  `version`, `description`, `authors`, `license`, `readme`,
   `keywords`, `urls`, `plugins`, `extras` and `scripts` all used the deprecated
   `[tool.poetry.*]` spelling — 11 warnings on every `poetry check`. They now live under
   `[project]`, `[project.optional-dependencies]`, `[project.entry-points]`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 # PEP 621 metadata. Migrated off the `[tool.poetry.*]` spelling 2026-08-04, which poetry 2.x
-# reported as 13 deprecation warnings on every `poetry check`. The migration had to come
+# reported as 11 deprecation warnings on every `poetry check`. The migration had to come
 # first: the `poetry>=2.0,<3.0` pin in the lockfile CI job was defensive against a future
 # major promoting those warnings to errors, and that pin can only be relaxed once nothing
-# deprecated is left. Poetry-specific keys (packages/include/exclude, dependency groups)
-# stay under [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
+# deprecated is left. Poetry-specific keys (include/exclude, dependency groups) stay under
+# [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
 [project]
 name = "hvantk"
 version = "0.2.0"


### PR DESCRIPTION
Comment- and CHANGELOG-only. Three inaccurate claims left behind by #256, found while cleaning up after that merge.

## `pyproject.toml` contradicted its own sibling comments

The header said **"13 deprecation warnings"**. The real count, measured against the pre-migration file, is **11** — 13 came from a grep that counted continuation lines. That miscount was corrected in the CHANGELOG and in the `poetry.lock in sync` workflow comment during review, but not in the file those two describe, so `pyproject.toml:2` disagreed with `.github/workflows/python-package-conda.yml:28`. `grep` now finds 11 in both and 13 nowhere.

The same comment listed the surviving Poetry-specific keys as `packages/include/exclude`. There is no `packages` key under `[tool.poetry]` — only `include` and `exclude`.

## The CHANGELOG undercounted the versioning gap by a factor of thirty

It said the package "shipped to `main` twice at `0.1.0`", which I carried over from the planning doc's "#184 and #249" rather than measuring.

Measured: the version has read `0.1.0` since **2025-05-04**, across **61 merges into `main`**, the most recent being `3735c7d` on 2026-08-01. Every merge on `main`'s first-parent line since then carried it; the only six that did not are the 2024-09 → 2025-05 merges predating the `version` key.

So the gap the `0.2.0` bump closes was fifteen months and 61 releases wide, not two. Same conclusion, but the entry should not understate its own justification.

## Not changed

The known-gaps entry on tagging is already accurate — releases still are not git-tagged, and the repo has **zero** tags. Backfilling them is not proposed here: all 61 of those merges genuinely were `0.1.0`, so there is no true version to assign retroactively, and inventing one would be worse than the gap. Tagging should start at `v0.2.0` when `dev` next lands on `main`.

## Verification

`poetry check` → "All set!". No executable line changed — the diff is six lines across a TOML comment and a CHANGELOG paragraph.
