### PR TITLE
fix(drift): install the ptm extra and retry rate-limited probes

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -61,9 +61,17 @@ jobs:
         run: |
           conda env update --file environment.yml --name base
 
+      # The `ptm` extra, not a bare install. The cptac probe fingerprints the INSTALLED
+      # cptac version (importlib.metadata) against PayneLab's latest GitHub release, so
+      # the package has to be present for the probe to mean anything -- and `cptac` is
+      # declared in the `ptm` extra. Under a bare `pip install -e .` both cptac:expression
+      # and cptac:phospho raised "The 'cptac' Python package is not installed; cannot
+      # fingerprint" on EVERY run, so upstream CPTAC drift has never once been detectable.
+      # Of the 22 probes these two are the only ones needing an extra; the other 20 use
+      # requests or the stdlib alone.
       - name: Install hvantk in development mode
         run: |
-          pip install -e .
+          pip install -e ".[ptm]"
 
       - name: Configure git author for bot commits
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The `cptac:expression` and `cptac:phospho` drift probes had never once succeeded.**
+  The drift workflow installed with a bare `pip install -e .`, but the cptac probe
+  fingerprints the *installed* `cptac` version (via `importlib.metadata`) against
+  PayneLab's latest GitHub release — and `cptac` is declared in the `ptm` extra. Every
+  scheduled run reported `The 'cptac' Python package is not installed; cannot
+  fingerprint`, so upstream CPTAC drift has never been detectable. The workflow now
+  installs `.[ptm]`. Of the 22 drift probes these two are the only ones needing an
+  extra; the other 20 use `requests` or the stdlib alone.
+- **A single rate-limited response could fail the whole scheduled drift run.** On
+  2026-08-04 GenCC answered the regeneration request with HTTP 429; the probe had no
+  retry, so it raised, no PR could be opened for the drifted dataset, and the run exited
+  non-zero with nothing actually wrong. New `hvantk/core/utils/http.py` provides
+  `request_with_retry`, which retries transient statuses (429 and the 5xx family) and
+  connection errors with exponential backoff. It honours `Retry-After` but **clamps**
+  it: `urllib3.util.Retry` sleeps for the header's full value with no upper bound
+  (`backoff_max` caps only the exponential path), so a host answering `Retry-After: 3600`
+  would park CI for an hour. The helper deliberately does not call `raise_for_status`,
+  so callers keep their existing error handling and only the transient case changes.
+  Wired into the GenCC probe; the other 12 HTTP probes can adopt it as needed.
+
 ## 0.2.0 — 2026-08-04
 
 First tagged release. Everything below had accumulated under `Unreleased` since `0.1.0`,

