### PR TITLE
release: 0.2.0

### DIFF
--- a/.github/scripts/check_wheel.py
+++ b/.github/scripts/check_wheel.py
@@ -1,0 +1,109 @@
+"""Assert the built wheel ships what it should and nothing else.
+
+Run by the `packaging-smoke` CI job after `poetry build -f wheel`. Nothing else in the
+pipeline builds a wheel, so before this existed the include/exclude globs in pyproject.toml
+were never checked and had silently rotted: the wheel carried 339 files under a tests/
+directory and 43.3 MB of fixtures (a 14.7 MB VDS zip, an 11.4 MB expression-atlas file) in a
+46.2 MB package, while the excludes that were supposed to stop it either named the wrong
+directory (`tests/data` where the skills use `tests/testdata`) or were overridden by a
+broader `include`.
+
+The size ceiling is deliberately generous. It is a tripwire for "someone added a fixture to a
+shipped path", not a byte budget -- a real regression here is an order of magnitude, not a few
+percent.
+"""
+from __future__ import annotations
+
+import glob
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+MAX_UNCOMPRESSED_MB = 10.0
+REPO = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    wheels = glob.glob(str(REPO / "dist" / "*.whl"))
+    if len(wheels) != 1:
+        print(f"FAIL expected exactly one wheel in dist/, found {len(wheels)}: {wheels}")
+        return 1
+    names = zipfile.ZipFile(wheels[0]).infolist()
+    paths = [i.filename for i in names]
+    failures: list[str] = []
+
+    def count(pred) -> int:
+        return sum(1 for p in paths if pred(p))
+
+    # --- things that must NOT ship
+    top_level_tests = count(lambda p: p.startswith("hvantk/tests/"))
+    if top_level_tests:
+        failures.append(f"{top_level_tests} files under hvantk/tests/ (expected 0)")
+
+    test_modules = count(lambda p: re.search(r"/test_[^/]*\.py$", p))
+    if test_modules:
+        failures.append(f"{test_modules} test_*.py modules (expected 0)")
+
+    # Drift fingerprints are the deliberate exception: `hvantk drift` compares a live probe
+    # against them at runtime, so they belong in the wheel. Multi-dataset providers suffix the
+    # name per dataset (drift_fingerprint_samples.json), hence the prefix match rather than an
+    # exact one.
+    def _is_fingerprint(p: str) -> bool:
+        return re.search(r"/drift_fingerprint[^/]*\.json$", p) is not None
+
+    fixtures = count(
+        lambda p: "/tests/" in p and not (_is_fingerprint(p) or p.endswith(".gitkeep"))
+    )
+    if fixtures:
+        failures.append(f"{fixtures} test fixtures under a tests/ dir (only fingerprints ship)")
+
+    mb = sum(i.file_size for i in names) / 1e6
+    if mb > MAX_UNCOMPRESSED_MB:
+        failures.append(f"wheel is {mb:.1f} MB uncompressed, ceiling is {MAX_UNCOMPRESSED_MB}")
+
+    # --- things that MUST ship. Counted against the tree, so adding a provider needs no edit
+    # here; a packaging glob that silently drops one is what this catches.
+    # Manifests alone are not enough. `hvantk plugins list` -- the CI job's other check --
+    # only reads YAML (loader Pass 1, no callables imported), so a packaging glob that dropped
+    # every builder.py would still print the right provider count and leave the job green.
+    # The skills-module count is what actually covers that, and the fingerprints are the
+    # runtime data `hvantk drift` compares against.
+    # `keep_disk` filters the TREE side so both sides count the same population. It matters for
+    # skills modules (test_*.py are excluded from the wheel on purpose, so counting them on
+    # disk would fail every run) and must NOT be applied to fingerprints, which legitimately
+    # live under tests/.
+    not_a_test = lambda p: "/tests/" not in Path(p).as_posix()  # noqa: E731
+    everything = lambda p: True                                  # noqa: E731
+
+    for label, pattern, wheel_pred, keep_disk in (
+        ("plugin.yaml manifests", "hvantk/skills/**/plugin.yaml",
+         lambda p: p.endswith("plugin.yaml"), everything),
+        ("SKILL.md files", "hvantk/skills/**/SKILL.md",
+         lambda p: p.endswith("SKILL.md"), everything),
+        ("catalog datasets.json", "hvantk/skills/**/catalog/*.json",
+         lambda p: "/catalog/" in p and p.endswith(".json"), everything),
+        ("drift fingerprints", "hvantk/skills/**/tests/drift_fingerprint*.json",
+         _is_fingerprint, everything),
+        ("skills modules", "hvantk/skills/**/*.py",
+         lambda p: p.startswith("hvantk/skills/") and p.endswith(".py"), not_a_test),
+    ):
+        on_disk = len([p for p in glob.glob(str(REPO / pattern), recursive=True)
+                       if keep_disk(p)])
+        in_wheel = count(wheel_pred)
+        if on_disk != in_wheel:
+            failures.append(f"{label}: {on_disk} in tree but {in_wheel} in wheel")
+
+    if not count(lambda p: p.endswith("entry_points.txt")):
+        failures.append("no entry_points.txt -- console script and provider plugins are unregistered")
+
+    for f in failures:
+        print(f"FAIL {f}")
+    if failures:
+        return 1
+    print(f"OK wheel is {mb:.2f} MB uncompressed, {len(paths)} files, no test payload")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,6 +2,12 @@ name: Python Package using Conda
 
 on: [push]
 
+# Every job here only reads the repo -- builds, installs, runs tests. The default token grants
+# write scopes none of them need. Flagged in review on #249 and not applied at the time; set
+# now at workflow level so new jobs inherit it rather than each having to remember.
+permissions:
+  contents: read
+
 jobs:
   # Runs in seconds and needs no environment, so it sits in the workflow that triggers on
   # every push rather than only on main-targeted PRs. Its absence is why poetry.lock drifted
@@ -14,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       # Pinned to the 2.x line rather than latest: pyproject.toml still uses the
@@ -26,6 +32,60 @@ jobs:
         run: python -m pip install --upgrade pip "poetry>=2.0,<3.0"
       - name: Check pyproject.toml is valid and poetry.lock matches it
         run: poetry check --lock
