### PR TITLE
fix(drift): stop re-pushing drift PRs that propose nothing new

### DIFF
--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -267,6 +267,29 @@ def remote_branch_exists(branch: str, *, dry_run: bool) -> bool:
     return bool((result.stdout or "").strip())
 
 
+def _discard_staged_fingerprints(*, dry_run: bool) -> None:
+    """Return index AND working tree for ``hvantk/skills`` to HEAD.
+
+    Every early return out of `handle_drifted` after `git add` must call this. The
+    regeneration is per-dataset but the checkout is not isolated: the next iteration
+    does `git checkout -B <next-branch> origin/<base>`, which leaves both the index and
+    the working tree untouched. A leftover staged fingerprint would therefore be picked
+    up by the next dataset's `git add hvantk/skills` and committed onto ITS branch --
+    contaminating an unrelated PR, and masking that dataset's own skip check because
+    the diff is no longer empty.
+
+    `git checkout HEAD -- <path>` rather than `git reset`: reset alone unstages but
+    leaves the modified file in the working tree, where the next `git add` re-stages it.
+    """
+    if dry_run:
+        print("[dry-run] (would discard staged fingerprint changes)")
+        return
+    subprocess.run(
+        ["git", "checkout", "HEAD", "--", "hvantk/skills"],
+        check=False, text=True, capture_output=True,
+    )
+
+
 def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
     """Should the staged fingerprints be pushed to ``branch``?
 
@@ -386,6 +409,7 @@ def handle_drifted(
                 f"  no fingerprint changes to commit for {dataset}; "
                 "drift may have already been addressed. Skipping PR."
             )
+            _discard_staged_fingerprints(dry_run=dry_run)
             return
 
         # ...and neither should a re-push that changes nothing but a timestamp.
@@ -403,10 +427,32 @@ def handle_drifted(
         # So: if the branch already exists and already proposes materially the same
         # fingerprint, leave it alone. The PR stays open with its original body; only a
         # genuine upstream change re-pushes.
-        if not branch_needs_update(branch, dry_run=dry_run):
+        # Only skip when an open PR actually exists to be left alone. A branch can
+        # outlive its PR -- closing a PR does not delete the head branch, and a run
+        # whose push succeeded while `gh pr create` failed leaves a branch with no PR
+        # at all (that exact failure is why this script exits nonzero on gh errors; see
+        # the module docstring). In either case the branch content matches, so a
+        # content-only check would skip forever and the dataset's drift would never be
+        # surfaced again -- the precise outcome `branch_needs_update` promises cannot
+        # happen. Re-opening a PR for an existing branch is cheap; silence is not.
+        if not branch_needs_update(branch, dry_run=dry_run) and pr_exists_for_branch(
+            branch, dry_run=dry_run
+        ):
             print(
                 f"  branch {branch} already proposes this fingerprint "
                 f"(only volatile keys differ); leaving it untouched."
+            )
+            # The regenerated fingerprint is still staged at this point. Leaving it
+            # there would carry THIS dataset's baseline into the NEXT dataset's branch:
+            # `git checkout -B` does not clear the index, so the next iteration's
+            # `git add hvantk/skills` would stage both, and the next PR would commit a
+            # bump it has nothing to do with. It would also defeat this very skip for
+            # every dataset processed after a skipped one.
+            _discard_staged_fingerprints(dry_run=dry_run)
+            _summary_line(
+                step_summary,
+                f"- DRIFT (unchanged): `{dataset}` -> branch `{branch}` still open; "
+                f"nothing new to push",
             )
             return
 

--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -28,7 +28,11 @@ For each ``status == "drifted"`` entry the script:
 3. Runs ``hvantk drift --regenerate <provider:dataset>`` to overwrite the
    committed ``drift_fingerprint.json``.
 4. Commits with a plain Conventional Commits message.
-5. Force-pushes with lease (the branch is bot-owned).
+5. Force-pushes with lease (the branch is bot-owned) -- but only if the branch does
+   not already propose the same fingerprint. ``--regenerate`` rewrites ``fetched_at``
+   every run, so without that check each open PR was re-pushed and its body re-edited
+   once a day forever: nine PRs churned daily for a week, ~63 notifications, none of
+   them new information.
 6. Opens a draft PR (or updates the body of an existing one).
 
 Probe-failed entries are recorded in the GitHub step summary but never
@@ -66,6 +70,13 @@ except ImportError:  # pragma: no cover - exercised only in stripped envs
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILLS_ROOT = REPO_ROOT / "hvantk" / "skills"
 
+# Mirrors hvantk.core.plugin.api.PROBE_FINGERPRINT_IGNORED_KEYS. Duplicated rather than
+# imported because this script runs from a checkout where the package may not be
+# importable, and `_fingerprints_match` must not become a no-op if the import fails --
+# a silently-empty ignore set would make every comparison "different" and restore the
+# exact churn this guards against. Kept in sync by test_drift_to_pr_script.py.
+FINGERPRINT_IGNORED_KEYS = frozenset({"fetched_at", "probe_version"})
+
 
 # --------------------------------------------------------------------------- #
 # Pure helpers (no side effects, easy to reason about / test).
@@ -81,6 +92,23 @@ def branch_name_for(dataset: str) -> str:
     if ":" not in dataset:
         raise ValueError(f"expected '<provider>:<dataset>', got: {dataset!r}")
     return "drift/" + dataset.replace(":", "-")
+
+
+def strip_ignored(fingerprint: dict) -> dict:
+    """Fingerprint minus the keys that change on every probe regardless of upstream."""
+    return {k: v for k, v in fingerprint.items() if k not in FINGERPRINT_IGNORED_KEYS}
+
+
+def fingerprints_match(a: str, b: str) -> bool:
+    """True if two fingerprint JSON blobs agree once volatile keys are dropped.
+
+    Unparseable input returns False -- "I cannot tell" must mean "push it", never
+    "skip it", or a malformed fingerprint would silently suppress a real drift PR.
+    """
+    try:
+        return strip_ignored(json.loads(a)) == strip_ignored(json.loads(b))
+    except (ValueError, AttributeError, TypeError):
+        return False
 
 
 def split_dataset(dataset: str) -> tuple[str, str]:
@@ -233,7 +261,57 @@ def remote_branch_exists(branch: str, *, dry_run: bool) -> bool:
         text=True,
         capture_output=True,
     )
-    return bool(result.stdout.strip())
+    # `or ""` rather than a bare .strip(): stdout is None whenever the call was made
+    # without capture_output, and a crash here would abort a drift run over a branch
+    # existence check.
+    return bool((result.stdout or "").strip())
+
+
+def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
+    """Should the staged fingerprints be pushed to ``branch``?
+
+    False only when the branch already exists AND every staged fingerprint is
+    materially identical to the one it already carries -- i.e. the sole difference is
+    `fetched_at`. Everything else returns True, deliberately: a branch that does not
+    exist, a file the branch lacks, an unreadable blob or a git failure all mean "I
+    cannot prove this is redundant", and the safe answer is to push. Suppressing a real
+    drift PR is far worse than one redundant force-push.
+    """
+    if dry_run:
+        return True
+    if not remote_branch_exists(branch, dry_run=dry_run):
+        return True
+
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=False, text=True, capture_output=True,
+    )
+    paths = [p for p in (staged.stdout or "").split("\n") if p.strip()]
+    if staged.returncode != 0 or not paths:
+        return True
+
+    # The branch ref may not exist locally -- the run checked out BASE_BRANCH, not this
+    # one -- so fetch it and read blobs out of FETCH_HEAD rather than assuming
+    # origin/<branch> is present.
+    fetched = subprocess.run(
+        ["git", "fetch", "origin", branch],
+        check=False, text=True, capture_output=True,
+    )
+    if fetched.returncode != 0:
+        return True
+
+    for path in paths:
+        current = (REPO_ROOT / path).read_text() if (REPO_ROOT / path).exists() else None
+        previous = subprocess.run(
+            ["git", "show", f"FETCH_HEAD:{path}"],
+            check=False, text=True, capture_output=True,
+        )
+        if current is None or previous.returncode != 0:
+            return True
+        if not fingerprints_match(current, previous.stdout):
+            return True
+
+    return False
 
 
 def pr_exists_for_branch(branch: str, *, dry_run: bool) -> str | None:
@@ -307,6 +385,28 @@ def handle_drifted(
             print(
                 f"  no fingerprint changes to commit for {dataset}; "
                 "drift may have already been addressed. Skipping PR."
+            )
+            return
+
+        # ...and neither should a re-push that changes nothing but a timestamp.
+        #
+        # The check above compares against BASE_BRANCH, so for a dataset that is still
+        # drifted it can never fire: `--regenerate` rewrites `fetched_at` on every run,
+        # which alone guarantees a non-empty diff. The result was that each of the nine
+        # open drift PRs got a fresh force-push and a body edit EVERY morning for a
+        # week -- ~63 notification events, none of them carrying new information --
+        # because nothing compared the new fingerprint against what the branch already
+        # proposed. `fetched_at` is excluded from drift comparison
+        # (PROBE_FINGERPRINT_IGNORED_KEYS) but still written into the committed file,
+        # so it is invisible to the detector and load-bearing for the diff.
+        #
+        # So: if the branch already exists and already proposes materially the same
+        # fingerprint, leave it alone. The PR stays open with its original body; only a
+        # genuine upstream change re-pushes.
+        if not branch_needs_update(branch, dry_run=dry_run):
+            print(
+                f"  branch {branch} already proposes this fingerprint "
+                f"(only volatile keys differ); leaving it untouched."
             )
             return
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Fixed
 
+- **Every open drift PR was force-pushed and its body re-edited once a day, forever.**
+  Nine PRs churned daily for a week — roughly 63 notification events, none carrying new
+  information. `hvantk drift --regenerate` rewrites `fetched_at` on every run, and the
+  existing emptiness check compared against the *base branch*, so for a dataset that was
+  still drifted it could never fire: the timestamp alone guaranteed a non-empty diff.
+  Nothing compared the freshly regenerated fingerprint against what the branch already
+  proposed. `drift_to_pr.py` now skips the push and the PR edit when the branch already
+  carries a materially identical fingerprint — "materially" meaning equal once
+  `fetched_at` and `probe_version` are dropped, the same keys the drift detector ignores.
+  Every other outcome (no branch yet, a file the branch lacks, an unreadable blob, a git
+  failure) still pushes: suppressing a real drift PR is far worse than one redundant
+  force-push. Note this does **not** reduce how often drift is *detected* — a content
+  revision, such as ClinGen's `content_length` moving while the checksum holds, is still
+  a genuine change and still opens a PR.
+
 - **The `cptac:expression` and `cptac:phospho` drift probes had never once succeeded.**
   The drift workflow installed with a bare `pip install -e .`, but the cptac probe
   fingerprints the *installed* `cptac` version (via `importlib.metadata`) against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,15 @@
   proposed. `drift_to_pr.py` now skips the push and the PR edit when the branch already
   carries a materially identical fingerprint — "materially" meaning equal once
   `fetched_at` and `probe_version` are dropped, the same keys the drift detector ignores.
-  Every other outcome (no branch yet, a file the branch lacks, an unreadable blob, a git
-  failure) still pushes: suppressing a real drift PR is far worse than one redundant
-  force-push. Note this does **not** reduce how often drift is *detected* — a content
+  The skip additionally requires an **open PR** to still exist: a branch outlives its PR
+  when one is closed, and a run whose push succeeded while `gh pr create` failed leaves a
+  branch with no PR at all — in both cases the branch content matches, so a content-only
+  check would suppress that dataset's drift forever. Every other outcome (no branch yet,
+  a file the branch lacks, an unreadable blob, a git failure) still pushes: suppressing a
+  real drift PR is far worse than one redundant force-push. A skipped dataset also
+  restores the index and working tree before returning — `git checkout -B` does not clear
+  the index, so a leftover staged fingerprint would be committed onto the *next*
+  dataset's branch — and still reports itself in the job's step summary. Note this does **not** reduce how often drift is *detected* — a content
   revision, such as ClinGen's `content_length` moving while the checksum holds, is still
   a genuine change and still opens a PR.
 

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -188,3 +188,150 @@ def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeyp
     """No branch yet -> always push. Cheap, but it is the common first-drift path."""
     monkeypatch.setattr(drift_to_pr, "remote_branch_exists", lambda b, dry_run: False)
     assert drift_to_pr.branch_needs_update("drift/x-y", dry_run=False) is True
+
+
+# --- the skip path itself, end to end -----------------------------------------------
+#
+# Adversarial review caught that NO test exercised the behaviour this change adds:
+# replacing the whole body of `branch_needs_update` with `return True` -- a complete
+# neutering of the fix -- left every test green. These drive handle_drifted and assert
+# on the git/gh commands actually issued.
+
+
+def _capture_handle_drifted(drift_to_pr, monkeypatch, *, needs_update, pr_exists):
+    """Run handle_drifted with git/gh stubbed, returning the commands it issued."""
+    cmds: list[list[str]] = []
+
+    def _record(cmd, **kwargs):
+        cmds.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(drift_to_pr, "_run", _record)
+    monkeypatch.setattr(drift_to_pr, "branch_needs_update", lambda b, dry_run: needs_update)
+    monkeypatch.setattr(
+        drift_to_pr, "pr_exists_for_branch", lambda b, dry_run: "7" if pr_exists else None
+    )
+    # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
+    # which is the state after a real regeneration.
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 1)
+    )
+
+    drift_to_pr.handle_drifted(
+        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=None
+    )
+    return cmds
+
+
+def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch):
+    """The behaviour the whole PR exists for. Fails if branch_needs_update is neutered
+    to `return True`, which is exactly the hole review found."""
+    cmds = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, needs_update=False, pr_exists=True
+    )
+    joined = [" ".join(c) for c in cmds]
+    assert not any(c.startswith("git commit") for c in joined), joined
+    assert not any(c.startswith("git push") for c in joined), joined
+    assert not any(c.startswith("gh pr") for c in joined), joined
+
+
+def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch):
+    """The complement: when the branch DOES need updating, nothing is suppressed."""
+    cmds = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, needs_update=True, pr_exists=True
+    )
+    joined = [" ".join(c) for c in cmds]
+    assert any(c.startswith("git commit") for c in joined), joined
+    assert any(c.startswith("git push") for c in joined), joined
+    assert any(c.startswith("gh pr edit") for c in joined), joined
+
+
+def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch):
+    """A branch can outlive its PR -- closing a PR leaves the head branch, and a run
+    whose push succeeded while `gh pr create` failed leaves a branch with no PR at all.
+    Skipping on branch content alone would suppress that dataset's drift forever."""
+    cmds = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, needs_update=False, pr_exists=False
+    )
+    joined = [" ".join(c) for c in cmds]
+    assert any(c.startswith("gh pr create") for c in joined), joined
+
+
+# --- branch_needs_update against a REAL git repo -------------------------------------
+#
+# The stubbed tests above drive handle_drifted's branching, but they monkeypatch
+# branch_needs_update itself, so they cannot detect that function being wrong. Neutering
+# it to `return True` left them all green -- the same vacuity adversarial review found in
+# the first version of this test file. This exercises the real thing over real git.
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, text=True, capture_output=True
+    )
+
+
+@pytest.fixture
+def repo_with_drift_branch(tmp_path, drift_to_pr, monkeypatch):
+    """A repo whose `drift/p-d` branch already carries a fingerprint, with `origin`
+    pointing back at itself so ls-remote/fetch behave as they do in CI."""
+    repo = tmp_path / "repo"
+    (repo / "hvantk" / "skills").mkdir(parents=True)
+    fp = repo / "hvantk" / "skills" / "drift_fingerprint.json"
+
+    _git(repo.parent, "init", "-q", str(repo))
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    fp.write_text(json.dumps({"source_version": "v1", "fetched_at": "2026-08-01"}))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    _git(repo, "branch", "-M", "dev")
+    _git(repo, "checkout", "-qb", "drift/p-d")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "branch head")
+    _git(repo, "checkout", "-q", "dev")
+    _git(repo, "remote", "add", "origin", str(repo))
+
+    monkeypatch.setattr(drift_to_pr, "REPO_ROOT", repo)
+    monkeypatch.chdir(repo)
+    return repo, fp
+
+
+def test_branch_needs_update_false_when_only_the_timestamp_moved(
+    repo_with_drift_branch, drift_to_pr
+):
+    """The regression this PR exists for, against real git."""
+    repo, fp = repo_with_drift_branch
+    fp.write_text(json.dumps({"source_version": "v1", "fetched_at": "2026-08-04"}))
+    _git(repo, "add", "hvantk/skills")
+
+    assert drift_to_pr.branch_needs_update("drift/p-d", dry_run=False) is False
+
+
+def test_branch_needs_update_true_when_the_source_actually_moved(
+    repo_with_drift_branch, drift_to_pr
+):
+    """The signal must survive: a real upstream change still pushes."""
+    repo, fp = repo_with_drift_branch
+    fp.write_text(json.dumps({"source_version": "v2", "fetched_at": "2026-08-04"}))
+    _git(repo, "add", "hvantk/skills")
+
+    assert drift_to_pr.branch_needs_update("drift/p-d", dry_run=False) is True
+
+
+def test_discard_staged_fingerprints_clears_index_and_worktree(
+    repo_with_drift_branch, drift_to_pr
+):
+    """The contamination fix: a skipped dataset must leave nothing behind for the next
+    one. `git checkout -B` does not clear the index, so a leftover staged fingerprint
+    would be committed onto an unrelated dataset's branch."""
+    repo, fp = repo_with_drift_branch
+    original = fp.read_text()
+    fp.write_text(json.dumps({"source_version": "LEAKED", "fetched_at": "x"}))
+    _git(repo, "add", "hvantk/skills")
+    assert _git(repo, "diff", "--cached", "--name-only").stdout.strip()
+
+    drift_to_pr._discard_staged_fingerprints(dry_run=False)
+
+    assert _git(repo, "diff", "--cached", "--name-only").stdout.strip() == ""
+    assert fp.read_text() == original, "working tree must be restored too, or the next "\
+        "`git add hvantk/skills` re-stages the leak"

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -211,7 +211,7 @@ def _capture_handle_drifted(
     `subprocess.run` directly, not `_run`, so it was invisible here.
     """
     cmds: list[list[str]] = []
-    cleanups: list[bool] = []
+    cleanups: list[dict] = []
 
     def _record(cmd, **kwargs):
         cmds.append(list(cmd))
@@ -222,8 +222,12 @@ def _capture_handle_drifted(
     monkeypatch.setattr(
         drift_to_pr, "pr_exists_for_branch", lambda b, dry_run: "7" if pr_exists else None
     )
+    # Record the KWARGS, not just the fact of a call. `_discard_staged_fingerprints`
+    # is a no-op under dry_run=True (it prints and returns), so a spy that discards its
+    # arguments cannot tell a real cleanup from a neutered one -- a call site changed to
+    # `dry_run=True` would restore the contamination bug with the suite still green.
     monkeypatch.setattr(
-        drift_to_pr, "_discard_staged_fingerprints", lambda **kw: cleanups.append(True)
+        drift_to_pr, "_discard_staged_fingerprints", lambda **kw: cleanups.append(kw)
     )
     # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
     # which is the state after a real regeneration. 0 means nothing to commit.
@@ -237,7 +241,7 @@ def _capture_handle_drifted(
     drift_to_pr.handle_drifted(
         dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
     )
-    return cmds, len(cleanups), (summary.read_text() if summary.exists() else "")
+    return cmds, cleanups, (summary.read_text() if summary.exists() else "")
 
 
 def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch, tmp_path):
@@ -252,7 +256,10 @@ def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch, tmp_path):
     assert not any(c.startswith("gh pr") for c in joined), joined
     # The staged fingerprint MUST be discarded before returning, or it is committed
     # onto the next dataset's branch. Deleting this call site was a silent revert.
-    assert cleanups == 1, "skip path must discard the staged fingerprint"
+    assert cleanups == [{"dry_run": False}], (
+        "skip path must discard the staged fingerprint, and must do it for real -- "
+        "dry_run=True would print and return, leaving the index contaminated"
+    )
     # ...and a still-drifting dataset must not vanish from the rendered report.
     assert "DRIFT (unchanged)" in summary, summary
 
@@ -365,4 +372,6 @@ def test_nothing_staged_path_also_discards(drift_to_pr, monkeypatch, tmp_path):
     _, cleanups, _ = _capture_handle_drifted(
         drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=True, staged=False
     )
-    assert cleanups == 1, "the 'nothing to commit' return must discard too"
+    assert cleanups == [{"dry_run": False}], (
+        "the 'nothing to commit' return must discard too, and for real"
+    )

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -198,9 +198,20 @@ def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeyp
 # on the git/gh commands actually issued.
 
 
-def _capture_handle_drifted(drift_to_pr, monkeypatch, *, needs_update, pr_exists):
-    """Run handle_drifted with git/gh stubbed, returning the commands it issued."""
+def _capture_handle_drifted(
+    drift_to_pr, monkeypatch, tmp_path, *, needs_update, pr_exists, staged=True
+):
+    """Run handle_drifted with git/gh stubbed.
+
+    Returns (commands issued, cleanup-call count, step-summary text). The cleanup count
+    and summary are captured deliberately: an earlier version of this helper recorded
+    only `_run` and passed step_summary=None, so deleting the
+    `_discard_staged_fingerprints(...)` CALL SITES -- a full revert of the fix they
+    belong to -- left the whole suite green. `_discard_staged_fingerprints` calls
+    `subprocess.run` directly, not `_run`, so it was invisible here.
+    """
     cmds: list[list[str]] = []
+    cleanups: list[bool] = []
 
     def _record(cmd, **kwargs):
         cmds.append(list(cmd))
@@ -211,34 +222,45 @@ def _capture_handle_drifted(drift_to_pr, monkeypatch, *, needs_update, pr_exists
     monkeypatch.setattr(
         drift_to_pr, "pr_exists_for_branch", lambda b, dry_run: "7" if pr_exists else None
     )
-    # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
-    # which is the state after a real regeneration.
     monkeypatch.setattr(
-        subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 1)
+        drift_to_pr, "_discard_staged_fingerprints", lambda **kw: cleanups.append(True)
+    )
+    # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
+    # which is the state after a real regeneration. 0 means nothing to commit.
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 1 if staged else 0),
     )
 
+    summary = tmp_path / "summary.md"
     drift_to_pr.handle_drifted(
-        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=None
+        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
     )
-    return cmds
+    return cmds, len(cleanups), (summary.read_text() if summary.exists() else "")
 
 
-def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch):
+def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch, tmp_path):
     """The behaviour the whole PR exists for. Fails if branch_needs_update is neutered
     to `return True`, which is exactly the hole review found."""
-    cmds = _capture_handle_drifted(
-        drift_to_pr, monkeypatch, needs_update=False, pr_exists=True
+    cmds, cleanups, summary = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=False, pr_exists=True
     )
     joined = [" ".join(c) for c in cmds]
     assert not any(c.startswith("git commit") for c in joined), joined
     assert not any(c.startswith("git push") for c in joined), joined
     assert not any(c.startswith("gh pr") for c in joined), joined
+    # The staged fingerprint MUST be discarded before returning, or it is committed
+    # onto the next dataset's branch. Deleting this call site was a silent revert.
+    assert cleanups == 1, "skip path must discard the staged fingerprint"
+    # ...and a still-drifting dataset must not vanish from the rendered report.
+    assert "DRIFT (unchanged)" in summary, summary
 
 
-def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch):
+def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch, tmp_path):
     """The complement: when the branch DOES need updating, nothing is suppressed."""
-    cmds = _capture_handle_drifted(
-        drift_to_pr, monkeypatch, needs_update=True, pr_exists=True
+    cmds, _, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=True
     )
     joined = [" ".join(c) for c in cmds]
     assert any(c.startswith("git commit") for c in joined), joined
@@ -246,12 +268,12 @@ def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch):
     assert any(c.startswith("gh pr edit") for c in joined), joined
 
 
-def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch):
+def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch, tmp_path):
     """A branch can outlive its PR -- closing a PR leaves the head branch, and a run
     whose push succeeded while `gh pr create` failed leaves a branch with no PR at all.
     Skipping on branch content alone would suppress that dataset's drift forever."""
-    cmds = _capture_handle_drifted(
-        drift_to_pr, monkeypatch, needs_update=False, pr_exists=False
+    cmds, _, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=False, pr_exists=False
     )
     joined = [" ".join(c) for c in cmds]
     assert any(c.startswith("gh pr create") for c in joined), joined
@@ -335,3 +357,12 @@ def test_discard_staged_fingerprints_clears_index_and_worktree(
     assert _git(repo, "diff", "--cached", "--name-only").stdout.strip() == ""
     assert fp.read_text() == original, "working tree must be restored too, or the next "\
         "`git add hvantk/skills` re-stages the leak"
+
+
+def test_nothing_staged_path_also_discards(drift_to_pr, monkeypatch, tmp_path):
+    """The OTHER early return after `git add`. Both must clean up, or whichever is left
+    uncovered reintroduces contamination on its own path."""
+    _, cleanups, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=True, staged=False
+    )
+    assert cleanups == 1, "the 'nothing to commit' return must discard too"

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -125,3 +125,66 @@ def test_branch_name_rejects_a_bare_provider(drift_to_pr):
     assert drift_to_pr.branch_name_for("clinvar:variants") == "drift/clinvar-variants"
     with pytest.raises(ValueError):
         drift_to_pr.branch_name_for("clinvar")
+
+
+# --- the daily-churn guard ---------------------------------------------------------
+#
+# Every open drift PR was force-pushed and its body re-edited once per DAY for a week --
+# nine PRs, ~63 notification events, none carrying new information. `--regenerate`
+# rewrites `fetched_at` on every run, and the pre-existing emptiness check compares
+# against BASE_BRANCH, so for a still-drifted dataset it could never fire. Nothing
+# compared the new fingerprint against what the branch already proposed.
+
+
+def test_fingerprints_match_ignores_only_volatile_keys(drift_to_pr):
+    """Same data, later probe -> match. Different source_version -> no match."""
+    base = {
+        "source_version": "2026-05-15",
+        "checksums": {"f.tsv": "abc"},
+        "fetched_at": "2026-08-01T00:00:00+00:00",
+        "probe_version": 1,
+    }
+    later = dict(base, fetched_at="2026-08-04T06:00:00+00:00", probe_version=2)
+    moved = dict(base, source_version="2026-07-31")
+
+    assert drift_to_pr.fingerprints_match(json.dumps(base), json.dumps(later))
+    assert not drift_to_pr.fingerprints_match(json.dumps(base), json.dumps(moved))
+
+
+def test_fingerprints_match_treats_a_content_change_as_material(drift_to_pr):
+    """ClinGen's real case: checksum identical, only `extras.content_length` moved.
+
+    That must still count as a change -- this guard is about suppressing *timestamp*
+    churn, not about suppressing upstream content revisions.
+    """
+    base = {"checksums": {"f.csv": "abc"}, "extras": {"content_length": "1113685"},
+            "fetched_at": "2026-08-01T00:00:00+00:00"}
+    grown = {"checksums": {"f.csv": "abc"}, "extras": {"content_length": "1114672"},
+             "fetched_at": "2026-08-04T00:00:00+00:00"}
+
+    assert not drift_to_pr.fingerprints_match(json.dumps(base), json.dumps(grown))
+
+
+def test_unparseable_fingerprint_is_never_treated_as_matching(drift_to_pr):
+    """"I cannot tell" must mean "push", never "skip".
+
+    Returning True here would silently suppress a real drift PR whenever a fingerprint
+    was malformed -- the failure mode this whole script exists to avoid.
+    """
+    assert not drift_to_pr.fingerprints_match("{not json", "{}")
+    assert not drift_to_pr.fingerprints_match("{}", "")
+
+
+def test_ignored_keys_stay_in_sync_with_the_package(drift_to_pr):
+    """The script duplicates PROBE_FINGERPRINT_IGNORED_KEYS because it runs from a
+    checkout where hvantk may not be importable. Duplication needs a guard, or the two
+    drift apart and the bot starts disagreeing with the detector."""
+    from hvantk.core.plugin.api import PROBE_FINGERPRINT_IGNORED_KEYS
+
+    assert drift_to_pr.FINGERPRINT_IGNORED_KEYS == PROBE_FINGERPRINT_IGNORED_KEYS
+
+
+def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeypatch):
+    """No branch yet -> always push. Cheap, but it is the common first-drift path."""
+    monkeypatch.setattr(drift_to_pr, "remote_branch_exists", lambda b, dry_run: False)
+    assert drift_to_pr.branch_needs_update("drift/x-y", dry_run=False) is True