--- a/hvantk/core/utils/http.py
+++ b/hvantk/core/utils/http.py
@@ -1,0 +1,126 @@
+"""Retrying HTTP request helper for drift probes and downloaders.
+
+Thirteen of the twenty-two drift probes call ``requests`` directly and none of them
+retried, so a single transient upstream response could fail the whole scheduled drift
+run. That is exactly what happened on 2026-08-04: GenCC answered the regenerate request
+with HTTP 429, the probe raised ``DriftProbeError``, no PR could be opened for the
+drifted dataset, and the workflow exited non-zero -- while nothing was actually wrong
+with either the data or the code.
+
+Why not ``urllib3.util.Retry`` mounted on an ``HTTPAdapter``, which is the obvious
+answer: it honours ``Retry-After`` through ``Retry.sleep_for_retry``, which calls
+``time.sleep(retry_after)`` with **no upper bound**. ``backoff_max`` (120s by default)
+caps only the exponential-backoff path, not this one -- verified against urllib3 2.6.3.
+A rate-limited host answering ``Retry-After: 3600`` would therefore park a CI job for an
+hour. This helper honours the header, because ignoring a server's explicit backoff
+request is how you get rate-limited harder, but clamps it to ``max_sleep_s``.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Iterable
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# 429 plus the transient 5xx family. 500 is included deliberately: several of the sources
+# these probes hit answer overload with a bare 500 rather than a 503.
+RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+DEFAULT_ATTEMPTS = 4
+DEFAULT_BACKOFF_S = 2.0
+DEFAULT_MAX_SLEEP_S = 30.0
+
+
+def parse_retry_after(value: str | None) -> float | None:
+    """``Retry-After`` as seconds, or ``None`` if absent/unparseable.
+
+    RFC 9110 permits both forms -- delta-seconds (``120``) and an HTTP-date
+    (``Wed, 21 Oct 2026 07:28:00 GMT``) -- and real servers send both. A date in the
+    past clamps to 0 rather than going negative.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:  # HTTP-dates are GMT; naive means UTC here
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    attempts: int = DEFAULT_ATTEMPTS,
+    backoff_s: float = DEFAULT_BACKOFF_S,
+    max_sleep_s: float = DEFAULT_MAX_SLEEP_S,
+    retry_statuses: Iterable[int] = RETRY_STATUSES,
+    session: requests.Session | None = None,
+    **kwargs,
+) -> requests.Response:
+    """``requests.request`` with retries on transient statuses and connection errors.
+
+    Returns the final :class:`requests.Response` **without** calling
+    ``raise_for_status``, so callers keep their existing error handling: a response that
+    is still 429 after the last attempt comes back as a 429 and raises where it always
+    did. Only the transient case changes behaviour.
+
+    Connection errors and timeouts are retried too -- they are the same class of problem
+    as a 503, and a probe that dies on one flaky TCP handshake is the bug this fixes.
+    Other ``RequestException`` subclasses (a malformed URL, say) are not retried, since
+    repeating them cannot help.
+    """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+
+    retry_statuses = frozenset(retry_statuses)
+    caller = session if session is not None else requests
+
+    for attempt in range(1, attempts + 1):
+        is_last = attempt == attempts
+        try:
+            response = caller.request(method, url, **kwargs)
+        except (requests.Timeout, requests.ConnectionError) as exc:
+            if is_last:
+                raise
+            sleep_s = min(backoff_s * 2 ** (attempt - 1), max_sleep_s)
+            logger.warning(
+                "%s %s failed (%s); retrying in %.1fs (attempt %d/%d)",
+                method.upper(), url, type(exc).__name__, sleep_s, attempt, attempts,
+            )
+            time.sleep(sleep_s)
+            continue
+
+        if is_last or response.status_code not in retry_statuses:
+            return response
+
+        # Retryable, with attempts left. Read Retry-After BEFORE closing: a streamed
+        # response holds its connection until closed or consumed, and leaving discarded
+        # attempts open would leak one connection per retry.
+        retry_after = parse_retry_after(response.headers.get("Retry-After"))
+        response.close()
+        backoff = backoff_s * 2 ** (attempt - 1)
+        sleep_s = min(retry_after if retry_after is not None else backoff, max_sleep_s)
+        logger.warning(
+            "%s %s returned %d; retrying in %.1fs (attempt %d/%d)",
+            method.upper(), url, response.status_code, sleep_s, attempt, attempts,
+        )
+        time.sleep(sleep_s)
+
+    raise AssertionError("unreachable: loop returns or raises on the last attempt")

--- a/hvantk/skills/gencc/drift_probe.py
+++ b/hvantk/skills/gencc/drift_probe.py
@@ -19,6 +19,7 @@ import requests
 
 from hvantk.skills.gencc.shared.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
 from hvantk.core.plugin.api import DriftProbeError
+from hvantk.core.utils.http import request_with_retry
 
 PROBE_VERSION = 1
 _FILENAME = f"{GENCC_FILE_PREFIX}.tsv"