+
+  # Nothing in CI installed the package, so `pytest` always imported hvantk from the checkout
+  # directory and three things were never exercised: the `hvantk` console script, the
+  # [tool.poetry.plugins."hvantk.providers"] entry points, and the include/exclude packaging
+  # globs. All three were broken and CI was green throughout:
+  #   - `hvantk --help` raised ModuleNotFoundError on a base install (the CLI eagerly imported
+  #     matplotlib, which is optional),
+  #   - the wheel shipped 43.3 MB of test data in a 46.2 MB wheel, because `hvantk/tests/**`
+  #     was absent from `exclude` and the skills excludes were overridden by an `include`.
+  # This job is the guard: it builds the wheel, checks its contents, installs it into a clean
+  # environment with NO extras, and runs the CLI from a directory where the checkout is not
+  # importable -- so it tests the installed copy rather than the source tree.
+  packaging-smoke:
+    name: Installed package smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      # hail is a hard dependency and needs Java 11 to import; the CLI imports it eagerly.
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip "poetry>=2.0,<3.0"
+          poetry build -f wheel
+      - name: Check wheel contents
+        run: python .github/scripts/check_wheel.py
+      - name: Install the wheel into a clean environment, without extras
+        run: |
+          python -m venv /tmp/venv
+          /tmp/venv/bin/pip install --upgrade pip
+          /tmp/venv/bin/pip install dist/*.whl
+      # `working-directory` is load-bearing: run this from the repo root and Python would
+      # import ./hvantk from the checkout, which is exactly what this job exists to avoid.
+      - name: Smoke-check the installed CLI
+        working-directory: /tmp
+        run: |
+          /tmp/venv/bin/python -c "import hvantk, os; p = os.path.dirname(hvantk.__file__); assert 'site-packages' in p, p; print('importing installed copy:', p)"
+          /tmp/venv/bin/hvantk --help
+          /tmp/venv/bin/hvantk plugins list
+      # A packaging glob that drops manifests would still let `plugins list` exit 0 with a
+      # short list, so assert the count instead of just the exit code.
+      - name: Every plugin manifest survived packaging
+        run: |
+          expected=$(find hvantk/skills -name plugin.yaml | wc -l | tr -d ' ')
+          actual=$(cd /tmp && /tmp/venv/bin/hvantk plugins list | tail -n +2 | grep -c '[^[:space:]]')
+          echo "manifests in tree: $expected / providers from installed copy: $actual"
+          test "$expected" = "$actual"
 
   build-linux:
     runs-on: ubuntu-latest
@@ -39,7 +99,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libopenblas-dev
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Add conda to system path
@@ -83,7 +143,7 @@ jobs:
           distribution: temurin
           java-version: "11"
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Add conda to system path
@@ -104,3 +164,42 @@ jobs:
                  hvantk/tests/test_hail_helpers.py \
                  hvantk/skills \
                  -m hail -rA
+
+  # hvantk/tests/hgc/ ran in NO CI job: pytest.ini deselects `hail`, and the job above is
+  # path-scoped to the contract tests. So test_convert_vds_to_mt -- the only end-to-end
+  # exercise of the `adj` code ported out of the gnomad dependency in #252 -- ran only under a
+  # manual `pytest -m hail`.
+  #
+  # Deliberately a SEPARATE job rather than more paths on plugin-contract. Appending would
+  # push that job from ~6 to ~12 min and delay the contract signal behind unrelated HGC work;
+  # as its own job it runs concurrently, so wall-clock to first failure is unchanged.
+  hgc-hail:
+    name: HGC pipeline (hail)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Add conda to system path
+        run: |
+          echo $CONDA/bin >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          conda env update --file environment.yml --name base
+      - name: Install test dependencies
+        run: |
+          python -m pip install pytest requests-mock
+      - name: Run HGC tests
+        run: |
+          pytest hvantk/tests/hgc -m hail -rA

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -23,19 +23,23 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      # Pinned to the 2.x line rather than latest: pyproject.toml still uses the
-      # `[tool.poetry.*]` spelling of keywords/urls/plugins/extras/scripts, which 2.x
-      # reports as deprecation warnings (exit 0). A future major is entitled to promote
-      # those to errors, which would break this gate on someone else's release rather
-      # than on a change of ours.
+      # Unpinned again as of the PEP 621 migration. The `<3.0` ceiling was defensive: with
+      # the `[tool.poetry.*]` spelling of name/version/description/authors/license/readme/
+      # keywords/urls/plugins/extras/scripts, `poetry check` emitted 11 deprecation warnings,
+      # and a future major promoting those to errors would have broken this gate on someone
+      # else's release rather than on a change of ours. All eleven are gone.
+      # This does NOT make the job immune to a poetry major: [tool.poetry] still carries
+      # include/exclude and the dev dependency group, which are poetry-specific and could
+      # change again. What it removes is the specific, already-announced deprecation that
+      # the ceiling was put up for. Re-pin if a future major actually breaks this.
       - name: Install poetry
-        run: python -m pip install --upgrade pip "poetry>=2.0,<3.0"
+        run: python -m pip install --upgrade pip poetry
       - name: Check pyproject.toml is valid and poetry.lock matches it
         run: poetry check --lock
 
   # Nothing in CI installed the package, so `pytest` always imported hvantk from the checkout
   # directory and three things were never exercised: the `hvantk` console script, the
-  # [tool.poetry.plugins."hvantk.providers"] entry points, and the include/exclude packaging
+  # [project.entry-points."hvantk.providers"] entry points, and the include/exclude packaging
   # globs. All three were broken and CI was green throughout:
   #   - `hvantk --help` raised ModuleNotFoundError on a base install (the CLI eagerly imported
   #     matplotlib, which is optional),
@@ -61,7 +65,8 @@ jobs:
           java-version: "11"
       - name: Build the wheel
         run: |
-          python -m pip install --upgrade pip "poetry>=2.0,<3.0"
+          # >=2.0 is a real floor, not caution: PEP 621 [project] metadata needs poetry-core 2.x
+          python -m pip install --upgrade pip "poetry>=2.0"
           poetry build -f wheel
       - name: Check wheel contents
         run: python .github/scripts/check_wheel.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,11 +3,19 @@
 
 name: Python package
 
+# `dev` is included deliberately. With main-only triggers the 3.10/3.11/3.12 matrix ran for
+# the first time at the release gate, so a version incompatibility introduced on a dev PR was
+# discovered with a whole release to bisect instead of a single commit. The cost is three jobs
+# per dev PR; the alternative is finding out later, on a bigger diff.
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
+
+# lint + test only; no write scopes needed
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -20,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 ### Changed
 
 - **Version bumped to `0.2.0`, and `pyproject.toml` migrated to PEP 621 `[project]`.** The
-  package shipped to `main` twice at `0.1.0`, so releases were not distinguishable by
-  version. Separately, `name`, `version`, `description`, `authors`, `license`, `readme`,
+  version had been `0.1.0` since 2025-05-04, across 61 merges into `main` — so no release in
+  fifteen months was distinguishable from any other by version. Separately, `name`,
+  `version`, `description`, `authors`, `license`, `readme`,
   `keywords`, `urls`, `plugins`, `extras` and `scripts` all used the deprecated
   `[tool.poetry.*]` spelling — 11 warnings on every `poetry check`. They now live under
   `[project]`, `[project.optional-dependencies]`, `[project.entry-points]`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,39 @@
   move. A base install still raises a bare `ModuleNotFoundError` rather than a message
   naming the extra; a `require_scipy()` guard (cf. `require_scanpy`) would fix the *text*,
   and is tracked separately because it changes no extra's contents.
+- **`hvantk` was unusable from a `pip install`.** The console script imported
+  `hvantk.tools.enrichex` at module scope, which ran `algorithms/enrichex/__init__.py`,
+  which eagerly imported `enrichex/plot.py`, `enrichex/report.py` and
+  `visualization/base.py` — all three import `matplotlib` at module scope. matplotlib is
+  optional, so on a base install **every** command including `hvantk --help` raised
+  `ModuleNotFoundError`. Those three imports are now resolved on attribute access (PEP 562
+  `__getattr__`), so the package imports without matplotlib and the CLI runs. The eight
+  plotting/reporting names stay in `__all__` and stay importable; touching one without
+  matplotlib now raises an `ImportError` naming the `enrichex` extra, matching
+  `require_scanpy` and `_require_matplotlib`. No plotting behaviour changed — the enrichex
+  CLIs already imported `generate_report` inside the functions that use it.
+- **The wheel shipped 43.3 MB of test data.** `hvantk/tests/**` was absent from `exclude`
+  (190 files, including a 14.7 MB VDS zip and an 11.4 MB expression-atlas fixture); the
+  skills excludes were overridden by `include = "hvantk/skills/**/*.py"`, since a path named
+  by `include` wins; and the excludes named `tests/data/**` where the skills actually use
+  `tests/testdata/**`. Fixed all three: the wheel goes from **46.2 MB to 2.86 MB**
+  uncompressed (28 MB to 897 KB on disk) with every manifest, skills module, catalog and
+  drift fingerprint intact.
+- **CI now installs the package.** New `packaging-smoke` job builds the wheel, checks its
+  contents with `.github/scripts/check_wheel.py`, installs it into a clean environment with
+  no extras, and runs `hvantk --help` / `hvantk plugins list` from a directory where the
+  checkout is not importable — so the console script, the entry-point registrations and the
+  packaging globs are exercised against the installed copy. It also asserts the provider
+  count matches the tree, since a dropped manifest would otherwise still exit 0. Both bugs
+  above were found by writing this job.
+- **`hvantk/tests/hgc/` now runs in CI** as a new `hgc-hail` job — separate from
+  `Plugin contract (hail)` rather than appended to it, so the contract signal is not delayed
+  behind ~6 min of unrelated HGC work. This is the first automatic run of
+  `test_convert_vds_to_mt`, the end-to-end exercise of the `adj` code ported in #252.
+- **The Python version matrix now runs on `dev` PRs**, not only `main`, so an incompatibility
+  is caught on one commit instead of at the release gate with a whole release to bisect.
+  `actions/setup-python` moved v3 → v5 and both workflows now declare
+  `permissions: contents: read` (both raised in review on #249).
 - The extras table is now guarded by a test. It is duplicated in three places — the
   `[tool.poetry.extras]` block, `README.md` and `docs_site/getting-started/installation.md`
   — and only the first is executable, so the prose copies had drifted eight cells
@@ -111,17 +144,6 @@
   (`default`, `adult-ctx`, `dev-ctx`) already have populated snapshot dirs.
 - The package version has never been bumped from `0.1.0`, so releases to `main` are not
   distinguishable by version.
-- No CI job installs the package (`pip install .` / `poetry install`), so `pytest` imports
-  `hvantk` from the checkout directory. Packaging — the `include`/`exclude` globs, the
-  console-script entry point, and the `[tool.poetry.plugins."hvantk.providers"]`
-  entry-point registrations — is therefore never exercised in CI, and the plugin loader's
-  entry-point discovery path is only ever tested via its filesystem fallback. (The lock
-  itself *is* now validated on every push — see the `poetry.lock in sync` job.)
-- The `build` and `build (3.10/3.11/3.12)` jobs run only on pull requests targeting
-  `main`, so a Python-version incompatibility introduced on a `dev` PR is not caught until
-  the release gate, with the whole release to bisect rather than one commit.
-- No CI job runs `hvantk/tests/hgc/`. `hail`-marked tests are deselected by `pytest.ini`'s
-  `addopts`, and the one hail-enabled job (`Plugin contract (hail)`) is path-scoped to the
-  plugin-contract tests. So the HGC integration suite — including `test_convert_vds_to_mt`,
-  which is the end-to-end exercise of `adj` — runs only when someone invokes `pytest -m hail`
-  locally. Unskipping that test made it *runnable*, not *automatically run*.
+  (The three CI gaps previously listed here — no install job, the version matrix running
+  only on `main`, and `hvantk/tests/hgc/` running in no job — are resolved; see the
+  packaging and CI entries under Changed.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,32 @@
 - `scikit-learn` floor raised to `>=1.4` (NaN-tolerant tree estimators, needed by rerank's
   optional RFECV wrapper). `scipy` is now declared explicitly, as an optional dependency in
   the `ml` / `ancestry` / `psroc` extras.
+- **Every command that imports `scipy` at module scope now has an extra that installs it.**
+  Three modules do, and they sit on three *different* commands — a mapping the previous
+  known-gaps note got wrong:
+  `algorithms/ptm/constraint.py` → `hvantk ptm constraint` (`constraint` extra);
+  `algorithms/enrichex/overlap.py` → `hvantk enrichex overlap` (new `enrichex` extra);
+  `algorithms/burden/fet.py` → `hvantk cohort burden` (new `cohort` extra).
+  `fet.py` is *not* reached by `hvantk enrichex burden`: its only importer is
+  `algorithms/burden/pipeline.py`, imported by `tools/cohort/cohort_cli.py` alone.
+  Previously `constraint` omitted `scipy`, so `pip install hvantk[constraint]` yielded a
+  documented extra whose own command still raised `ModuleNotFoundError`, and neither
+  `hvantk enrichex overlap` nor `hvantk cohort burden` had any extra to install.
+  `enrichex` also carries matplotlib/seaborn, because `enrichex/__init__` imports
+  `plot.py`/`report.py` unconditionally and a scipy-only extra would break on import.
+  `scipy` was added to `expression` too — a resolution no-op, since scanpy already depends
+  on it, but `visualization/expression/anndata.py` imports `scipy.sparse` directly and this
+  project declares what it imports rather than inheriting it from a transitive edge that can
+  move. A base install still raises a bare `ModuleNotFoundError` rather than a message
+  naming the extra; a `require_scipy()` guard (cf. `require_scanpy`) would fix the *text*,
+  and is tracked separately because it changes no extra's contents.
+- The extras table is now guarded by a test. It is duplicated in three places — the
+  `[tool.poetry.extras]` block, `README.md` and `docs_site/getting-started/installation.md`
+  — and only the first is executable, so the prose copies had drifted eight cells
+  (`psroc`/`ancestry`/`ml` missing `scipy`, `ptm` missing `sorted-nearest`) across two
+  releases. `hvantk/tests/test_pyproject_extras.py` now parses both markdown tables and
+  fails if either disagrees with `pyproject.toml`, and also fails if an extra names a
+  package that is not declared `optional = true`. Non-Hail, so it runs in the default suite.
 - `scanpy` moved out of the base install into a new `expression` extra. It is required by
   `hvantk expression summarize`, `hvantk expression markers`, and `hvantk ptm constraint
   --expression-metric mean`; those now fail with an actionable message naming the extra
@@ -83,11 +109,6 @@
   `cptac:expression`, and `cptac:phospho`. The first hail-enabled CI run with
   `--regenerate-snapshots` will bootstrap them. All `ucsc-cellbrowser` variants
   (`default`, `adult-ctx`, `dev-ctx`) already have populated snapshot dirs.
-- `scipy` is imported at module scope by `algorithms/burden/fet.py`,
-  `algorithms/enrichex/overlap.py` and `algorithms/ptm/constraint.py`, none of which sit
-  behind an extra that pulls it in, so `hvantk enrichex burden|overlap` and
-  `hvantk ptm constraint` raise `ModuleNotFoundError` on a base install. Pre-existing:
-  scipy was previously not declared at all.
 - The package version has never been bumped from `0.1.0`, so releases to `main` are not
   distinguishable by version.
 - No CI job installs the package (`pip install .` / `poetry install`), so `pytest` imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@
 
 ### Changed
 
+- **Version bumped to `0.2.0`, and `pyproject.toml` migrated to PEP 621 `[project]`.** The
+  package shipped to `main` twice at `0.1.0`, so releases were not distinguishable by
+  version. Separately, `name`, `version`, `description`, `authors`, `license`, `readme`,
+  `keywords`, `urls`, `plugins`, `extras` and `scripts` all used the deprecated
+  `[tool.poetry.*]` spelling — 11 warnings on every `poetry check`. They now live under
+  `[project]`, `[project.optional-dependencies]`, `[project.entry-points]`,
+  `[project.scripts]` and `[project.urls]`; only genuinely Poetry-specific keys
+  (`include`/`exclude`, dependency groups) remain under `[tool.poetry]`.
+  **The migration is resolution-neutral**: the lock resolves to the same 187 packages,
+  name-for-name and version-for-version, before and after. Poetry's caret shorthand is
+  spelled out as the PEP 508 equivalent it always meant (`^8.1.3` → `>=8.1.3,<9.0.0`), not
+  re-pinned. With nothing deprecated left, the defensive `poetry>=2.0,<3.0` pin in the
+  `poetry.lock in sync` CI job is unpinned again.
+  One consequence is new: PEP 621 puts the full specifier in each extra, so `scipy>=1.8`
+  is written six times and `scikit-learn>=1.4,<2.0` three times, and one could be re-pinned
+  with the others left behind — resolving differently depending on which extra a user
+  installs. `test_pyproject_extras.py` now asserts every extra spells a shared package
+  identically, alongside a check that no extra re-declares a base dependency.
 - **`gnomad` is no longer a dependency.** hvantk used exactly one function from it,
   `annotate_adj`, which is ~15 lines of Hail expression with no gnomAD data behind it.
   It is now ported into `hvantk/algorithms/hgc/adj.py` (gnomad_methods is MIT; the port
@@ -142,8 +160,8 @@
   `cptac:expression`, and `cptac:phospho`. The first hail-enabled CI run with
   `--regenerate-snapshots` will bootstrap them. All `ucsc-cellbrowser` variants
   (`default`, `adult-ctx`, `dev-ctx`) already have populated snapshot dirs.
-- The package version has never been bumped from `0.1.0`, so releases to `main` are not
-  distinguishable by version.
+- (Resolved: version bumped to 0.2.0 — see Changed.) Releases are still not git-tagged, so
+  a release is identifiable by version but not by a tag.
   (The three CI gaps previously listed here — no install job, the version matrix running
   only on `main`, and `hvantk/tests/hgc/` running in no job — are resolved; see the
   packaging and CI entries under Changed.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 — 2026-08-04
+
+First tagged release. Everything below had accumulated under `Unreleased` since `0.1.0`,
+which sat on `main` unchanged from 2025-05-04 across 61 merges.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ opt-in via Poetry extras. Install only what a given workflow needs:
 | `interactive` | Interactive plots / dashboards | plotly |
 | `duckdb` | DuckDB-backed queries | duckdb |
 | `hgc` | Joint genotyping plots (genotype adjustment needs no extra) | matplotlib, seaborn |
-| `psroc` | Pathogenicity Score ROC analysis | matplotlib, plotly, scikit-learn |
-| `ptm` | CPTAC proteomics builders | cptac |
-| `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn |
-| `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn |
-| `ml` | scikit-learn-backed features only | scikit-learn |
-| `expression` | `hvantk expression summarize` / `markers`, and `ptm constraint --expression-metric mean` | scanpy |
+| `psroc` | Pathogenicity Score ROC analysis | matplotlib, plotly, scikit-learn, scipy |
+| `ptm` | CPTAC proteomics builders | cptac, sorted-nearest |
+| `constraint` | Tissue-specificity / constraint metrics | tspex, matplotlib, seaborn, scipy |
+| `enrichex` | `hvantk enrichex overlap` / `burden` and their plots | scipy, matplotlib, seaborn |
+| `cohort` | `hvantk cohort burden` (Fisher gene burden) | scipy |
+| `ancestry` | Ancestry inference (PCA + Random Forest + plots) | scikit-learn, matplotlib, seaborn, scipy |
+| `ml` | scikit-learn-backed features only | scikit-learn, scipy |
+| `expression` | `hvantk expression summarize` / `markers`, and `ptm constraint --expression-metric mean` | scanpy, scipy |
 
 ```bash
 # One or more extras at once

--- a/docs_site/getting-started/installation.md
+++ b/docs_site/getting-started/installation.md
@@ -35,14 +35,16 @@ poetry install --extras "viz hgc"      # or: poetry install --all-extras
 |---|---|---|
 | `viz` | matplotlib, seaborn, plotly | plots and HTML reports |
 | `interactive` | plotly | interactive QC dashboards |
-| `ml` | scikit-learn | ML-backed analyses |
-| `ancestry` | scikit-learn, matplotlib, seaborn | `hvantk ancestry-inference` |
-| `psroc` | scikit-learn, matplotlib, plotly | `hvantk psroc` |
+| `ml` | scikit-learn, scipy | ML-backed analyses |
+| `ancestry` | scikit-learn, matplotlib, seaborn, scipy | `hvantk ancestry-inference` |
+| `psroc` | scikit-learn, matplotlib, plotly, scipy | `hvantk psroc` |
 | `hgc` | matplotlib, seaborn | `hvantk hgc` QC plots/reports |
-| `ptm` | cptac | CPTAC PTM downloads |
-| `constraint` | tspex, matplotlib, seaborn | `hvantk ptm constraint` |
+| `ptm` | cptac, sorted-nearest | CPTAC PTM downloads |
+| `constraint` | tspex, matplotlib, seaborn, scipy | `hvantk ptm constraint` |
+| `enrichex` | scipy, matplotlib, seaborn | `hvantk enrichex overlap` / `burden` |
+| `cohort` | scipy | `hvantk cohort burden` |
 | `duckdb` | duckdb | DuckDB-backed catalog queries |
-| `expression` | scanpy | `hvantk expression summarize` and `markers` |
+| `expression` | scanpy, scipy | `hvantk expression summarize` and `markers` |
 
 Three command paths need this extra:
 

--- a/docs_site/guide/hpc-migration.md
+++ b/docs_site/guide/hpc-migration.md
@@ -147,7 +147,8 @@ From: python:3.10-slim-bookworm
         zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libdeflate-dev \
         libopenblas-dev liblapack-dev liblz4-dev libhdf5-dev git
     # --- hvantk via Poetry, from the committed lock (reproducible) ---
-    pip install --no-cache-dir "poetry==1.8.*"
+    # >=2.0: pyproject.toml uses PEP 621 [project] metadata, which poetry 1.8 cannot read.
+    pip install --no-cache-dir "poetry>=2.0"
     cd /opt/hvantk
     poetry config virtualenvs.create false
     # install the locked deps + the extras you actually run (trim as needed):
@@ -179,8 +180,9 @@ From: python:3.10-slim-bookworm
 > Trim `--extras` to what you run. The core install omits scikit-learn / scipy / viz /
 > cptac / tspex / duckdb / scanpy — they live behind extras (`hgc`, `ptm`,
 > `ancestry`, `psroc`, `constraint`, `enrichex`, `cohort`, `ml`, `viz`, `duckdb`,
-> `interactive`, `expression`). The authoritative list is `[tool.poetry.extras]` in
-> `pyproject.toml`; this one is prose and is not machine-checked.
+> `interactive`, `expression`). The authoritative list is
+> `[project.optional-dependencies]` in `pyproject.toml`; this one is prose and is not
+> machine-checked.
 > `pyBigWig` is **not** a hvantk dependency — include it only for experiments that
 > query bigWig tracks. Genotype adjustment needs **no** extra: `annotate_adj` is
 > ported in-tree, so `gnomad` is no longer a dependency at all.

--- a/docs_site/guide/hpc-migration.md
+++ b/docs_site/guide/hpc-migration.md
@@ -152,7 +152,7 @@ From: python:3.10-slim-bookworm
     poetry config virtualenvs.create false
     # install the locked deps + the extras you actually run (trim as needed):
     poetry install --no-interaction --no-root \
-        --extras "hgc ptm qtl ancestry psroc constraint viz duckdb"
+        --extras "hgc ptm ancestry psroc constraint enrichex cohort viz duckdb"
     poetry install --no-interaction --only-root
     # experiment-only extras NOT in pyproject (e.g. PTM functionality pilot):
     pip install --no-cache-dir pyBigWig
@@ -176,9 +176,11 @@ From: python:3.10-slim-bookworm
     hail 0.2.137
 ```
 
-> Trim `--extras` to what you run. The core install omits scikit-learn / viz /
+> Trim `--extras` to what you run. The core install omits scikit-learn / scipy / viz /
 > cptac / tspex / duckdb / scanpy — they live behind extras (`hgc`, `ptm`,
-> `ancestry`, `psroc`, `constraint`, `ml`, `viz`, `duckdb`, `expression`).
+> `ancestry`, `psroc`, `constraint`, `enrichex`, `cohort`, `ml`, `viz`, `duckdb`,
+> `interactive`, `expression`). The authoritative list is `[tool.poetry.extras]` in
+> `pyproject.toml`; this one is prose and is not machine-checked.
 > `pyBigWig` is **not** a hvantk dependency — include it only for experiments that
 > query bigWig tracks. Genotype adjustment needs **no** extra: `annotate_adj` is
 > ported in-tree, so `gnomad` is no longer a dependency at all.
@@ -458,6 +460,6 @@ launching at scale.
   localhost.
 - **Stray system/conda Python** below the 3.10 floor → use the container's Python;
   never run hvantk against an unmanaged interpreter.
-- **Core install ≠ full toolkit** — install the right **extras** (`hgc ptm qtl
-  ancestry psroc constraint viz duckdb`) in the image.
+- **Core install ≠ full toolkit** — install the right **extras** (`hgc ptm
+  ancestry psroc constraint enrichex cohort viz duckdb`) in the image.
 - **Scratch is purged** — copy results to project/home before the window.

--- a/docs_site/guide/hpc-migration.md
+++ b/docs_site/guide/hpc-migration.md
@@ -62,6 +62,32 @@ unusually native-lib-heavy — Hail's JVM/Spark, `pysam` (htslib), `pyarrow` (Ar
 C++), `h5py` (HDF5), `scipy`/`scikit-learn` (BLAS/LAPACK), `duckdb` — so the
 container payoff is large.
 
+### 1.1 Keeping the cluster's clone current
+
+The cluster has its own bare repo, and the working repo pushes to it via a **second
+remote** called `hpc`. Local branches track `origin` (GitHub), so a bare `git push`
+**does not** update the cluster:
+
+| Remote | URL | Role |
+|---|---|---|
+| `origin` | `git@github.com:bigbio/hvantk.git` | GitHub; PRs and CI |
+| `hpc` | `hpc:/user/<user>/git/pyvatk.git` | bare repo on the cluster; the node-side clone pulls from here |
+
+After anything lands on `main` or `dev`:
+
+```bash
+# confirm it is a fast-forward, so no cluster-side commits are clobbered
+git fetch hpc
+git merge-base --is-ancestor hpc/dev origin/dev && echo "fast-forward, safe"
+
+git push hpc main dev
+```
+
+**This matters more than ordinary repo hygiene**, because the `.sif` is built from
+`poetry.lock` (§3.2). A stale cluster clone rebuilds the *previous* dependency set
+without any error — the build succeeds, it is just the wrong environment. Rebuild the
+image whenever `poetry.lock` changes, not only when `hvantk/` does.
+
 ---
 
 ## 2. Cluster facts to confirm on first login

--- a/hvantk/algorithms/enrichex/__init__.py
+++ b/hvantk/algorithms/enrichex/__init__.py
@@ -79,15 +79,6 @@ from hvantk.core.utils.gene_sets import (
     load_gene_sets_from_dict,
     load_marker_genes,
 )
-from hvantk.algorithms.visualization.base import encode_figure_to_base64
-from hvantk.algorithms.enrichex.plot import (
-    plot_burden_forest,
-    plot_burden_volcano,
-    plot_celltype_burden_heatmap,
-    plot_celltype_forest,
-    plot_enrichment_barplot,
-    plot_enrichment_dotplot,
-)
 from hvantk.algorithms.enrichex.overlap import (
     OverlapResult,
     compute_overlap_enrichment,
@@ -98,8 +89,65 @@ from hvantk.algorithms.enrichex.pipeline import (
     BurdenPipeline,
     BurdenRunResult,
 )
-from hvantk.algorithms.enrichex.report import generate_report
 from hvantk.algorithms.enrichex.simulation import check_type_i_error
+
+# Plotting and reporting are resolved on ATTRIBUTE ACCESS, not at package import (PEP 562).
+#
+# They used to be plain `from ... import` lines here, and that broke `hvantk` outright: the
+# CLI imports hvantk.algorithms.enrichex.constants, which runs this module, which pulled in
+# enrichex.plot / enrichex.report / visualization.base -- all three import matplotlib at
+# module scope. matplotlib is optional, so on a base install `pip install hvantk` produced a
+# console script where even `hvantk --help` raised ModuleNotFoundError. Every command paid
+# for plotting whether or not it plotted.
+#
+# The names below stay importable and stay in __all__, so this is not an API change; the
+# import simply happens on first use. The CLI never trips it -- overlap_cli and burden_cli
+# already import `generate_report` inside the functions that need it -- so a base install
+# now runs, and the `enrichex` extra (which carries matplotlib) is what a plotting caller
+# installs.
+_LAZY = {
+    "encode_figure_to_base64": "hvantk.algorithms.visualization.base",
+    "generate_report": "hvantk.algorithms.enrichex.report",
+    "plot_burden_forest": "hvantk.algorithms.enrichex.plot",
+    "plot_burden_volcano": "hvantk.algorithms.enrichex.plot",
+    "plot_celltype_burden_heatmap": "hvantk.algorithms.enrichex.plot",
+    "plot_celltype_forest": "hvantk.algorithms.enrichex.plot",
+    "plot_enrichment_barplot": "hvantk.algorithms.enrichex.plot",
+    "plot_enrichment_dotplot": "hvantk.algorithms.enrichex.plot",
+}
+
+
+_PLOTTING_HINT = (
+    "matplotlib is required for EnrichEx plotting and reporting, and is not part of the "
+    "base install. Install the 'enrichex' extra:\n"
+    "    pip install 'hvantk[enrichex]'\n"
+    "    poetry install --extras enrichex"
+)
+
+
+def __getattr__(name: str):
+    """Resolve the plotting/reporting exports on first access."""
+    module = _LAZY.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    try:
+        value = getattr(importlib.import_module(module), name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - needs matplotlib absent
+        # Same contract as require_scanpy (algorithms/expression/matrix_utils.py) and
+        # _require_matplotlib (algorithms/qtlcascade/plot.py): name the extra rather than
+        # leave the caller a bare ModuleNotFoundError. Deferring the import must not also
+        # degrade the message -- that was the review finding on the scanpy extra in #248.
+        if exc.name and exc.name.split(".")[0] in {"matplotlib", "seaborn"}:
+            raise ImportError(_PLOTTING_HINT) from exc
+        raise
+    globals()[name] = value  # cache, so the import cost is paid once
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY))
 
 try:
     from hvantk.algorithms.enrichex.simulation import generate_synthetic_burden_cohort

--- a/hvantk/skills/clingen/tests/drift_fingerprint.json
+++ b/hvantk/skills/clingen/tests/drift_fingerprint.json
@@ -19,7 +19,7 @@
     "Clingen-Gene-Disease-Summary.csv": "1bf26b3670c0d7ff2700df59ee07d1aff8a70bc2c63a7ffc062377312cccf440"
   },
   "extras": {
-    "content_length": "1113685"
+    "content_length": "1114672"
   },
-  "fetched_at": "2026-07-27T17:14:46.968306+00:00"
+  "fetched_at": "2026-08-04T08:36:42.849280+00:00"
 }