### PR DESCRIPTION
Fixes the drift-PR notification flood. The rate turned out not to be what it looked like.

## What was actually happening

**Only 9 drift PRs have ever been created** — 8 on 2026-07-28, 1 on 07-29, none since. There was never a weekly batch of new PRs. The same 9 were **force-pushed and their bodies re-edited every single morning**, which is ~63 notification events a week and reads like a recurring flood.

## Why

Per drifted dataset, per daily run:

```
git checkout -B <branch> origin/dev     # discards yesterday's commit
hvantk drift --regenerate <dataset>     # rewrites fetched_at to "now"
git add hvantk/skills
git diff --cached --quiet               # the emptiness guard
git push --force-with-lease
```

The guard exists precisely to prevent no-op commits, and **it can never fire**. It compares the staged tree against `origin/dev`, so for a dataset that is still drifted the regenerated `fetched_at` alone guarantees a non-empty diff. Nothing ever compared the new fingerprint against *what the branch already proposed*.

`fetched_at` is excluded from drift comparison via `PROBE_FINGERPRINT_IGNORED_KEYS` — invisible to the detector, load-bearing for the diff. That gap is the whole bug.

Direct evidence: #242 and #243 proposed byte-identical fingerprints differing only in `fetched_at` (`08:37:30` vs `08:37:37`).

