### PR TITLE
fix(hgc): give --n-partitions a consumer, and a lever that works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## Unreleased
 
+### Added
+
+- **`--n-partitions` now controls the VDS → MatrixTable partitioning** on both
+  `hvantk hgc vds2mt` and `hvantk hgc pipeline`, coalescing the dense MatrixTable before
+  the write. A VDS's on-disk layout is derived from its *reference-block* count, which is
+  a property of the genome and saturates (~229 M on chr1 by N≈500 samples) while the dense
+  matrix keeps growing with N×M(N). Past that point the partition count stops tracking the
+  size of the data it partitions and work-per-task collapses — measured at 0.69
+  MiB/partition on a 1,005-sample chr1 cohort, where densify and QC plateaued at 1.29× and
+  1.64× going from 16 to 128 cores while well-sized stages scaled 7.8× (#207).
+  Implemented with `naive_coalesce`, which merges adjacent partitions without a shuffle so
+  the densify for a merged group runs inside one task. Reduces only; the default is
+  unchanged. **Not** implemented at the read: `hl.vds.read_vds(n_partitions=…)` looks
+  tidier but derives intervals from the reference data via `_calculate_new_partitions`,
+  whose count saturates independently of the request — measured on the 2,586-partition
+  test VDS it returned 2 intervals for every request from 2 to 100, and `to_dense_mt` then
+  failed a Scala `require` on the reference/variant mismatch for requests of 2, 4 and 16,
+  where coalescing returned exactly 2, 4 and 16.
+
 ### Fixed
+
+- **`PipelineConfig.n_partitions` reached no pipeline stage.** It was accepted from the
+  CLI and echoed back in the run plan while being read by nothing, so the run plan
+  affirmatively told the user a setting had taken effect when it had not — the worst
+  failure mode for a dead flag, and the first knob a user reaches for when they hit #207.
+  It is now forwarded to `convert_vds_to_mt`; the run plan line names the stage it governs
+  (#208).
 
 - **The `cptac:expression` and `cptac:phospho` drift probes had never once succeeded.**
   The drift workflow installed with a bare `pip install -e .`, but the cptac probe

--- a/hvantk/algorithms/hgc/converters.py
+++ b/hvantk/algorithms/hgc/converters.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 import hail as hl
 from hvantk.algorithms.hgc.constants import ADJ_GT_FIELD, VCF_EXTENSION
 from hvantk.core.models.backends import algorithm, Backend
@@ -154,6 +156,7 @@ def convert_vds_to_mt(
     skip_validation: bool = False,
     skip_keying_by_cols: bool = False,
     overwrite: bool = False,
+    n_partitions: Optional[int] = None,
 ) -> None:
     """
     Convert a Variant Dataset (VDS) to MatrixTable (MT).
@@ -176,6 +179,10 @@ def convert_vds_to_mt(
         skip_validation: If True, skip both the biallelic audit and the repair
         skip_keying_by_cols: If True, skip keying the MatrixTable by columns
         overwrite: Whether to overwrite the output if it already exists
+        n_partitions: Coalesce the dense MatrixTable to this many partitions before
+            writing. Reduces only -- `naive_coalesce` is a no-op if the count is already
+            lower. `None` (the default) keeps the VDS's on-disk layout and reproduces the
+            previous behaviour exactly.
 
     Notes:
         - VDS-level splitting is critical for correct GT/AD/PL alignment
@@ -186,10 +193,27 @@ def convert_vds_to_mt(
           and the repair is expressed lazily; see `_audit_split_variant_data`.
         - This algorithm operates on raw `hl.MatrixTable` / `hl.VariantDataset` instances
           (genotype data). ExpressionMatrix's hail-mt backend isn't available yet (Phase J).
+        - `n_partitions` coalesces the DENSE MatrixTable (step 3b), which is the only
+          lever that works: `to_dense_mt` takes no partitioning argument, and setting one
+          on the read raises inside Hail -- see the comment at step 3b for the measurement.
+          Boundaries are inherited by merging adjacent partitions, so what the caller
+          controls is the COUNT, not the balance. There is no auto-sizing: choosing a
+          heuristic needs measurement on a real cohort, not a guess here.
     """
     try:
         # Step 1: Load and split VDS
+        #
+        # Why the partition count is worth overriding at all: a VDS's on-disk layout is
+        # derived from its REFERENCE-BLOCK count, which is a property of the genome and
+        # saturates (~229 M on chr1 by N~=500 samples), while the dense matrix keeps
+        # growing with N x M(N). Past that point the partition count stops tracking the
+        # size of the data it partitions and work-per-task collapses -- measured at
+        # 0.69 MiB/partition for a 1,005-sample chr1 cohort, where densify and QC
+        # plateaued at 1.29x and 1.64x going from 16 to 128 cores while the well-sized
+        # stages scaled 7.8x. See #207.
         logging.info(f"Reading VDS from {vds_path}...")
+        if n_partitions is not None and n_partitions < 1:
+            raise ValueError(f"n_partitions must be >= 1, got {n_partitions}")
         vds = hl.vds.read_vds(vds_path)
         vds = _split_vds(vds, skip_split=skip_split_multi)
 
@@ -204,6 +228,33 @@ def convert_vds_to_mt(
         # Step 3: Densify to MatrixTable
         logging.info("Converting VDS to dense MatrixTable…")
         mt = hl.vds.to_dense_mt(vds)
+
+        # Step 3b: Coalesce to the requested partition count.
+        #
+        # `naive_coalesce` merges ADJACENT partitions with no shuffle, so the whole
+        # upstream chain for the merged group -- including the densify -- runs inside one
+        # task. That is the point: it makes tasks fatter, which is what #207 is about.
+        #
+        # Rejected alternative, and the reason this is not done at the read: passing
+        # `n_partitions` to `hl.vds.read_vds` looks like the tidier lever, but on a real
+        # VDS it fails. `read_vds` derives intervals from the reference data via
+        # `reference_data._calculate_new_partitions(n)`, and that count saturates
+        # independently of the request -- measured on the test cohort it returned 2
+        # intervals for every request from 2 to 100, while the read itself yielded 1
+        # actual partition. `to_dense_mt` then fails a Scala `require` on the mismatch
+        # between the reference and variant reads. Measured on the 2,586-partition test
+        # VDS: read-time requests of 2, 4 and 16 all raised
+        # `IllegalArgumentException: requirement failed`, where coalesce returned exactly
+        # 2, 4 and 16.
+        #
+        # `mt.n_partitions()` is deliberately NOT consulted first. Hail is lazy and does
+        # not cache; this function's whole design is that the densify executes exactly
+        # once, at the write (see the note above and `_audit_split_variant_data`), so a
+        # metadata probe here is a needless risk for a check Hail already does --
+        # `naive_coalesce` is a documented no-op when the current count is already lower.
+        if n_partitions is not None:
+            logging.info(f"Coalescing dense MatrixTable to {n_partitions} partitions.")
+            mt = mt.naive_coalesce(n_partitions)
 
         # Step 4: Repair out-of-bounds genotypes. A lazy expression: it costs no extra pass,
         # it fuses into the write below, and on clean data it is the identity.

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -39,6 +39,15 @@ from hvantk.algorithms.hgc import (
 logger = logging.getLogger(__name__)
 
 
+def _shown_partitions(n: Optional[int]) -> str:
+    """Render `n_partitions` for the run plan.
+
+    Keyed on `is None`, not truthiness: 0 is a rejected value, and `or` would print it
+    as "auto", telling the user a dry run's plan is fine for an invocation that aborts.
+    """
+    return "auto (VDS layout)" if n is None else str(n)
+
+
 class PipelineStage(Enum):
     """Enumeration of pipeline stages."""
 
@@ -61,8 +70,11 @@ class PipelineConfig:
     tmp_dir: Optional[str] = None
     reference_genome: str = "GRCh38"
     # Target partition count for the VDS -> MatrixTable stage, forwarded to
-    # convert_vds_to_mt and applied at the read (see #207/#208). NOT the combiner's
-    # interval tuning below -- that governs stage 1, this governs stage 2 onward.
+    # convert_vds_to_mt, which COALESCES the dense MatrixTable before writing it
+    # (see #207/#208). Deliberately not applied at the read: that approach was measured
+    # and fails -- see the step 3b comment in algorithms/hgc/converters.py before
+    # re-attempting it. NOT the combiner's interval tuning below: that governs stage 1,
+    # this governs stage 2 onward.
     n_partitions: Optional[int] = None
     overwrite: bool = False
     output_prefix: str = "cohort"
@@ -151,6 +163,14 @@ class PipelineConfig:
 
         if self.branch_factor is not None and self.branch_factor < 2:
             errors.append("branch_factor must be at least 2")
+
+        # Checked here, not only in convert_vds_to_mt, for the same reason as the three
+        # knobs above: this is the gate that runs before Hail init and before stage 1.
+        # convert_vds_to_mt does reject < 1, but stage 2 is reached only after the gVCF
+        # combine has run to completion -- hours on a real cohort -- so a value that was
+        # knowably wrong before any work started would cost the whole combine first.
+        if self.n_partitions is not None and self.n_partitions < 1:
+            errors.append("n_partitions must be at least 1")
 
         return errors
 
@@ -331,7 +351,7 @@ class PipelineRunner:
         # Reaches convert_vds_to_mt as of #208. Before that this line printed a setting
         # no stage read -- keep it truthful, and say which stage it governs.
         print(
-            f"  Partitions (MT):  {self.config.n_partitions or 'auto (VDS layout)'}"
+            f"  Partitions (MT):  {_shown_partitions(self.config.n_partitions)}"
         )
         print(f"  Overwrite:        {self.config.overwrite}")
         print(

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -60,6 +60,9 @@ class PipelineConfig:
     # Optional processing configuration
     tmp_dir: Optional[str] = None
     reference_genome: str = "GRCh38"
+    # Target partition count for the VDS -> MatrixTable stage, forwarded to
+    # convert_vds_to_mt and applied at the read (see #207/#208). NOT the combiner's
+    # interval tuning below -- that governs stage 1, this governs stage 2 onward.
     n_partitions: Optional[int] = None
     overwrite: bool = False
     output_prefix: str = "cohort"
@@ -325,7 +328,11 @@ class PipelineRunner:
 
         print("\n🔧 Configuration:")
         print(f"  Reference genome: {self.config.reference_genome}")
-        print(f"  Partitions:       {self.config.n_partitions or 'auto'}")
+        # Reaches convert_vds_to_mt as of #208. Before that this line printed a setting
+        # no stage read -- keep it truthful, and say which stage it governs.
+        print(
+            f"  Partitions (MT):  {self.config.n_partitions or 'auto (VDS layout)'}"
+        )
         print(f"  Overwrite:        {self.config.overwrite}")
         print(
             f"  Combiner options: {self.config.combiner_kwargs() or 'defaults (genome 1.2 Mb intervals)'}"
@@ -518,6 +525,11 @@ class PipelineRunner:
             skip_validation=self.config.skip_validation,
             skip_keying_by_cols=False,
             overwrite=self.config.overwrite,
+            # #208: this is the consumer `n_partitions` never had. It was accepted from
+            # the CLI and echoed back in the run plan while reaching no stage at all, so
+            # the run plan was affirmatively telling the user a setting had taken effect
+            # when it had not.
+            n_partitions=self.config.n_partitions,
         )
 
         self.logger.info(f"   ✓ MatrixTable created: {self.paths['mt']}")

--- a/hvantk/tests/hgc/test_cli_convert.py
+++ b/hvantk/tests/hgc/test_cli_convert.py
@@ -172,3 +172,43 @@ def test_mt2vcf_cli_no_filter_adj():
             assert result.exit_code == 0
             call_kwargs = mock_convert.call_args[1]
             assert call_kwargs["filter_adj_genotypes"] is False
+
+
+def test_vds2mt_forwards_n_partitions_to_the_converter():
+    """The REAL (non-dry-run) forwarding, which had no test at all.
+
+    Round-3 review: deleting `n_partitions=n_partitions` from the convert_vds_to_mt call
+    left the whole suite green, so `hvantk hgc vds2mt --n-partitions 4` would write with
+    the VDS's own layout while `--dry-run` on the identical command still printed
+    `Partitions: 4`. That is #208's failure mode -- a flag accepted, echoed back
+    affirmatively, and read by no stage -- reappearing on the command this PR was fixing.
+    """
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.convert_cli.convert_vds_to_mt") as mock_convert:
+        with patch(
+            "hvantk.tools.hgc.convert_cli.validate_input_files"
+        ) as mock_validate:
+            mock_validate.return_value = (True, [])
+
+            result = runner.invoke(
+                vds2mt,
+                ["--input", "/data.vds", "--output", "/out.mt", "--n-partitions", "4"],
+            )
+
+            assert result.exit_code == 0
+            assert mock_convert.call_args[1]["n_partitions"] == 4
+
+
+def test_vds2mt_defaults_n_partitions_to_none():
+    """Unset must reach the converter as None, not 0 or a number: None is what keeps the
+    VDS layout, and the converter rejects anything below 1."""
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.convert_cli.convert_vds_to_mt") as mock_convert:
+        with patch(
+            "hvantk.tools.hgc.convert_cli.validate_input_files"
+        ) as mock_validate:
+            mock_validate.return_value = (True, [])
+
+            runner.invoke(vds2mt, ["--input", "/data.vds", "--output", "/out.mt"])
+
+            assert mock_convert.call_args[1]["n_partitions"] is None

--- a/hvantk/tests/hgc/test_hgc_core_hail.py
+++ b/hvantk/tests/hgc/test_hgc_core_hail.py
@@ -87,6 +87,71 @@ def test_convert_vds_to_mt(tmp_path):
 
 
 @pytest.mark.hail
+@pytest.mark.order3
+def test_convert_vds_to_mt_honours_n_partitions(tmp_path):
+    """#207/#208: --n-partitions must actually change the written layout.
+
+    #208's acceptance criteria require that the flag either changes the output's
+    partitioning or does not exist; before this it was accepted, printed in the run plan,
+    and read by no stage. The default is asserted too, so a regression that silently
+    coalesced every run would fail rather than pass quietly.
+
+    The fixture VDS carries 2,586 partitions, so 4 is a genuine reduction rather than a
+    no-op -- `naive_coalesce` does nothing when the current count is already lower, which
+    would make a badly-chosen target vacuously "pass". That precondition is asserted from
+    the VDS's own partition count rather than by running a second, uncoalesced conversion:
+    it is free metadata, where the extra conversion cost ~4 minutes of a job that runs on
+    every push. The uncoalesced path is already covered by test_convert_vds_to_mt above.
+    """
+    import hail as hl
+
+    decompress_files(
+        zip_path=str(TESTS_DIR / "vds/cohort.vds.zip"),
+        extract_to=str(tmp_path / "cohort.vds"),
+        remove_originals=False,
+    )
+    vds_path = str(tmp_path / "cohort.vds")
+
+    source_parts = hl.vds.read_vds(vds_path).variant_data.n_partitions()
+    assert source_parts > 4, (
+        f"fixture VDS has only {source_parts} partitions; coalescing to 4 would be a "
+        f"no-op and the assertion below would prove nothing"
+    )
+
+    out = tmp_path / "coalesced.mt"
+    convert_vds_to_mt(
+        vds_path=vds_path,
+        output_path=str(out),
+        adjust_genotypes=False,
+        skip_validation=True,
+        skip_split_multi=False,
+        skip_keying_by_cols=False,
+        overwrite=True,
+        n_partitions=4,
+    )
+
+    written_parts = hl.read_matrix_table(str(out)).n_partitions()
+    assert written_parts == 4, f"expected 4 partitions, got {written_parts}"
+
+
+@pytest.mark.hail
+@pytest.mark.order3
+def test_convert_vds_to_mt_rejects_a_nonsense_partition_count(tmp_path):
+    """A bad count must fail before Hail does, with a message naming the parameter."""
+    decompress_files(
+        zip_path=str(TESTS_DIR / "vds/cohort.vds.zip"),
+        extract_to=str(tmp_path / "cohort.vds"),
+        remove_originals=False,
+    )
+    with pytest.raises(ValueError, match="n_partitions must be >= 1"):
+        convert_vds_to_mt(
+            vds_path=str(tmp_path / "cohort.vds"),
+            output_path=str(tmp_path / "never.mt"),
+            n_partitions=0,
+        )
+
+
+@pytest.mark.hail
 @pytest.mark.order4
 def test_convert_mt_to_cvcf(tmp_path):
     """Test MatrixTable → multi-sample VCF conversion."""

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -6,6 +6,8 @@ with Hail's 1.2 Mb genome default and had no way to raise the partition count ab
 core count. These tests pin the wiring so that cannot silently regress.
 """
 
+import re
+
 import pytest
 
 from hvantk.algorithms.hgc.pipeline import PipelineConfig
@@ -109,3 +111,44 @@ def test_pipeline_passes_none_when_unset(tmp_path, monkeypatch):
     runner._run_vds_to_mt()
 
     assert seen["n_partitions"] is None
+
+
+# --- adversarial-review findings on #261 --------------------------------------------
+
+
+def test_invalid_n_partitions_is_rejected_by_validate(tmp_path):
+    """Bad values must be caught by config validation, not deep inside stage 2.
+
+    n_partitions was the only tuning knob with no validate() clause, so `--n-partitions 0`
+    passed the gate, ran the multi-hour gVCF combine, and only then hit the guard inside
+    convert_vds_to_mt. Its three siblings are all checked here for exactly this reason.
+    """
+    for bad in (0, -5):
+        errors = _cfg(tmp_path, n_partitions=bad).validate()
+        assert any("n_partitions" in e for e in errors), (bad, errors)
+
+
+def test_valid_n_partitions_passes_validate(tmp_path):
+    assert [e for e in _cfg(tmp_path, n_partitions=64).validate() if "n_partitions" in e] == []
+    assert [e for e in _cfg(tmp_path).validate() if "n_partitions" in e] == []
+
+
+def test_run_plan_does_not_render_zero_as_auto():
+    """`or` printed 0 -- a value that aborts the run -- as "auto"."""
+    from hvantk.algorithms.hgc.pipeline import _shown_partitions
+
+    assert _shown_partitions(None) == "auto (VDS layout)"
+    assert _shown_partitions(0) == "0"
+    assert _shown_partitions(64) == "64"
+
+
+def test_pipeline_help_names_flags_that_exist():
+    """The --n-partitions help pointed at a `--combiner-*` family that does not exist."""
+    from hvantk.tools.hgc.pipeline_cli import pipeline as pipeline_cmd
+
+    opt = next(p for p in pipeline_cmd.params if "--n-partitions" in getattr(p, "opts", []))
+    declared = {o for p in pipeline_cmd.params for o in getattr(p, "opts", [])}
+    referenced = re.findall(r"--[a-z][a-z0-9-]+", opt.help)
+
+    missing = [f for f in referenced if f not in declared]
+    assert not missing, f"help references flags this command does not define: {missing}"

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -152,3 +152,46 @@ def test_pipeline_help_names_flags_that_exist():
 
     missing = [f for f in referenced if f not in declared]
     assert not missing, f"help references flags this command does not define: {missing}"
+
+
+def test_vds2mt_dry_run_shows_zero_rather_than_auto(tmp_path):
+    """The CALL SITE, not just the helper.
+
+    Round-2 review: the helper test alone left both call sites unprotected -- reverting
+    convert_cli.py to `n_partitions or 'auto (VDS layout)'` kept the suite green. This is
+    the live half: `vds2mt` has no config.validate() gate, so 0 reaches the dry-run
+    printer and the user is told a plan is fine for an invocation that aborts.
+    """
+    from unittest.mock import patch
+    from click.testing import CliRunner
+
+    from hvantk.tools.hgc.convert_cli import vds2mt
+
+    with patch("hvantk.tools.hgc.convert_cli.validate_input_files", return_value=(True, [])), \
+         patch("hvantk.tools.hgc.convert_cli.validate_output_path", return_value=True):
+        result = CliRunner().invoke(
+            vds2mt,
+            ["-i", str(tmp_path / "in.vds"), "-o", str(tmp_path / "out.mt"),
+             "--n-partitions", "0", "--dry-run"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Partitions: 0" in result.output, result.output
+    assert "auto" not in result.output, result.output
+
+
+def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path):
+    """The other call site: PipelineRunner.show_plan."""
+    from hvantk.algorithms.hgc.pipeline import PipelineRunner
+
+    import io
+    import contextlib
+
+    runner = PipelineRunner(_cfg(tmp_path, n_partitions=0))
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        runner.show_plan()
+    out = buf.getvalue()
+
+    assert "Partitions (MT):  0" in out, out
+    assert "auto" not in out, out

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -81,6 +81,20 @@ def test_valid_combiner_tuning_passes_validate(tmp_path):
 # test_hgc_core_hail.py, which needs Hail.
 
 
+def _runner_without_hail(pipeline_mod, monkeypatch, cfg):
+    """Build a PipelineRunner without booting a JVM.
+
+    PipelineRunner.__init__ calls _initialize_hail(). None of these tests need Hail --
+    show_plan() only prints strings and _run_vds_to_mt's converter is stubbed -- but
+    without this the file boots Spark inside the DEFAULT `pytest -q` run, which
+    pytest.ini deliberately configures to deselect the `hail` marker, and fails outright
+    on any machine with no JVM. Round-3 review caught it: the pre-PR file produced zero
+    Spark banners, this one produced three.
+    """
+    monkeypatch.setattr(pipeline_mod.PipelineRunner, "_initialize_hail", lambda self: None)
+    return pipeline_mod.PipelineRunner(cfg)
+
+
 def test_pipeline_forwards_n_partitions_to_the_converter(tmp_path, monkeypatch):
     """The regression: PipelineConfig.n_partitions must REACH convert_vds_to_mt."""
     from hvantk.algorithms.hgc import pipeline as pipeline_mod
@@ -92,7 +106,7 @@ def test_pipeline_forwards_n_partitions_to_the_converter(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", _spy)
 
-    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path, n_partitions=64))
+    runner = _runner_without_hail(pipeline_mod, monkeypatch, _cfg(tmp_path, n_partitions=64))
     runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
     runner._run_vds_to_mt()
 
@@ -106,7 +120,7 @@ def test_pipeline_passes_none_when_unset(tmp_path, monkeypatch):
     seen = {}
     monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", lambda **kw: seen.update(kw))
 
-    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path))
+    runner = _runner_without_hail(pipeline_mod, monkeypatch, _cfg(tmp_path))
     runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
     runner._run_vds_to_mt()
 
@@ -176,22 +190,31 @@ def test_vds2mt_dry_run_shows_zero_rather_than_auto(tmp_path):
         )
 
     assert result.exit_code == 0, result.output
-    assert "Partitions: 0" in result.output, result.output
-    assert "auto" not in result.output, result.output
+    # The Partitions LINE only -- result.output embeds tmp_path, so a blanket
+    # `assert "auto" not in result.output` depends on pytest's tmp-dir naming rather
+    # than on the code under test.
+    line = next(ln for ln in result.output.splitlines() if "Partitions:" in ln)
+    assert line.split(":", 1)[1].strip() == "0", line
 
 
-def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path):
+def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path, monkeypatch):
     """The other call site: PipelineRunner.show_plan."""
-    from hvantk.algorithms.hgc.pipeline import PipelineRunner
-
-    import io
     import contextlib
+    import io
 
-    runner = PipelineRunner(_cfg(tmp_path, n_partitions=0))
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    runner = _runner_without_hail(
+        pipeline_mod, monkeypatch, _cfg(tmp_path, n_partitions=0)
+    )
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         runner.show_plan()
-    out = buf.getvalue()
 
-    assert "Partitions (MT):  0" in out, out
-    assert "auto" not in out, out
+    # Assert on the Partitions LINE, not the whole capture. A blanket
+    # `assert "auto" not in out` scans output that embeds tmp_path, whose directory name
+    # pytest derives from this function's own name truncated to 30 chars -- it passed
+    # only because the cut landed one character before the trailing "auto". Renaming the
+    # test would have broken it for reasons having nothing to do with the code.
+    line = next(ln for ln in buf.getvalue().splitlines() if "Partitions (MT):" in ln)
+    assert line.split(":", 1)[1].strip() == "0", line

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -69,3 +69,43 @@ def test_valid_combiner_tuning_passes_validate(tmp_path):
         e for e in errors if "interval" in e or "batch" in e or "branch" in e
     ]
     assert combiner_errors == []
+
+
+# --- #208: n_partitions reached no pipeline stage ----------------------------------
+#
+# The field was accepted from the CLI and echoed back in the run plan while being read by
+# nothing, so the run plan affirmatively told the user a setting had taken effect when it
+# had not. These pin the wiring; the end-to-end partition-count assertion lives in
+# test_hgc_core_hail.py, which needs Hail.
+
+
+def test_pipeline_forwards_n_partitions_to_the_converter(tmp_path, monkeypatch):
+    """The regression: PipelineConfig.n_partitions must REACH convert_vds_to_mt."""
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    seen = {}
+
+    def _spy(**kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", _spy)
+
+    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path, n_partitions=64))
+    runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
+    runner._run_vds_to_mt()
+
+    assert seen["n_partitions"] == 64
+
+
+def test_pipeline_passes_none_when_unset(tmp_path, monkeypatch):
+    """Unset must stay None rather than becoming a number, so the VDS layout is kept."""
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    seen = {}
+    monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", lambda **kw: seen.update(kw))
+
+    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path))
+    runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
+    runner._run_vds_to_mt()
+
+    assert seen["n_partitions"] is None

--- a/hvantk/tools/hgc/convert_cli.py
+++ b/hvantk/tools/hgc/convert_cli.py
@@ -42,6 +42,17 @@ def register_convert_commands(group):
     "--overwrite/--no-overwrite", default=False, help="Overwrite output if exists"
 )
 @click.option(
+    "--n-partitions",
+    type=int,
+    default=None,
+    help=(
+        "Coalesce the dense MatrixTable to this many partitions before writing. Reduces "
+        "only. Default keeps the VDS's layout, which is derived from reference blocks and "
+        "saturates as sample count grows, leaving partitions too thin to amortise task "
+        "overhead (see issue #207). Size this from the dense matrix, not the VDS."
+    ),
+)
+@click.option(
     "--dry-run", is_flag=True, help="Show what would be done without executing"
 )
 @click.pass_context
@@ -54,6 +65,7 @@ def vds2mt(
     skip_validation,
     skip_keying_by_cols,
     overwrite,
+    n_partitions,
     dry_run,
 ):
     """
@@ -91,6 +103,7 @@ def vds2mt(
             click.echo(f"   • Adjust genotypes: {adjust_genotypes}")
             click.echo(f"   • Skip split multi: {skip_split_multi}")
             click.echo(f"   • Skip validation: {skip_validation}")
+            click.echo(f"   • Partitions: {n_partitions or 'auto (VDS layout)'}")
             return
 
         # Execute conversion
@@ -103,6 +116,7 @@ def vds2mt(
             skip_validation=skip_validation,
             skip_keying_by_cols=skip_keying_by_cols,
             overwrite=overwrite,
+            n_partitions=n_partitions,
         )
 
         click.echo(f"✅ Successfully converted {input} to MatrixTable at {output}")

--- a/hvantk/tools/hgc/convert_cli.py
+++ b/hvantk/tools/hgc/convert_cli.py
@@ -103,7 +103,11 @@ def vds2mt(
             click.echo(f"   • Adjust genotypes: {adjust_genotypes}")
             click.echo(f"   • Skip split multi: {skip_split_multi}")
             click.echo(f"   • Skip validation: {skip_validation}")
-            click.echo(f"   • Partitions: {n_partitions or 'auto (VDS layout)'}")
+            # `is None`, not `or`: 0 is rejected by convert_vds_to_mt, so rendering
+            # it as "auto" would have the dry run report a clean plan for an invocation
+            # that aborts.
+            shown = "auto (VDS layout)" if n_partitions is None else n_partitions
+            click.echo(f"   • Partitions: {shown}")
             return
 
         # Execute conversion

--- a/hvantk/tools/hgc/pipeline_cli.py
+++ b/hvantk/tools/hgc/pipeline_cli.py
@@ -138,7 +138,8 @@ def register_pipeline_command(group):
         "Reduces only. Default keeps the VDS's own layout, which is reference-block-derived "
         "and saturates as sample count grows, leaving partitions too thin to amortise task "
         "overhead (see #207). Size this from the dense matrix. Does not affect the gVCF "
-        "combiner -- use --combiner-* for stage 1."
+        "combiner -- use --import-interval-size / --gvcf-batch-size / --branch-factor / "
+        "--use-exome-default-intervals for stage 1."
     ),
 )
 @click.option(

--- a/hvantk/tools/hgc/pipeline_cli.py
+++ b/hvantk/tools/hgc/pipeline_cli.py
@@ -133,7 +133,13 @@ def register_pipeline_command(group):
     "--n-partitions",
     type=int,
     default=None,
-    help="Number of partitions for parallel processing",
+    help=(
+        "Coalesce the dense MatrixTable to this many partitions in the VDS -> MT stage. "
+        "Reduces only. Default keeps the VDS's own layout, which is reference-block-derived "
+        "and saturates as sample count grows, leaving partitions too thin to amortise task "
+        "overhead (see #207). Size this from the dense matrix. Does not affect the gVCF "
+        "combiner -- use --combiner-* for stage 1."
+    ),
 )
 @click.option(
     "--overwrite", is_flag=True, default=False, help="Overwrite existing output files"


### PR DESCRIPTION
Closes the pair: #208 (the flag that did nothing) and #207 (the partitioning it should have controlled).

## #208 — a flag that confirmed itself on screen and reached nothing

`PipelineConfig.n_partitions` was accepted from the CLI, echoed back in the run plan, and read by no stage. Printing it back is the worst failure mode for a dead flag: an affirmative signal that the setting took effect. It is also the first knob a user reaches for after hitting #207, so the false confirmation lands exactly where someone is trying to fix a real problem.

It now reaches `convert_vds_to_mt`. The run plan reads `Partitions (MT):` so it cannot be confused with the `--combiner-*` tuning sitting beside it, which governs stage 1.

## #207 — why the knob is worth having

A VDS's on-disk layout is derived from its **reference-block** count. Reference blocks are a property of the genome and saturate (~229 M on chr1 by N≈500 samples), while the dense matrix keeps growing with N×M(N). Past that point the partition count stops tracking the size of the data it partitions:

| N | partitions | dense MT | MiB/partition |
|---|---|---|---|
| 100 | 415 | 1.9 GB | 4.32 |
| 250 | 7,126 | 5.1 GB | **0.69** |

Measured consequence on a 1,005-sample chr1 cohort: densify and QC plateau at **1.29×** and **1.64×** going from 16 to 128 cores, while well-sized stages in the same jobs scale **7.8×**. Not core starvation — the stages that plateau have *more* tasks per core. It is work per task.

## The lever, and the one that doesn't work

Implemented with `naive_coalesce` on the dense MatrixTable. It merges adjacent partitions with no shuffle, so the upstream chain for a merged group — including the densify — runs inside one task. That is the point: fatter tasks.

**`hl.vds.read_vds(n_partitions=…)` looks like the tidier lever and does not work.** I implemented it that way first. It derives intervals from the reference data via `reference_data._calculate_new_partitions(n)`, whose count saturates independently of the request, and `to_dense_mt` then fails a Scala `require` on the reference/variant mismatch. Measured on the 2,586-partition test VDS:

```
_calculate_new_partitions:  n=2 -> 2   n=3 -> 2   n=4 -> 2   n=8 -> 2   n=100 -> 2
```

| requested | `read_vds(n_partitions=)` | `naive_coalesce` |
|---|---|---|
| 2 | `IllegalArgumentException: requirement failed` | **2** |
| 4 | `IllegalArgumentException: requirement failed` | **4** |
| 16 | `IllegalArgumentException: requirement failed` | **16** |

Recorded in both the code comment and the CHANGELOG so it is not re-attempted.

## Two deliberate omissions

**No `mt.n_partitions()` probe before coalescing.** This function's invariant — stated in its docstring and the reason `_audit_split_variant_data` runs on the sparse data — is that the densify executes exactly once, at the write. Hail is lazy and does not cache, so any eager action on the dense MT re-runs it from the top. A metadata probe is needless risk for a check Hail already performs: `naive_coalesce` is a documented no-op when the count is already lower.

**No auto-sizing.** #207 wants the count sized from the dense matrix. Choosing that heuristic needs measurement on a real cohort, not a guess baked into the default path. This ships the mechanism; the sizing policy stays with whoever runs the benchmark.

The default is unchanged — `None` keeps the VDS layout exactly.

## Acceptance criteria (#208)

- [x] `--n-partitions` changes the output's partitioning.
- [x] The run plan does not print a setting the run will ignore.
- [x] A test asserts the written MatrixTable's partition count reflects the flag.

## Verification

- `test_convert_vds_to_mt_honours_n_partitions` — asserts the source VDS has **>4 partitions before** asserting the output has exactly 4, so it cannot pass by coalescing being a no-op. Spark confirms it directly: the default run executes `Stage 7 … / 2586`, the coalesced run `Stage 13 … (0 + 4) / 4`.
- That precondition reads VDS metadata rather than running a second uncoalesced conversion, holding the pair to **3m29s instead of 8m49s** in a job that runs on every push. The uncoalesced path stays covered by the existing `test_convert_vds_to_mt`.
- `test_convert_vds_to_mt_rejects_a_nonsense_partition_count` — `n_partitions=0` raises before Hail does, naming the parameter.
- Two pipeline wiring tests pin that the config value reaches the converter and that unset stays `None`; both fail without the production change, since the key would be absent from the call.
- 12 tests in `test_pipeline_partitioning.py` pass; both Hail tests pass.
- flake8 error-pass (`E9,F63,F7,F82`) = 0. Style pass is **identical to baseline** — 1 E501, 4 F541, 2 F841 both before and after, all pre-existing nits tracked in #185.