--- a/hvantk/skills/clinvar/tests/drift_fingerprint.json
+++ b/hvantk/skills/clinvar/tests/drift_fingerprint.json
@@ -1,11 +1,11 @@
 {
   "probe_version": 1,
-  "source_version": "Sun, 04 May 2026 12:08:00 GMT",
+  "source_version": "Tue, 28 Jul 2026 22:07:55 GMT",
   "headers": {
     "clinvar.vcf.gz": {
-      "content_length": "97582033"
+      "content_length": "193012905"
     }
   },
   "checksums": {},
-  "fetched_at": "2026-05-16T00:00:00+00:00"
+  "fetched_at": "2026-08-04T08:36:51.182152+00:00"
 }

--- a/hvantk/skills/gencc/tests/drift_fingerprint.json
+++ b/hvantk/skills/gencc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Sun, 26 Jul 2026 06:01:33 GMT",
+  "source_version": "Sun, 02 Aug 2026 06:02:19 GMT",
   "headers": {
     "gencc-submissions.tsv": [
       "sgc_id",
@@ -39,5 +39,5 @@
   "checksums": {
     "gencc-submissions.tsv": "6f07ac79f908bca4cfb99874e13d7d1ae5a9c839112baba0243b45fbc018f308"
   },
-  "fetched_at": "2026-07-27T17:10:04.227093+00:00"
+  "fetched_at": "2026-08-03T09:43:52.920327+00:00"
 }

--- a/hvantk/skills/gtex_eqtl/tests/drift_fingerprint.json
+++ b/hvantk/skills/gtex_eqtl/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "cl361-2-gd31acd02",
+  "source_version": "cl361-18-g22266644",
   "headers": {
     "gtex-portal-qtl-downloads": [
       "gtex-version",
@@ -10,13 +10,13 @@
     ]
   },
   "checksums": {
-    "gtex-portal-qtl-downloads": "64ac98e23e7563a94c9c6fc95a06404176c016e46bf44500ea44af327da1bc58"
+    "gtex-portal-qtl-downloads": "f4d9e7abc470f25e8a3c116ca738cc065057064d35a32c744a4465d29ffe8ff5"
   },
-  "fetched_at": "2026-05-18T10:31:35.600729+00:00",
+  "fetched_at": "2026-08-04T08:37:02.512856+00:00",
   "extras": {
-    "gtex_version": "cl361-2-gd31acd02",
-    "gtex_build_date": "3/13/2026, 2:21:21 PM",
-    "etag": "W/\"69b455fb-2424\"",
-    "last_modified": "Fri, 13 Mar 2026 18:22:51 GMT"
+    "gtex_version": "cl361-18-g22266644",
+    "gtex_build_date": "6/26/2026, 12:09:59 PM",
+    "etag": "W/\"6a3ea4e8-23af\"",
+    "last_modified": "Fri, 26 Jun 2026 16:12:24 GMT"
   }
 }