## The fix

`branch_needs_update()` compares the freshly regenerated fingerprints against the ones the remote branch already carries, ignoring `fetched_at` and `probe_version` — the same keys the detector ignores. If they match, the push and the PR edit are both skipped and the PR is left exactly as it was.

**Every other outcome still pushes**, deliberately:

| situation | result |
|---|---|
| branch doesn't exist yet | push |
| branch lacks the file | push |
| blob unreadable / git failure | push |
| fingerprint unparseable | push |
| materially identical | **skip** |

Each of those means "I cannot prove this is redundant." Suppressing a real drift PR is far worse than one redundant force-push, so the guard only fires on positive proof of redundancy.

## What this does *not* change

**Detection is untouched.** A content revision still opens a PR — including ClinGen's case, where `extras.content_length` moved from 1,113,685 to 1,114,672 while the file checksum held. That is a genuine upstream change, and this PR deliberately does not suppress it. Only the *daily re-push of an unchanged proposal* goes away.

If you also want fewer PRs overall, that is a separate decision — splitting structural drift (headers/checksums) from content-only drift, or batching datasets into one PR. Not attempted here.

## On the duplicated constant

`FINGERPRINT_IGNORED_KEYS` is copied from `hvantk.core.plugin.api` rather than imported: this script runs from a checkout where the package may not be importable, and a failed import would leave an empty ignore set — which would make every comparison "different" and restore the exact churn this fixes. `test_ignored_keys_stay_in_sync_with_the_package` pins the two together so they cannot drift apart.

## Also

`remote_branch_exists` assumed `result.stdout` is always a string. The new call path reaches it in contexts where the result may not have been captured, and a crash there would abort an entire drift run over a branch-existence check.

## Verification

- 25 drift tests pass (`test_drift_to_pr_script.py`, `test_drift_ignored_keys_regression.py`, `test_drift_runner.py`), including 5 new ones covering the volatile-key match, the ClinGen content-change case staying material, unparseable input never matching, constant sync, and the new-branch path.
- `--dry-run` end-to-end still exits 0 and renders a PR body.
- flake8 clean on both the error pass and the 127-column style pass.