@@ -33,15 +34,19 @@ def fetch_fingerprint() -> dict:
     portion of the body up to and including the column-header line (begins
     with ``sgc_id``). Does not stream the full TSV (~MB-scale).
     """
+    # Retrying, because GenCC rate-limits: on 2026-08-04 it answered the scheduled
+    # drift regeneration with HTTP 429, which failed the probe and then the whole
+    # workflow run. request_with_retry honours Retry-After but clamps the wait, so a
+    # long backoff request cannot stall CI.
     try:
-        head = requests.head(
-            GENCC_BASE_URL, timeout=_TIMEOUT_S, allow_redirects=True
+        head = request_with_retry(
+            "HEAD", GENCC_BASE_URL, timeout=_TIMEOUT_S, allow_redirects=True
         )
         head.raise_for_status()
         last_modified = head.headers.get("Last-Modified")
 
-        with requests.get(
-            GENCC_BASE_URL, timeout=_TIMEOUT_S, stream=True, allow_redirects=True
+        with request_with_retry(
+            "GET", GENCC_BASE_URL, timeout=_TIMEOUT_S, stream=True, allow_redirects=True
         ) as resp:
             resp.raise_for_status()
             buf = io.StringIO()

--- a/hvantk/tests/test_http_retry.py
+++ b/hvantk/tests/test_http_retry.py
@@ -1,0 +1,103 @@
+"""Guard the drift-probe HTTP retry helper.
+
+Regression: on 2026-08-04 GenCC answered the scheduled drift regeneration with HTTP 429.
+No probe retried, so it raised, no PR could be opened for the drifted dataset, and the
+whole workflow run failed -- with nothing wrong with either the data or the code.
+
+The clamp is tested as carefully as the retry because it is the reason this helper exists
+instead of ``urllib3.util.Retry``: that honours ``Retry-After`` via ``time.sleep``
+with no upper bound, so a host answering ``Retry-After: 3600`` would park CI for an hour.
+Deliberately non-Hail so it runs in the default suite.
+"""
+from __future__ import annotations
+
+import pytest
+import requests
+
+from hvantk.core.utils import http as http_util
+
+URL = "https://example.invalid/drift.tsv"
+
+
+@pytest.fixture
+def slept(monkeypatch):
+    """Record sleep durations instead of actually sleeping."""
+    calls: list[float] = []
+    monkeypatch.setattr(http_util.time, "sleep", calls.append)
+    return calls
+
+
+def test_retries_past_a_429_and_returns_the_success(requests_mock, slept):
+    """The GenCC failure, end to end: transient 429 then a good response."""
+    requests_mock.get(URL, [{"status_code": 429}, {"status_code": 200, "text": "ok"}])
+
+    resp = http_util.request_with_retry("GET", URL)
+
+    assert resp.status_code == 200
+    assert resp.text == "ok"
+    assert len(slept) == 1, "should have backed off exactly once"
+
+
+def test_retry_after_is_honoured_but_clamped(requests_mock, slept):
+    """A long Retry-After must not be able to stall the job.
+
+    This is the specific behaviour urllib3 does NOT give us.
+    """
+    requests_mock.get(
+        URL,
+        [
+            {"status_code": 429, "headers": {"Retry-After": "3600"}},
+            {"status_code": 200, "text": "ok"},
+        ],
+    )
+
+    resp = http_util.request_with_retry("GET", URL, max_sleep_s=30.0)
+
+    assert resp.status_code == 200
+    assert slept == [30.0], "Retry-After should be clamped to max_sleep_s, not obeyed"
+
+
+def test_exhausted_retries_return_the_last_response(requests_mock, slept):
+    """Callers keep their existing error handling.
+
+    The helper never calls raise_for_status itself, so a response that is still 429
+    after the final attempt comes back as a 429 and raises exactly where it used to.
+    """
+    requests_mock.get(URL, status_code=429)
+
+    resp = http_util.request_with_retry("GET", URL, attempts=3)
+
+    assert resp.status_code == 429
+    assert len(slept) == 2, "3 attempts means 2 gaps"
+    with pytest.raises(requests.HTTPError):
+        resp.raise_for_status()
+
+
+def test_connection_errors_are_retried_but_other_request_errors_are_not(
+    requests_mock, slept
+):
+    """A flaky handshake is the same class of problem as a 503; a bad URL is not."""
+    requests_mock.get(URL, [{"exc": requests.ConnectionError}, {"text": "ok"}])
+    assert http_util.request_with_retry("GET", URL).text == "ok"
+    assert len(slept) == 1
+
+    slept.clear()
+    requests_mock.get(URL, exc=requests.URLRequired)
+    with pytest.raises(requests.URLRequired):
+        http_util.request_with_retry("GET", URL)
+    assert slept == [], "non-transient errors must not be retried"
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("120", 120.0),
+        ("  90  ", 90.0),
+        ("not-a-date", None),
+        ("", None),
+        (None, None),
+        ("Wed, 21 Oct 1990 07:28:00 GMT", 0.0),  # in the past -> clamped to 0, not negative
+    ],
+)
+def test_parse_retry_after(header, expected):
+    assert http_util.parse_retry_after(header) == expected


### PR DESCRIPTION
Fixes the two independent causes of the failing `Scheduled drift check` — one permanent, one transient. Neither was introduced by the 0.2.0 release; both predate it.

## `cptac` — never once succeeded

The workflow installed with a bare `pip install -e .`. But the cptac probe fingerprints the **installed** `cptac` version (`importlib.metadata.version("cptac")`) against PayneLab's latest GitHub release, and `cptac` is declared in the `ptm` extra. So every scheduled run since these probes were added reported:

```
The 'cptac' Python package is not installed; cannot fingerprint.
```

Meaning **upstream CPTAC drift has never been detectable** — the probe reported a failure, not a clean result, so nothing silently passed, but the datasets have had no working drift coverage at all.

Now installs `.[ptm]`. Of the 22 drift probes, these two are the only ones needing an extra; the other 20 use `requests` or the stdlib alone. Both extra packages resolve cleanly in the lock (`cptac` 1.5.14, `sorted-nearest` 0.0.41, `python-versions >=3.6`).

## GenCC 429 — one bad response failed the whole run

On 2026-08-04 GenCC answered the regeneration request with HTTP 429. No probe retried, so it raised `DriftProbeError`, no PR could be opened for the drifted dataset, and the run exited non-zero — with nothing wrong with either the data or the code. Thirteen of the 22 probes call `requests` directly and none of them retried.

New `hvantk/core/utils/http.py` provides `request_with_retry`: retries transient statuses (429 plus the 5xx family) and connection errors with exponential backoff.

**Why not `urllib3.util.Retry` on an `HTTPAdapter`** — the obvious answer, and I checked it against the installed 2.6.3 rather than assuming. `Retry.sleep_for_retry` does `time.sleep(retry_after)` with **no upper bound**; `backoff_max` (120s) caps only the exponential path:

```python
def sleep_for_retry(self, response):
    retry_after = self.get_retry_after(response)
    if retry_after:
        time.sleep(retry_after)   # unbounded
        return True
```

A rate-limited host answering `Retry-After: 3600` would park a CI job for an hour. This helper honours the header — ignoring an explicit backoff request is how you get rate-limited harder — but clamps it to `max_sleep_s` (30s default).

Two deliberate choices:

- **It does not call `raise_for_status`.** Callers keep their existing error handling: a response still 429 after the final attempt comes back as a 429 and raises exactly where it used to. Only the transient case changes behaviour.
- **It lives in `core/utils`, not the skill**, per the sibling-skill rule in CLAUDE.md. The other 12 HTTP probes have identical exposure and can adopt it; this PR wires only GenCC, the one that actually failed.

Connection errors and timeouts are retried as the same class of problem as a 503. Other `RequestException` subclasses (a malformed URL) are not, since repeating them cannot help.

## Tests

`hvantk/tests/test_http_retry.py` — non-Hail, so it runs in the default suite. Covers the regression (429 → retry → success), the clamp (the reason for not using urllib3), exhaustion returning the last response so `raise_for_status` still fires, connection-vs-other error handling, and `Retry-After` parsing in both RFC 9110 forms including a past date clamping to 0 rather than going negative.

## Verification

- Full default suite: **1451 selected, exit 0** (378 deselected by markers). That is the prior 1441 plus this PR's 10 cases, which reconciles exactly.
- flake8 clean on all changed files, both the error pass (`E9,F63,F7,F82`) and the 127-column style pass.
- All five workflow files parse.

## Not fixed here

The three `ucsc-cellbrowser` datasets share one `tests/drift_fingerprint.json` while `fetch_fingerprint()` takes no arguments, so they produce identical output and the workflow opens three mutually-conflicting PRs per drift event (see #241 / #242 / #243). Cosmetic rather than a correctness bug — no baseline gets clobbered, since all three would write the same bytes — but it is three PRs of noise each time.
