### PR TITLE
chore(release): stamp 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 — 2026-08-04
+
+First tagged release. Everything below had accumulated under `Unreleased` since `0.1.0`,
+which sat on `main` unchanged from 2025-05-04 across 61 merges.
 
 ### Added
 


### PR DESCRIPTION
Flips the CHANGELOG's `## Unreleased` header to `## 0.2.0 — 2026-08-04` ahead of the `dev` → `main` release.

CHANGELOG-only; no code, no metadata. `pyproject.toml` already carries `version = "0.2.0"` from #256.

Context for the note added under the header: `0.1.0` sat on `main` from 2025-05-04 across 61 merges, so this is the first release identifiable by version — and, once tagged, the first locatable in history. The repo currently has zero tags; `v0.2.0` will be its first.

Backfilling tags for the earlier 61 was considered and rejected: they genuinely all were `0.1.0`, so there is no true version to assign retroactively.