--- a/hvantk/skills/gwas_catalog/tests/drift_fingerprint.json
+++ b/hvantk/skills/gwas_catalog/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Tue, 28 Apr 2026 11:02:27 GMT",
+  "source_version": "Mon, 03 Aug 2026 13:52:00 GMT",
   "headers": {
     "gwas-catalog-associations-full.zip": [
       "ETag",
@@ -9,7 +9,7 @@
     ]
   },
   "checksums": {
-    "gwas-catalog-associations-full.zip": "10b1dfa16264605b4a1d10b690b99f57e13147b1dccb10cbe93fd0d2d9103d1a"
+    "gwas-catalog-associations-full.zip": "01eb84105c079cd97c7c56df20c9f7fbe36904c1b0b599e282050b85130e8de0"
   },
-  "fetched_at": "2026-05-18T09:52:48.536067+00:00"
+  "fetched_at": "2026-08-04T08:37:09.312137+00:00"
 }

--- a/hvantk/skills/hgnc/tests/drift_fingerprint.json
+++ b/hvantk/skills/hgnc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Fri, 15 May 2026 13:37:00 GMT",
+  "source_version": "Fri, 31 Jul 2026 12:53:50 GMT",
   "headers": {
     "hgnc_complete_set.txt": [
       "hgnc_id",
@@ -62,5 +62,5 @@
   "checksums": {
     "hgnc_complete_set.txt": "b8cfde58b7ea456e6f05482a4cf663fe329a6508a00809713167cc827200790c"
   },
-  "fetched_at": "2026-05-16T05:57:38.906136+00:00"
+  "fetched_at": "2026-08-04T08:37:16.272927+00:00"
 }

--- a/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
+++ b/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Sat, 16 May 2026 01:18:32 GMT",
+  "source_version": "Sat, 01 Aug 2026 00:28:36 GMT",
   "headers": {
     "cells_ucsc_datasets.json": [
       "local-catalog-hash"
@@ -13,7 +13,7 @@
   },
   "checksums": {
     "cells_ucsc_datasets.json": "f448a4b146a7137d21a7c376db4734f39cb56623de362c96da8f05e7e5e380be",
-    "dataset.json": "7c13884c398c7568f371d8c143130e59d24ab748f9055d89ce3e80cb41311c97"
+    "dataset.json": "91aceacd2ac9432bf83c4fc997e2d5aae0237bc171f3aad4a75ea3d1973b2bb1"
   },
-  "fetched_at": "2026-05-18T09:55:40.704219+00:00"
+  "fetched_at": "2026-08-04T08:37:23.836275+00:00"
 }

--- a/hvantk/tests/test_plugin_loader.py
+++ b/hvantk/tests/test_plugin_loader.py
@@ -83,7 +83,7 @@ def test_loading_same_directory_twice_is_idempotent():
 
     The skills-root scan and the entry-point scan can both surface the same
     in-tree plugin once it is listed in pyproject.toml's
-    `[tool.poetry.plugins."hvantk.providers"]` table. The loader must dedupe
+    `[project.entry-points."hvantk.providers"]` table. The loader must dedupe
     so this discovery overlap does not crash every CLI invocation.
     """
     reg = PluginRegistry()

--- a/hvantk/tests/test_pyproject_extras.py
+++ b/hvantk/tests/test_pyproject_extras.py
@@ -1,12 +1,33 @@
-"""Guard the declared Poetry extras/deps that runtime imports rely on.
+"""Guard the declared Poetry extras -- both what they contain and how they are documented.
 
 #198: cptac imports pyranges, whose compiled dep `sorted_nearest` is not always
 pulled by an extras install, breaking `import cptac`. The ptm extra must declare
 `sorted-nearest` explicitly.
+
+The docs half exists because the extras table is duplicated in THREE places -- the
+`[tool.poetry.extras]` block, README.md, and docs_site/getting-started/installation.md --
+and only the first is executable. Three separate hand-fixes to the two prose copies were
+needed in as many sessions, two of them caught only by adversarial review, and a fourth
+drift (psroc/ancestry/ml missing scipy, ptm missing sorted-nearest -- eight wrong cells)
+survived a release. A reader following a wrong table installs an environment that cannot run
+the command the table promises, which is exactly the failure `pip install hvantk[constraint]`
+produced. Deliberately non-Hail so it runs in the default suite.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+# (path, the column holding the dependency list). Both tables are markdown pipe tables whose
+# first column is the extra name in backticks; they differ in column order, so each doc names
+# its own header rather than assuming a position.
+DOC_TABLES = [
+    (ROOT / "README.md", "Pulls in"),
+    (ROOT / "docs_site" / "getting-started" / "installation.md", "Pulls in"),
+]
 
 
 def _load_pyproject() -> dict:
@@ -14,11 +35,104 @@ def _load_pyproject() -> dict:
         import tomllib as toml  # Python >= 3.11
     except ModuleNotFoundError:  # Python 3.10
         import tomli as toml
-    root = Path(__file__).resolve().parents[2]
-    return toml.loads((root / "pyproject.toml").read_text())
+    return toml.loads((ROOT / "pyproject.toml").read_text())
+
+
+def _declared_extras() -> dict[str, set[str]]:
+    return {k: set(v) for k, v in _load_pyproject()["tool"]["poetry"]["extras"].items()}
+
+
+def _parse_doc_table(path: Path, dep_header: str) -> dict[str, set[str]]:
+    """Extras -> dependency set, read from the first markdown table that has `dep_header`.
+
+    Only rows whose first cell is a single backticked token are treated as extras rows, so
+    prose tables elsewhere in the file cannot be picked up by accident.
+    """
+    rows: dict[str, set[str]] = {}
+    header_cols: list[str] | None = None
+    done = False
+    for line in path.read_text().splitlines():
+        if not line.strip().startswith("|"):
+            # The table ENDS at the first non-table line. Without this the parser would run
+            # to end of file and read any later markdown table as more extras rows, using the
+            # extras table's column index -- so a future unrelated table with a backticked
+            # first column would silently overwrite a real row and mask the very drift this
+            # test exists to catch.
+            if header_cols is not None:
+                done = True
+            continue
+        if done:
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if header_cols is None:
+            if dep_header in cells:
+                header_cols = cells
+            continue
+        if set("".join(cells)) <= set("-: "):        # the |---|---| separator
+            continue
+        name = re.fullmatch(r"`([a-z0-9-]+)`", cells[0])
+        if not name:
+            continue
+        deps = cells[header_cols.index(dep_header)]
+        rows[name.group(1)] = {d.strip().strip("`") for d in deps.split(",") if d.strip()}
+    assert header_cols is not None, f"{path.name}: no table with a {dep_header!r} column"
+    return rows
+
+
+def test_parser_stops_at_the_end_of_the_extras_table(tmp_path):
+    """A later table must not be read as more extras rows.
+
+    Regression guard: the first version of this parser never reset on a non-table line, so it
+    consumed the rest of the file. A second table whose first column is a backticked token --
+    an ordinary thing to add to these docs -- would overwrite a real row using the extras
+    table's column index, turning this guard into a source of false passes and false failures.
+    """
+    doc = tmp_path / "doc.md"
+    doc.write_text(
+        "| Extra | Pulls in |\n"
+        "|---|---|\n"
+        "| `viz` | matplotlib |\n"
+        "\n"
+        "Some prose between the tables.\n"
+        "\n"
+        "| Command | Pulls in |\n"
+        "|---|---|\n"
+        "| `viz` | something-else |\n"
+    )
+    assert _parse_doc_table(doc, "Pulls in") == {"viz": {"matplotlib"}}
 
 
 def test_ptm_extra_includes_sorted_nearest():
     poetry = _load_pyproject()["tool"]["poetry"]
     assert "sorted-nearest" in poetry["extras"]["ptm"]
     assert "sorted-nearest" in poetry["dependencies"]
+
+
+def test_every_extra_dependency_is_declared_optional():
+    """An extra naming a package that is not an optional dependency installs nothing."""
+    poetry = _load_pyproject()["tool"]["poetry"]
+    deps = poetry["dependencies"]
+    for extra, packages in poetry["extras"].items():
+        for pkg in packages:
+            assert pkg in deps, f"extra {extra!r} names undeclared dependency {pkg!r}"
+            spec = deps[pkg]
+            assert isinstance(spec, dict) and spec.get("optional") is True, \
+                f"extra {extra!r} names {pkg!r}, which is not optional = true"
+
+
+@pytest.mark.parametrize("path,dep_header", DOC_TABLES, ids=lambda p: getattr(p, "name", p))
+def test_documented_extras_match_pyproject(path: Path, dep_header: str):
+    declared = _declared_extras()
+    documented = _parse_doc_table(path, dep_header)
+
+    missing = sorted(set(declared) - set(documented))
+    assert not missing, f"{path.name}: extras declared but undocumented: {missing}"
+    unknown = sorted(set(documented) - set(declared))
+    assert not unknown, f"{path.name}: extras documented but not declared: {unknown}"
+
+    wrong = {
+        name: {"documented": sorted(documented[name]), "declared": sorted(declared[name])}
+        for name in sorted(declared)
+        if documented[name] != declared[name]
+    }
+    assert not wrong, f"{path.name}: extras table disagrees with pyproject: {wrong}"

--- a/hvantk/tests/test_pyproject_extras.py
+++ b/hvantk/tests/test_pyproject_extras.py
@@ -5,7 +5,8 @@ pulled by an extras install, breaking `import cptac`. The ptm extra must declare
 `sorted-nearest` explicitly.
 
 The docs half exists because the extras table is duplicated in THREE places -- the
-`[tool.poetry.extras]` block, README.md, and docs_site/getting-started/installation.md --
+`[project.optional-dependencies]` table, README.md, and
+docs_site/getting-started/installation.md --
 and only the first is executable. Three separate hand-fixes to the two prose copies were
 needed in as many sessions, two of them caught only by adversarial review, and a fourth
 drift (psroc/ancestry/ml missing scipy, ptm missing sorted-nearest -- eight wrong cells)
@@ -38,8 +39,20 @@ def _load_pyproject() -> dict:
     return toml.loads((ROOT / "pyproject.toml").read_text())
 
 
+def _optional_dependencies() -> dict[str, list[str]]:
+    """Extras as PEP 621 declares them: name -> list of full requirement specifiers."""
+    return _load_pyproject()["project"]["optional-dependencies"]
+
+
+def _requirement_name(spec: str) -> str:
+    """`scikit-learn>=1.4,<2.0` -> `scikit-learn`. Bare names pass through unchanged."""
+    return re.split(r"[<>=!~;@\[\s]", spec, maxsplit=1)[0].strip()
+
+
 def _declared_extras() -> dict[str, set[str]]:
-    return {k: set(v) for k, v in _load_pyproject()["tool"]["poetry"]["extras"].items()}
+    """Extras as bare package names, for comparison against the prose tables."""
+    return {k: {_requirement_name(s) for s in v}
+            for k, v in _optional_dependencies().items()}
 
 
 def _parse_doc_table(path: Path, dep_header: str) -> dict[str, set[str]]:
@@ -103,21 +116,31 @@ def test_parser_stops_at_the_end_of_the_extras_table(tmp_path):
 
 
 def test_ptm_extra_includes_sorted_nearest():
-    poetry = _load_pyproject()["tool"]["poetry"]
-    assert "sorted-nearest" in poetry["extras"]["ptm"]
-    assert "sorted-nearest" in poetry["dependencies"]
+    assert "sorted-nearest" in _declared_extras()["ptm"]
 
 
-def test_every_extra_dependency_is_declared_optional():
-    """An extra naming a package that is not an optional dependency installs nothing."""
-    poetry = _load_pyproject()["tool"]["poetry"]
-    deps = poetry["dependencies"]
-    for extra, packages in poetry["extras"].items():
-        for pkg in packages:
-            assert pkg in deps, f"extra {extra!r} names undeclared dependency {pkg!r}"
-            spec = deps[pkg]
-            assert isinstance(spec, dict) and spec.get("optional") is True, \
-                f"extra {extra!r} names {pkg!r}, which is not optional = true"
+def test_no_extra_duplicates_a_base_dependency():
+    """A package in [project.dependencies] is always installed; gating it behind an extra
+    would advertise a choice that does not exist."""
+    base = {_requirement_name(s) for s in _load_pyproject()["project"]["dependencies"]}
+    for extra, packages in _declared_extras().items():
+        overlap = sorted(packages & base)
+        assert not overlap, f"extra {extra!r} re-declares base dependencies {overlap}"
+
+
+def test_extras_agree_on_every_shared_constraint():
+    """PEP 621 puts the full specifier in each extra, so `scipy>=1.8` is written six times
+    and `scikit-learn>=1.4,<2.0` three times. Nothing stops one from being re-pinned and the
+    rest left behind -- an inconsistency that would resolve differently depending on which
+    extra a user installed. This is the drift the old [tool.poetry.dependencies] split could
+    not have, and it arrived with the migration, so it is guarded here."""
+    seen: dict[str, dict[str, str]] = {}
+    for extra, specs in _optional_dependencies().items():
+        for spec in specs:
+            seen.setdefault(_requirement_name(spec), {})[extra] = spec
+    for pkg, by_extra in sorted(seen.items()):
+        distinct = set(by_extra.values())
+        assert len(distinct) == 1, f"{pkg} is spelled inconsistently across extras: {by_extra}"
 
 
 @pytest.mark.parametrize("path,dep_header", DOC_TABLES, ids=lambda p: getattr(p, "name", p))

--- a/poetry.lock
+++ b/poetry.lock
@@ -5935,9 +5935,11 @@ remote = ["fsspec (>=2023.10.0)", "obstore (>=0.5.1)"]
 
 [extras]
 ancestry = ["matplotlib", "scikit-learn", "scipy", "seaborn"]
-constraint = ["matplotlib", "seaborn", "tspex"]
+cohort = ["scipy"]
+constraint = ["matplotlib", "scipy", "seaborn", "tspex"]
 duckdb = ["duckdb"]
-expression = ["scanpy"]
+enrichex = ["matplotlib", "scipy", "seaborn"]
+expression = ["scanpy", "scipy"]
 hgc = ["matplotlib", "seaborn"]
 interactive = ["plotly"]
 ml = ["scikit-learn", "scipy"]
@@ -5948,4 +5950,4 @@ viz = ["matplotlib", "plotly", "seaborn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0.0"
-content-hash = "feac0f9f42756b4ecf0b2d754c1785fcf6889b75d12c3b9f0619f5ddafbd8d72"
+content-hash = "399feafeb18269ff1e3ecabd1bad77ccd0bb574fc5c526883616927b3d13d8ca"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3352,7 +3352,7 @@ description = "A Python package for describing statistical models and for buildi
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"expression\" or extra == \"ptm\""
+markers = "extra == \"ptm\" or extra == \"expression\""
 files = [
     {file = "patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a"},
     {file = "patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0"},
@@ -5259,7 +5259,7 @@ description = "Statistical computations and models for Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"expression\" or extra == \"ptm\""
+markers = "extra == \"ptm\" or extra == \"expression\""
 files = [
     {file = "statsmodels-0.14.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9fc2b5cdc0c95cba894849651fec1fa1511d365e3eb72b0cc75caac44077cd48"},
     {file = "statsmodels-0.14.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b8d96b0bbaeabd3a557c35cc7249baa9cfbc6dd305c32a9f2cbdd7f46c037e7f"},
@@ -5950,4 +5950,4 @@ viz = ["matplotlib", "plotly", "seaborn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0.0"
-content-hash = "399feafeb18269ff1e3ecabd1bad77ccd0bb574fc5c526883616927b3d13d8ca"
+content-hash = "94b316d095fa5bea930c0d19d88f0db71d2be966cf85d5e492795b86f66a5593"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,20 @@
-[tool.poetry]
+# PEP 621 metadata. Migrated off the `[tool.poetry.*]` spelling 2026-08-04, which poetry 2.x
+# reported as 13 deprecation warnings on every `poetry check`. The migration had to come
+# first: the `poetry>=2.0,<3.0` pin in the lockfile CI job was defensive against a future
+# major promoting those warnings to errors, and that pin can only be relaxed once nothing
+# deprecated is left. Poetry-specific keys (packages/include/exclude, dependency groups)
+# stay under [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
+[project]
 name = "hvantk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hail-based toolkit for multi-omics variant annotation and analysis"
-authors = ["Yasset Perez-Riverol <ypriverol@gmail.com>",
-           "Enrique Audain <enrique.audain@uni-oldenburg.de>"]
+authors = [
+    { name = "Yasset Perez-Riverol", email = "ypriverol@gmail.com" },
+    { name = "Enrique Audain", email = "enrique.audain@uni-oldenburg.de" },
+]
 license = "MIT"
 readme = "README.md"
+requires-python = ">=3.10.0,<4.0.0"
 keywords = [
     "multiomics",
     "annotation-toolkit",
@@ -14,6 +23,36 @@ keywords = [
     "genotype-combining",
     "joint-genotyping"
 ]
+# PEP 508 specifiers, so poetry's caret shorthand is spelled out. These are exact
+# equivalents, not re-pins: ^8.1.3 == >=8.1.3,<9.0.0 and ^2.0.0 == >=2.0.0,<3.0.0. The lock
+# resolves to the same 187 packages as before the migration.
+dependencies = [
+    "hail>=0.2.137",
+    "click>=8.1.3,<9.0.0",
+    "requests",
+    "tqdm",
+    "pandas>=2.0.0,<3.0.0",
+    # Imported at module scope in ~68 modules. It has always arrived transitively via
+    # pandas/hail, but code that imports a package directly should declare it -- otherwise
+    # the day pandas drops or re-pins numpy, the break surfaces somewhere unrelated.
+    "numpy>=1.23",
+    "pyarrow>=14.0",
+    "PyYAML",
+    "jsonschema>=4.0",
+    "psutil",
+    "pysam>=0.22",
+    "certifi",
+    "anndata>=0.10.0",
+]
+
+[project.urls]
+GitHub = "https://github.com/bigbio/hvantk/"
+LICENSE = "https://github.com/bigbio/hvantk/blob/main/LICENSE"
+
+[project.scripts]
+hvantk = "hvantk.hvantk:main"
+
+[tool.poetry]
 include = [
   { path = "hvantk/skills/**/plugin.yaml", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/SKILL.md", format = ["sdist", "wheel"] },
@@ -48,39 +87,11 @@ exclude = [
 # drift_fingerprint.json stays -- it is included on purpose, being what `hvantk drift`
 # compares a live probe against.
 
-[tool.poetry.dependencies]
-python = ">=3.10.0,<4.0.0"
-hail = ">=0.2.137"
-click = "^8.1.3"
-requests = "*"
-tqdm = "*"
-pandas = "^2.0.0"
-# Imported at module scope in ~68 modules. It has always arrived transitively via
-# pandas/hail, but code that imports a package directly should declare it -- otherwise the
-# day pandas drops or re-pins numpy, the break surfaces somewhere unrelated.
-numpy = ">=1.23"
-pyarrow = ">=14.0"
-PyYAML = "*"
-jsonschema = ">=4.0"
-psutil = "*"
-pysam = ">=0.22"
-certifi = "*"
-anndata = ">=0.10.0"
-# OPTIONAL, unlike anndata: scanpy pulls numba -> llvmlite, and llvmlite ships no
-# x86_64 macOS wheel from 0.47 on, so a base-level declaration makes the whole
-# package uninstallable on Intel Macs -- including for the ~99% of the toolkit that
-# never touches expression. Both import sites (algorithms/expression/matrix_utils.py,
-# tools/expression/summarize_expression_cli.py) already import it inside the function
-# body, so nothing breaks at import time when it is absent. anndata is pure Python and
-# stays in the base install.
-scanpy = { version = ">=1.10.0", optional = true }
-# ^1.4, not ^1.3: rerank's opt-in RFECV step wraps RandomForestClassifier, which only
-# tolerates NaN from 1.4 onward, and these feature matrices are 20-50% missing by design.
-# The floor stays as long as `SelectionPolicy(wrapper="rfecv")` is reachable -- it is now
-# off by default, not removed. Drop to ^1.3 only if the wrapper is deleted outright.
-scikit-learn = { version = "^1.4", optional = true }
-# Declared explicitly rather than leaned on as a transitive dep of scikit-learn, because
-# relying on a transitive dependency is how it silently breaks later.
+# Optional dependencies. In PEP 621 an extra carries the full specifier, so a constraint
+# repeated across extras (scipy in six, scikit-learn in three) is a drift surface that the
+# old [tool.poetry.dependencies] + [tool.poetry.extras] split did not have -- one extra could
+# be re-pinned and the others left behind, silently. test_pyproject_extras.py asserts every
+# extra spells the same package identically, so that divergence fails the build.
 #
 # scipy is NOT only needed where sklearn is. Three modules `from scipy...` at MODULE scope
 # with no sklearn nearby, and they sit on three DIFFERENT commands -- check the call graph
@@ -90,52 +101,42 @@ scikit-learn = { version = "^1.4", optional = true }
 #   algorithms/burden/fet.py         -> `hvantk cohort burden`       -> cohort extra
 # fet.py is NOT reached by `hvantk enrichex burden`: its only importer is
 # algorithms/burden/pipeline.py, which is imported by tools/cohort/cohort_cli.py alone.
-# (algorithms/enrichex/burden.py imports scipy at CALL time only, so it does not gate import.)
-# Until 2026-08-03 `constraint` omitted scipy, so `pip install hvantk[constraint]` produced a
-# documented extra whose own command still raised ModuleNotFoundError, and enrichex and cohort
-# had no extra at all.
 #
-# A call-time require_scipy() guard (cf. require_scanpy in algorithms/expression/matrix_utils)
-# would additionally turn a BASE install's bare ModuleNotFoundError into a message naming the
-# extra. That is a separate improvement: it changes the error text, not what any extra
-# installs, so it is not needed to make these extras correct.
-scipy = { version = ">=1.8", optional = true }
-matplotlib = { version = "*", optional = true }
-seaborn = { version = "*", optional = true }
-plotly = { version = "*", optional = true }
-duckdb = { version = ">=0.9.0", optional = true }
-cptac = { version = "*", optional = true }
-# sorted-nearest is a compiled runtime dep of pyranges (imported by cptac); an
-# extras install doesn't reliably pull it, so declare it explicitly. Import name
-# is `sorted_nearest`. Already resolved in poetry.lock (0.0.41).
-sorted-nearest = { version = "*", optional = true }
-tspex = { version = ">=0.6.0", optional = true }
-
-[tool.poetry.extras]
+# scikit-learn floor is >=1.4, not >=1.3: rerank's opt-in RFECV step wraps
+# RandomForestClassifier, which only tolerates NaN from 1.4 onward, and these feature
+# matrices are 20-50% missing by design.
+#
+# scanpy is optional, unlike anndata: it pulls numba -> llvmlite, which ships no x86_64 macOS
+# wheel from 0.47 on, so a base-level declaration would make the package uninstallable on
+# Intel Macs -- including for the ~99% of the toolkit that never touches expression.
+#
+# sorted-nearest is a compiled runtime dep of pyranges (imported by cptac); an extras install
+# doesn't reliably pull it, so it is declared explicitly. Import name is `sorted_nearest`.
+[project.optional-dependencies]
 viz = ["matplotlib", "seaborn", "plotly"]
-duckdb = ["duckdb"]
+duckdb = ["duckdb>=0.9.0"]
 interactive = ["plotly"]
 hgc = ["matplotlib", "seaborn"]
-psroc = ["matplotlib", "plotly", "scikit-learn", "scipy"]
+psroc = ["matplotlib", "plotly", "scikit-learn>=1.4,<2.0", "scipy>=1.8"]
 ptm = ["cptac", "sorted-nearest"]
-constraint = ["tspex", "matplotlib", "seaborn", "scipy"]
+constraint = ["tspex>=0.6.0", "matplotlib", "seaborn", "scipy>=1.8"]
 # enrichex needs matplotlib as well as scipy. scipy is eager -- overlap.py imports
 # scipy.stats at module scope, so `hvantk enrichex overlap` needs it to import at all.
 # matplotlib is no longer eager: enrichex/__init__ resolves plot.py / report.py through a
 # PEP 562 __getattr__, so a base install can run the CLI. It is still in this extra because
 # the plotting and --generate-report paths need it at call time, and accessing a plotting
 # name without it raises an ImportError naming this extra.
-enrichex = ["scipy", "matplotlib", "seaborn"]
+enrichex = ["scipy>=1.8", "matplotlib", "seaborn"]
 # cohort covers `hvantk cohort burden`, whose pipeline reaches algorithms/burden/fet.py and
 # its module-scope `from scipy.stats import fisher_exact`. scipy alone: nothing on that path
 # imports matplotlib.
-cohort = ["scipy"]
-ancestry = ["scikit-learn", "matplotlib", "seaborn", "scipy"]
-ml = ["scikit-learn", "scipy"]
+cohort = ["scipy>=1.8"]
+ancestry = ["scikit-learn>=1.4,<2.0", "matplotlib", "seaborn", "scipy>=1.8"]
+ml = ["scikit-learn>=1.4,<2.0", "scipy>=1.8"]
 # scanpy already depends on scipy, so listing it changes no resolution -- but
 # visualization/expression/anndata.py imports scipy.sparse directly, and this file's rule is
 # to declare what is imported rather than inherit it from a transitive edge that can move.
-expression = ["scanpy", "scipy"]
+expression = ["scanpy>=1.10.0", "scipy>=1.8"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
@@ -152,7 +153,7 @@ mkdocs = "*"
 mkdocs-material = "*"
 ipykernel = "^7.2.0"
 
-[tool.poetry.plugins."hvantk.providers"]
+[project.entry-points."hvantk.providers"]
 # In-tree plugins register themselves the same way as external ones.
 # Only providers migrated to the plugin layout appear here.
 hgnc = "hvantk.skills.hgnc"
@@ -173,12 +174,11 @@ uniprot-ptm = "hvantk.skills.uniprot_ptm"
 testpaths = ["hvantk/tests", "hvantk/skills"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+# >=2.0, not >=1.0: PEP 621 `[project]` metadata is only read by poetry-core 2.x, and the
+# `license = "MIT"` SPDX expression needs its PEP 639 support. Against an older poetry-core
+# this file's name/version/dependencies would simply not be found, since [tool.poetry] no
+# longer carries them -- a build that fails, or worse produces a wheel with empty metadata.
+# The floor was left at 1.0.0 through the migration and only caught in review; CI masked it
+# because the packaging-smoke job installs a modern poetry explicitly.
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.urls]
-GitHub = "https://github.com/bigbio/hvantk/"
-LICENSE = "https://github.com/bigbio/hvantk/blob/main/LICENSE"
-
-[tool.poetry.scripts]
-hvantk = "hvantk.hvantk:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,14 +64,23 @@ scikit-learn = { version = "^1.4", optional = true }
 # Declared explicitly rather than leaned on as a transitive dep of scikit-learn, because
 # relying on a transitive dependency is how it silently breaks later.
 #
-# NOTE, and it is not fully true that scipy only matters where sklearn does:
-# algorithms/burden/fet.py, algorithms/enrichex/overlap.py and algorithms/ptm/constraint.py
-# all `from scipy...` at MODULE scope without sklearn anywhere nearby, so `hvantk enrichex
-# burden|overlap` and `hvantk ptm constraint` raise ModuleNotFoundError on a base install.
-# That is pre-existing -- scipy was previously not declared here at all, so those paths were
-# already broken without an extra -- and keeping scipy optional does not make it worse. The
-# real fix is either a gating extra for enrichex/ptm or call-time imports with a
-# require_scipy() guard (cf. require_scanpy in algorithms/expression/matrix_utils.py).
+# scipy is NOT only needed where sklearn is. Three modules `from scipy...` at MODULE scope
+# with no sklearn nearby, and they sit on three DIFFERENT commands -- check the call graph
+# before assigning one to an extra, because the obvious mapping is wrong:
+#   algorithms/ptm/constraint.py     -> `hvantk ptm constraint`      -> constraint extra
+#   algorithms/enrichex/overlap.py   -> `hvantk enrichex overlap`    -> enrichex extra
+#   algorithms/burden/fet.py         -> `hvantk cohort burden`       -> cohort extra
+# fet.py is NOT reached by `hvantk enrichex burden`: its only importer is
+# algorithms/burden/pipeline.py, which is imported by tools/cohort/cohort_cli.py alone.
+# (algorithms/enrichex/burden.py imports scipy at CALL time only, so it does not gate import.)
+# Until 2026-08-03 `constraint` omitted scipy, so `pip install hvantk[constraint]` produced a
+# documented extra whose own command still raised ModuleNotFoundError, and enrichex and cohort
+# had no extra at all.
+#
+# A call-time require_scipy() guard (cf. require_scanpy in algorithms/expression/matrix_utils)
+# would additionally turn a BASE install's bare ModuleNotFoundError into a message naming the
+# extra. That is a separate improvement: it changes the error text, not what any extra
+# installs, so it is not needed to make these extras correct.
 scipy = { version = ">=1.8", optional = true }
 matplotlib = { version = "*", optional = true }
 seaborn = { version = "*", optional = true }
@@ -91,10 +100,22 @@ interactive = ["plotly"]
 hgc = ["matplotlib", "seaborn"]
 psroc = ["matplotlib", "plotly", "scikit-learn", "scipy"]
 ptm = ["cptac", "sorted-nearest"]
-constraint = ["tspex", "matplotlib", "seaborn"]
+constraint = ["tspex", "matplotlib", "seaborn", "scipy"]
+# enrichex needs matplotlib as well as scipy: overlap.py imports scipy.stats and
+# plot.py / report.py import matplotlib, all at module scope, and enrichex/__init__ pulls
+# both in unconditionally -- so a scipy-only extra would break the moment `hvantk enrichex`
+# drew anything.
+enrichex = ["scipy", "matplotlib", "seaborn"]
+# cohort covers `hvantk cohort burden`, whose pipeline reaches algorithms/burden/fet.py and
+# its module-scope `from scipy.stats import fisher_exact`. scipy alone: nothing on that path
+# imports matplotlib.
+cohort = ["scipy"]
 ancestry = ["scikit-learn", "matplotlib", "seaborn", "scipy"]
 ml = ["scikit-learn", "scipy"]
-expression = ["scanpy"]
+# scanpy already depends on scipy, so listing it changes no resolution -- but
+# visualization/expression/anndata.py imports scipy.sparse directly, and this file's rule is
+# to declare what is imported rather than inherit it from a transitive edge that can move.
+expression = ["scanpy", "scipy"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 # PEP 621 metadata. Migrated off the `[tool.poetry.*]` spelling 2026-08-04, which poetry 2.x
-# reported as 13 deprecation warnings on every `poetry check`. The migration had to come
+# reported as 11 deprecation warnings on every `poetry check`. The migration had to come
 # first: the `poetry>=2.0,<3.0` pin in the lockfile CI job was defensive against a future
 # major promoting those warnings to errors, and that pin can only be relaxed once nothing
-# deprecated is left. Poetry-specific keys (packages/include/exclude, dependency groups)
-# stay under [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
+# deprecated is left. Poetry-specific keys (include/exclude, dependency groups) stay under
+# [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
 [project]
 name = "hvantk"
 version = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,19 +16,37 @@ keywords = [
 ]
 include = [
   { path = "hvantk/skills/**/plugin.yaml", format = ["sdist", "wheel"] },
-  { path = "hvantk/skills/**/*.py", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/SKILL.md", format = ["sdist", "wheel"] },
   { path = "hvantk/skills/**/catalog/*.json", format = ["sdist", "wheel"] },
-  { path = "hvantk/skills/**/tests/drift_fingerprint.json", format = ["sdist", "wheel"] },
+  # multi-dataset providers suffix this per dataset (drift_fingerprint_samples.json)
+  { path = "hvantk/skills/**/tests/drift_fingerprint*.json", format = ["sdist", "wheel"] },
 ]
+# These excludes were previously defeated and shipped 43.3 MB of test data in a 46.2 MB
+# wheel -- 339 files under a tests/ dir, including a 14.7 MB VDS zip and an 11.4 MB
+# expression-atlas fixture. Two causes, both fixed here:
+#   1. `hvantk/tests/**` was never listed at all (190 of those files), so the top-level test
+#      suite and its testdata/ shipped to every user in full.
+#   2. The skills excludes were overridden by the explicit `include` of
+#      "hvantk/skills/**/*.py" above: a path named by `include` wins, so test_*.py under a
+#      skill came back in regardless of being excluded. The include is now narrowed to the
+#      non-.py data files it exists for -- ordinary package modules under hvantk/ need no
+#      include, since `packages` already carries them.
+# Nothing in CI built a wheel, so none of this was visible. The packaging-smoke job added in
+# this change asserts wheel hygiene so it cannot regress silently again.
 exclude = [
+    "hvantk/tests/**",
     "hvantk/skills/**/tests/test_*.py",
     "hvantk/skills/**/tests/conftest.py",
     "hvantk/skills/**/tests/__init__.py",
     "hvantk/skills/**/tests/data/**",
+    "hvantk/skills/**/tests/testdata/**",
     "hvantk/skills/**/tests/snapshots/**",
     "hvantk/skills/**/tests/fixtures/**",
 ]
+# `testdata` (above) was the name actually used by the skills; the pre-existing list named
+# only data/, snapshots/ and fixtures/, so per-skill fixture VCF/TSV/parquet files shipped.
+# drift_fingerprint.json stays -- it is included on purpose, being what `hvantk drift`
+# compares a live probe against.
 
 [tool.poetry.dependencies]
 python = ">=3.10.0,<4.0.0"
@@ -101,10 +119,12 @@ hgc = ["matplotlib", "seaborn"]
 psroc = ["matplotlib", "plotly", "scikit-learn", "scipy"]
 ptm = ["cptac", "sorted-nearest"]
 constraint = ["tspex", "matplotlib", "seaborn", "scipy"]
-# enrichex needs matplotlib as well as scipy: overlap.py imports scipy.stats and
-# plot.py / report.py import matplotlib, all at module scope, and enrichex/__init__ pulls
-# both in unconditionally -- so a scipy-only extra would break the moment `hvantk enrichex`
-# drew anything.
+# enrichex needs matplotlib as well as scipy. scipy is eager -- overlap.py imports
+# scipy.stats at module scope, so `hvantk enrichex overlap` needs it to import at all.
+# matplotlib is no longer eager: enrichex/__init__ resolves plot.py / report.py through a
+# PEP 562 __getattr__, so a base install can run the CLI. It is still in this extra because
+# the plotting and --generate-report paths need it at call time, and accessing a plotting
+# name without it raises an ImportError naming this extra.
 enrichex = ["scipy", "matplotlib", "seaborn"]
 # cohort covers `hvantk cohort burden`, whose pipeline reaches algorithms/burden/fet.py and
 # its module-scope `from scipy.stats import fisher_exact`. scipy alone: nothing on that path

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # run still goes green -- which is exactly how the rerank tests came to be skipped on this
 # path while passing under conda.
 
-# --- base runtime, mirroring [tool.poetry.dependencies] ---
+# --- base runtime, mirroring [project.dependencies] ---
 hail>=0.2.137
 click>=8.1.3,<9
 requests


### PR DESCRIPTION
Release `0.2.0` — 24 commits, 12 merged PRs, 20 files.

This is the **first tagged release**. The repo has no tags at all; `v0.2.0` will be its first, applied to this merge commit. `0.1.0` had sat on `main` since 2025-05-04 across 61 merges, so no release in fifteen months was distinguishable from any other by version.

## Packaging — the user-visible fixes

- **`pip install hvantk` produced a CLI that could not start.** `hvantk --help` raised `ModuleNotFoundError` on a base install, because the enrichex package imported matplotlib at module scope and matplotlib is optional. Now resolved through a PEP 562 `__getattr__`, so the plotting names load on access and a base install runs the CLI. Accessing one without matplotlib raises an `ImportError` that names the extra to install. (#255)
- **The wheel shipped 43.3 MB of test data in a 46.2 MB wheel** — 339 files including a 14.7 MB VDS zip and an 11.4 MB expression-atlas fixture. Two independent causes: `hvantk/tests/**` was never in `exclude` at all, and the skills excludes were being overridden by an `include` glob, since a path named by `include` wins. **Now 2.86 MB.** (#255)
- **Four extras installed environments that could not run their own commands.** `pip install hvantk[constraint]` gave you `hvantk ptm constraint`, which imports `scipy` at module scope — and `constraint` did not declare scipy. Every command with a module-scope scipy import now has an extra that installs it, including two new extras (`enrichex`, `cohort`) for commands that previously had none. The call graph is not what it looks like: `algorithms/burden/fet.py` is reached by `hvantk cohort burden`, *not* by `hvantk enrichex burden`. (#254)

## Metadata and versioning

- `pyproject.toml` migrated to PEP 621 `[project]`, clearing **11 deprecation warnings** on every `poetry check` — now "All set!". Resolution-neutral, verified by name+version set rather than count: the lock resolves to the same 187 packages before and after, none added, none removed. (#256)
- `build-system.requires` raised to `poetry-core>=2.0.0`, which PEP 621 metadata actually requires — the floor was left at `1.0.0` through the migration and caught only in review. CI had masked it because the packaging job installs a modern poetry explicitly. (#256)
- Version `0.1.0` → `0.2.0`. (#256)

## CI — the gaps that let all of the above stay green

Nothing in CI installed the package, so `pytest` always imported `hvantk` from the checkout directory. The console script, the provider entry points, and the packaging globs were therefore never exercised — all three were broken, and CI was green throughout.

- New `packaging-smoke` job: builds the wheel, checks its contents both directions, installs into a clean venv with **no extras**, and runs the CLI from a directory where the checkout is not importable. It asserts the plugin-manifest count rather than just the exit code, since a glob that drops manifests would still let `plugins list` exit 0 with a short list. (#255)
- New `hgc-hail` job. `hvantk/tests/hgc/` ran in no job at all — `pytest.ini` deselects the `hail` marker and the existing hail job is path-scoped — so `test_convert_vds_to_mt`, the only end-to-end exercise of the `adj` code ported out of the gnomad dependency, ran only under a manual invocation. (#255)
- `permissions: contents: read` set at workflow level; version matrix extended to trigger on `dev`. (#255)

## Data baselines

Seven drift fingerprints accepted (#236–#241, #245): HGNC May 15 → Jul 31, GTEx `cl361-2` → `cl361-18`, plus ClinVar, ClinGen, GenCC, GWAS Catalog, UCSC Cell Browser.

**These record that upstream moved — they do not rebuild anything.** Artifacts built from the older data are still stale, and `hvantk drift` will now report clean for these datasets. GTEx skipping roughly four months of releases is the one most worth a rebuild.

## Verification

All nine checks green on `dev`: both hail jobs, `packaging-smoke`, the 3.10/3.11/3.12 matrix, `build-linux`, and `poetry.lock in sync`. Codacy is excluded deliberately — it reports findings through neither GitHub review comments nor check annotations (both endpoints verified empty), its gate is set to zero new issues at any severity, and it is not a required check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Released version 0.2.0 with feature selection, provider plugins, plugin management, drift detection, reprocessing, and scheduled CI capabilities.
  - Added support for optional installation extras across machine learning, ancestry, cohort, expression, and other workflows.
  - Improved startup behavior by loading optional plotting and reporting features only when needed.

- **Documentation**
  - Updated installation, HPC migration, README, and changelog documentation with current extras, packaging, and deployment guidance.

- **Bug Fixes**
  - Improved package validation and smoke testing to verify clean installation, CLI availability, manifests, and packaged contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->