### PR TITLE
fix(drift): one PR per drift signal, not per dataset

### DIFF
--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -111,23 +111,34 @@ def fingerprints_match(a: str, b: str) -> bool:
         return False
 
 
-def branch_name_for_signal(datasets: list[str]) -> str:
+def branch_name_for_signal(datasets: list[str], fingerprint_path: str = "") -> str:
     """Branch name for a drift signal covering one or more datasets.
 
     A single dataset keeps its historical name exactly (``drift/<provider>-<dataset>``),
-    so existing branches and their open PRs are still matched. A group that is entirely
-    one provider's collapses to ``drift/<provider>`` -- stable across runs, and it does
-    not privilege whichever member happened to be listed first in the manifest.
+    so existing branches and their open PRs are still matched.
+
+    A group takes ``drift/<provider>``, plus the baseline's distinguishing suffix when it
+    has one. The suffix matters: the branch must identify the SIGNAL, and a provider can
+    own more than one. Multi-dataset providers suffix their baselines per dataset
+    (``drift_fingerprint_samples.json`` alongside ``drift_fingerprint.json``), so keying
+    on the provider alone would collapse two independent signals onto one branch, where
+    the second would overwrite the first's commit and rewrite its PR body. Deriving from
+    the path rather than from the member list also keeps the name stable across runs, and
+    does not privilege whichever member the manifest happens to list first.
     """
     if len(datasets) == 1:
         return branch_name_for(datasets[0])
+
     providers = {split_dataset(d)[0] for d in datasets}
-    if len(providers) == 1:
-        return "drift/" + providers.pop()
-    # A baseline shared ACROSS providers should be impossible -- the path lives inside
-    # one plugin directory -- but fall back to something deterministic rather than
-    # picking arbitrarily, so the branch does not move between runs.
-    return branch_name_for(sorted(datasets)[0])
+    if len(providers) != 1:
+        # A baseline shared ACROSS providers should be impossible -- the path lives
+        # inside one plugin directory -- but stay deterministic rather than arbitrary.
+        return branch_name_for(sorted(datasets)[0])
+
+    base = "drift/" + providers.pop()
+    stem = Path(fingerprint_path).stem if fingerprint_path else ""
+    suffix = stem[len("drift_fingerprint"):].strip("_-") if stem.startswith("drift_fingerprint") else stem
+    return f"{base}-{suffix}" if suffix else base
 
 
 def group_by_drift_signal(drifted: list[dict]) -> list[dict]:
@@ -446,7 +457,7 @@ def handle_drifted(
     # to just this one, so a report without the field behaves exactly as before.
     covers = entry.get("datasets") or [dataset]
     provider, dataset_short = split_dataset(dataset)
-    branch = branch_name_for_signal(covers)
+    branch = branch_name_for_signal(covers, entry.get("fingerprint_path") or "")
     skill_md = find_skill_md(provider, dataset_short)
     maintainers = read_maintainers(provider)
     diff = entry.get("diff") or {}

--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -111,6 +111,60 @@ def fingerprints_match(a: str, b: str) -> bool:
         return False
 
 
+def branch_name_for_signal(datasets: list[str]) -> str:
+    """Branch name for a drift signal covering one or more datasets.
+
+    A single dataset keeps its historical name exactly (``drift/<provider>-<dataset>``),
+    so existing branches and their open PRs are still matched. A group that is entirely
+    one provider's collapses to ``drift/<provider>`` -- stable across runs, and it does
+    not privilege whichever member happened to be listed first in the manifest.
+    """
+    if len(datasets) == 1:
+        return branch_name_for(datasets[0])
+    providers = {split_dataset(d)[0] for d in datasets}
+    if len(providers) == 1:
+        return "drift/" + providers.pop()
+    # A baseline shared ACROSS providers should be impossible -- the path lives inside
+    # one plugin directory -- but fall back to something deterministic rather than
+    # picking arbitrarily, so the branch does not move between runs.
+    return branch_name_for(sorted(datasets)[0])
+
+
+def group_by_drift_signal(drifted: list[dict]) -> list[dict]:
+    """Collapse drifted entries that report the SAME drift signal into one.
+
+    Datasets sharing a ``fingerprint_path`` share a baseline file, so they cannot have
+    independent drift: one upstream event produces N identical reports, N branches
+    writing the same file, and N mutually conflicting PRs. `ucsc-cellbrowser` is the
+    worked case -- `default`, `adult-ctx` and `dev-ctx` are distinct *schema* variants
+    (obs cell-type column `celltype` / `Class` / `Type_v2`), but the probe fingerprints
+    the provider-wide catalog, so all three always agree. Merging one made the other two
+    conflict.
+
+    Returns one entry per signal, each carrying a ``datasets`` list naming every member,
+    so the PR can say what it covers. Entries WITHOUT a fingerprint_path are never
+    grouped -- an older report shape, or a runner that did not populate it, must not
+    silently collapse unrelated datasets into one PR.
+
+    Order is preserved so branch names stay stable across runs.
+    """
+    grouped: dict[str, dict] = {}
+    out: list[dict] = []
+    for entry in drifted:
+        path = entry.get("fingerprint_path")
+        if not path:
+            out.append({**entry, "datasets": [entry.get("dataset_name")]})
+            continue
+        existing = grouped.get(path)
+        if existing is None:
+            merged = {**entry, "datasets": [entry.get("dataset_name")]}
+            grouped[path] = merged
+            out.append(merged)
+        else:
+            existing["datasets"].append(entry.get("dataset_name"))
+    return out
+
+
 def split_dataset(dataset: str) -> tuple[str, str]:
     provider, _, name = dataset.partition(":")
     return provider, name
@@ -181,11 +235,23 @@ def build_pr_body(
     diff: dict | None,
     skill_md: Path | None,
     maintainers: list[str],
+    covers: list[str] | None = None,
 ) -> str:
     lines: list[str] = []
+    others = [d for d in (covers or []) if d and d != dataset]
     lines.append(
         f"Automated drift detection found upstream changes for `{dataset}`."
     )
+    if others:
+        listed = ", ".join(f"`{d}`" for d in others)
+        lines.append("")
+        lines.append(
+            f"This also covers {listed}. Those datasets declare the same "
+            "`drift_fingerprint` baseline and the same probe, so they report one drift "
+            "signal between them, not one each -- they are distinct *schema* variants "
+            "of the same upstream resource. Previously each opened its own PR proposing "
+            "byte-identical content, and merging any one made the rest conflict."
+        )
     lines.append("")
     lines.append(
         "This PR regenerates `drift_fingerprint.json` so the test suite "
@@ -219,7 +285,11 @@ def build_pr_body(
     return "\n".join(lines) + "\n"
 
 
-def pr_title_for(dataset: str) -> str:
+def pr_title_for(dataset: str, covers: list[str] | None = None) -> str:
+    extra = len([d for d in (covers or []) if d and d != dataset])
+    if extra:
+        provider = split_dataset(dataset)[0]
+        return f"chore(drift): {provider} snapshot regeneration ({extra + 1} datasets)"
     return f"chore(drift): {dataset} snapshot regeneration"
 
 
@@ -349,8 +419,11 @@ def handle_drifted(
     step_summary: Path | None,
 ) -> None:
     dataset = entry["dataset_name"]
+    # Datasets sharing this entry's drift signal (see group_by_drift_signal). Defaults
+    # to just this one, so a report without the field behaves exactly as before.
+    covers = entry.get("datasets") or [dataset]
     provider, dataset_short = split_dataset(dataset)
-    branch = branch_name_for(dataset)
+    branch = branch_name_for_signal(covers)
     skill_md = find_skill_md(provider, dataset_short)
     maintainers = read_maintainers(provider)
     diff = entry.get("diff") or {}
@@ -422,8 +495,8 @@ def handle_drifted(
     )
 
     # 5) open or update PR
-    body = build_pr_body(dataset, diff, skill_md, maintainers)
-    title = pr_title_for(dataset)
+    body = build_pr_body(dataset, diff, skill_md, maintainers, covers=covers)
+    title = pr_title_for(dataset, covers=covers)
 
     existing = pr_exists_for_branch(branch, dry_run=dry_run)
     if existing:
@@ -563,8 +636,15 @@ def main(argv: list[str] | None = None) -> int:
         f"{len(clean)} clean, {len(stub)} stub"
     )
 
+    groups = group_by_drift_signal(drifted)
+    if len(groups) < len(drifted):
+        print(
+            f"  {len(drifted)} drifted dataset(s) share {len(groups)} distinct drift "
+            f"signal(s); opening one PR per signal."
+        )
+
     failed: list[str] = []
-    for entry in drifted:
+    for entry in groups:
         try:
             handle_drifted(
                 entry,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Changed
+
+- **Datasets that share a `drift_fingerprint` baseline are now treated as sharing one
+  drift signal**, rather than as N independent ones. `hvantk drift` probes such a group
+  once and fans the result out — every dataset still gets its own report entry, and each
+  now carries `fingerprint_path` — and the drift workflow opens a single PR per signal.
+  `ucsc-cellbrowser` is the case that forced it: `default`, `adult-ctx` and `dev-ctx` are
+  genuinely distinct *schema* variants (their obs cell-type column is `celltype`, `Class`
+  and `Type_v2`, which is why each earns its own snapshot), but `fetch_fingerprint()`
+  takes no arguments and fingerprints the provider-wide catalog at
+  `cells.ucsc.edu/dataset.json`. One upstream event therefore produced three identical
+  PRs whose branches all wrote the same file, so merging any one made the other two
+  conflict — #241 merged, #242 and #243 were closed as superseded. Grouping is keyed on
+  *(baseline path, probe callable)*, not the path alone: two datasets sharing a baseline
+  while declaring different probes would each overwrite the other's, so they deliberately
+  do not group, and `hvantk plugins validate` now rejects that declaration outright. A
+  lone dataset keeps its historical `drift/<provider>-<dataset>` branch name exactly, so
+  existing open PRs are still matched; a group uses `drift/<provider>`.
+
 ### Fixed
 
 - **Every open drift PR was force-pushed and its body re-edited once a day, forever.**

--- a/hvantk/core/plugin/drift_runner.py
+++ b/hvantk/core/plugin/drift_runner.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import json
 import signal
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from .api import (
     DatasetSpec,
@@ -27,6 +27,10 @@ class DriftResult:
     expected: dict[str, Any] | None = None
     diff: dict[str, Any] | None = None
     probe_error: BaseException | None = None
+    #: The committed baseline this result was diffed against. Datasets that share one
+    #: share a drift signal, which is what lets the CI bot collapse them into a single
+    #: PR instead of one per dataset. See `run_drift_checks`.
+    fingerprint_path: str | None = None
 
 
 def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
@@ -36,6 +40,45 @@ def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
     reg = plugin_loader.get_registry()
     spec = reg.get_dataset(dataset_name)
     return _run_drift_check_with_spec(spec, timeout=timeout)
+
+
+def run_drift_checks(
+    specs: "Iterable[DatasetSpec]", *, timeout: int = 60
+) -> list[DriftResult]:
+    """Drift-check many datasets, probing once per distinct drift signal.
+
+    Datasets that declare the SAME ``drift_fingerprint`` baseline and resolve to the
+    SAME probe callable do not have separate drift signals -- they have one, reported
+    several times. `ucsc-cellbrowser` is the worked example: `default`, `adult-ctx` and
+    `dev-ctx` are distinct *schema* variants (their obs cell-type column is `celltype`,
+    `Class` and `Type_v2` respectively, which is why each earns its own snapshot), but
+    `fetch_fingerprint()` takes no arguments and fingerprints the provider-wide catalog
+    at cells.ucsc.edu/dataset.json. One upstream event therefore produced three
+    identical drift reports, three branches writing the same file, and three mutually
+    conflicting PRs -- merging any one made the other two conflict.
+
+    Grouping is keyed on ``(fingerprint path, probe callable)`` rather than the path
+    alone. Two datasets sharing a baseline but resolving to DIFFERENT probes is a
+    manifest error (the two would overwrite each other's baseline), and this key makes
+    the runtime conservative about it: they simply do not group, and each is probed and
+    reported on its own. `hvantk plugins validate` reports the misconfiguration.
+
+    Every dataset still gets its own entry in the returned list, so the report shape is
+    unchanged; members of a group share ``fingerprint_path``, which is what lets the CI
+    bot open one PR per signal instead of one per dataset.
+    """
+    cache: dict[tuple[str, int], DriftResult] = {}
+    results: list[DriftResult] = []
+    for spec in specs:
+        key = (str(spec.test_paths.drift_fingerprint), id(spec.drift_probe))
+        cached = cache.get(key)
+        if cached is None:
+            cached = _run_drift_check_with_spec(spec, timeout=timeout)
+            cache[key] = cached
+        # `replace` rather than reuse: the shared result carries the FIRST member's
+        # dataset_name, and every caller keys off that field.
+        results.append(replace(cached, dataset_name=spec.name))
+    return results
 
 
 def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
@@ -53,13 +96,22 @@ def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
             f"{exc}; additionally, expected fingerprint is missing at {fp_path}"
         )
     return DriftResult(
-        dataset_name=spec.name, status="probe_failed", probe_error=exc
+        dataset_name=spec.name,
+        status="probe_failed",
+        probe_error=exc,
+        fingerprint_path=str(fp_path),
     )
 
 
 def _run_drift_check_with_spec(
     spec: DatasetSpec, *, timeout: int = 60
 ) -> DriftResult:
+    # Resolved up front because every return below reports it, including the stub
+    # branch, which returns before the baseline is read. Reading the PATH is not
+    # reading the FILE, so this does not disturb the probe-before-baseline ordering
+    # described below.
+    fp_path = Path(spec.test_paths.drift_fingerprint)
+
     # Invoke the probe before loading the baseline so an intentional stub
     # (documentation-only source with no probeable URL) is reported as
     # status="stub" — these plugins ship no committed baseline, so a
@@ -78,9 +130,9 @@ def _run_drift_check_with_spec(
             dataset_name=spec.name,
             status="stub",
             observed=observed,
+            fingerprint_path=str(fp_path),
         )
 
-    fp_path = Path(spec.test_paths.drift_fingerprint)
     try:
         expected = json.loads(fp_path.read_text())
     except FileNotFoundError:
@@ -91,6 +143,7 @@ def _run_drift_check_with_spec(
             probe_error=DriftProbeError(
                 f"missing expected fingerprint at {fp_path}"
             ),
+            fingerprint_path=str(fp_path),
         )
 
     # A hand-seeded baseline cannot equal a live observation, so diffing it would
@@ -107,6 +160,7 @@ def _run_drift_check_with_spec(
                 f"committed baseline at {fp_path} was never captured from a live "
                 f"probe ({seeded}); run `hvantk drift --regenerate {spec.name}`"
             ),
+            fingerprint_path=str(fp_path),
         )
 
     diff = _compare_fingerprints(expected, observed)
@@ -116,6 +170,7 @@ def _run_drift_check_with_spec(
             status="clean",
             observed=observed,
             expected=expected,
+            fingerprint_path=str(fp_path),
         )
     return DriftResult(
         dataset_name=spec.name,
@@ -123,6 +178,7 @@ def _run_drift_check_with_spec(
         observed=observed,
         expected=expected,
         diff=diff,
+        fingerprint_path=str(fp_path),
     )
 
 

--- a/hvantk/skills/_conventions/SKILL.md
+++ b/hvantk/skills/_conventions/SKILL.md
@@ -195,11 +195,17 @@ Each dataset declares a `drift_probe.module` + `function` in `plugin.yaml`. The 
 
 The expected fingerprint lives at `hvantk/skills/<provider>/[<dataset>/]tests/drift_fingerprint.json`. `hvantk drift <provider:dataset>` compares the live probe output against this file. Update the fingerprint when an intentional upstream change has been validated; do not silently regenerate it in the same PR as a behavioural change.
 
+**Sharing one `drift_fingerprint` across datasets is meaningful, not a shortcut.** Datasets that point at the same baseline *and* the same probe are declaring that they have **one** drift signal between them, not one each — which is the honest declaration when the probe is provider-scoped. `ucsc-cellbrowser` is the worked example: `default`, `adult-ctx` and `dev-ctx` are distinct *schema* variants (their obs cell-type column is `celltype`, `Class` and `Type_v2` respectively, so each earns its own snapshot), but `fetch_fingerprint()` takes no arguments and fingerprints the provider-wide catalog, so all three always report identically.
+
+`hvantk drift` probes such a group once and fans the result out — every dataset still gets its own report entry — and the drift workflow opens a single PR per signal. Without that, one upstream event produced three identical PRs whose branches all wrote the same file, so merging any one made the others conflict.
+
+Two datasets may **not** share a baseline while declaring *different* probes: each would overwrite the other's file, and whichever regenerated last would define "clean" for both. `hvantk plugins validate` rejects that.
+
 ### Automated drift workflow
 
 A scheduled GitHub Actions workflow (`.github/workflows/drift.yml`) runs `hvantk drift --all --json` daily at 06:00 UTC. For each plugin reporting `status: drifted`, the workflow:
 
-1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`).
+1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`) — or `drift/<provider>` when several of that provider's datasets share one drift signal, so the group gets a single PR.
 2. Regenerates `drift_fingerprint.json` via `hvantk drift --regenerate <provider:dataset>`.
 3. Opens (or updates) a draft PR via `gh pr create` / `gh pr edit`, with the structured diff embedded in the body and the regenerated fingerprint already committed. If the plugin's `plugin.yaml` declares `maintainers:` whose entries look like GitHub handles, those handles are `cc`'d in the PR body.
 

--- a/hvantk/tests/test_drift_runner.py
+++ b/hvantk/tests/test_drift_runner.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from hvantk.core.plugin import drift_runner
 from hvantk.core.plugin.drift_runner import DriftResult, run_drift_check
 from hvantk.core.plugin.api import DatasetSpec, DriftProbeError, TestPaths
 
@@ -345,3 +346,88 @@ def test_empty_checksums_map_is_still_not_a_placeholder(tmp_path: Path):
     spec = _make_spec(probe_return=dict(fp), fingerprint_path=fp_path)
 
     assert _run_with_spec(spec).status == "clean"
+
+
+# --- one probe per drift signal ------------------------------------------------------
+
+
+def _spec(name, fingerprint_path, probe):
+    """Minimal DatasetSpec stand-in: run_drift_checks touches only these fields."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        name=name,
+        drift_probe=probe,
+        test_paths=SimpleNamespace(drift_fingerprint=str(fingerprint_path)),
+    )
+
+
+def test_datasets_sharing_a_baseline_and_probe_are_probed_once(tmp_path):
+    """ucsc-cellbrowser's three datasets share one baseline and one zero-arg probe, so
+    they have ONE drift signal. Probing per dataset made three identical HTTP calls and
+    produced three mutually-conflicting PRs."""
+    fp = tmp_path / "drift_fingerprint.json"
+    fp.write_text(json.dumps({"source_version": "v1", "fetched_at": "2026-01-01"}))
+
+    calls = []
+
+    def probe():
+        calls.append(1)
+        return {"source_version": "v1", "fetched_at": "2026-08-04"}
+
+    specs = [_spec(f"ucsc:{n}", fp, probe) for n in ("default", "adult-ctx", "dev-ctx")]
+    results = drift_runner.run_drift_checks(specs)
+
+    assert len(calls) == 1, f"probe ran {len(calls)} times; expected 1"
+    assert [r.dataset_name for r in results] == [
+        "ucsc:default", "ucsc:adult-ctx", "ucsc:dev-ctx"
+    ], "every dataset must still get its own entry"
+    assert {r.status for r in results} == {"clean"}
+    assert {r.fingerprint_path for r in results} == {str(fp)}
+
+
+def test_same_baseline_but_different_probes_are_not_grouped(tmp_path):
+    """Conservative on a manifest error: two probes writing one baseline would each
+    overwrite the other, so they must not share a result. `plugins validate` rejects the
+    declaration; the runtime simply refuses to merge them."""
+    fp = tmp_path / "drift_fingerprint.json"
+    fp.write_text(json.dumps({"source_version": "v1"}))
+
+    calls = []
+
+    def probe_a():
+        calls.append("a")
+        return {"source_version": "v1"}
+
+    def probe_b():
+        calls.append("b")
+        return {"source_version": "v1"}
+
+    results = drift_runner.run_drift_checks(
+        [_spec("p:one", fp, probe_a), _spec("p:two", fp, probe_b)]
+    )
+
+    assert sorted(calls) == ["a", "b"], "each distinct probe must run"
+    assert len(results) == 2
+
+
+def test_distinct_baselines_are_probed_separately(tmp_path):
+    """The obvious non-regression: unrelated datasets keep independent drift."""
+    calls = []
+
+    def make(version):
+        def probe():
+            calls.append(version)
+            return {"source_version": version}
+        return probe
+
+    specs = []
+    for name, version in (("a:x", "1"), ("b:y", "2")):
+        fp = tmp_path / f"{name.replace(':', '_')}.json"
+        fp.write_text(json.dumps({"source_version": version}))
+        specs.append(_spec(name, fp, make(version)))
+
+    results = drift_runner.run_drift_checks(specs)
+
+    assert sorted(calls) == ["1", "2"]
+    assert {r.status for r in results} == {"clean"}

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -417,3 +417,25 @@ def test_discard_staged_fingerprints_clears_index_and_worktree(
     assert _git(repo, "diff", "--cached", "--name-only").stdout.strip() == ""
     assert fp.read_text() == original, "working tree must be restored too, or the next "\
         "`git add hvantk/skills` re-stages the leak"
+
+
+def test_two_signals_from_one_provider_do_not_collide_on_one_branch(drift_to_pr):
+    """Review finding on #263: keying a group's branch on the provider alone discards the
+    baseline path that DEFINES the signal. Multi-dataset providers suffix their baselines
+    per dataset, so a provider can own two independent signals; collapsing them onto one
+    branch means the second overwrites the first's commit and rewrites its PR."""
+    a = drift_to_pr.branch_name_for_signal(
+        ["p:one", "p:two"], "hvantk/skills/p/tests/drift_fingerprint.json"
+    )
+    b = drift_to_pr.branch_name_for_signal(
+        ["p:three", "p:four"], "hvantk/skills/p/tests/drift_fingerprint_samples.json"
+    )
+    assert a != b, f"distinct signals collided on {a}"
+    assert a == "drift/p"                 # the unsuffixed baseline keeps the plain name
+    assert b == "drift/p-samples"
+
+
+def test_group_branch_still_stable_across_member_order(drift_to_pr):
+    fp = "hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json"
+    assert drift_to_pr.branch_name_for_signal(["u:a", "u:b", "u:c"], fp) == \
+           drift_to_pr.branch_name_for_signal(["u:c", "u:a", "u:b"], fp)

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -188,3 +188,87 @@ def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeyp
     """No branch yet -> always push. Cheap, but it is the common first-drift path."""
     monkeypatch.setattr(drift_to_pr, "remote_branch_exists", lambda b, dry_run: False)
     assert drift_to_pr.branch_needs_update("drift/x-y", dry_run=False) is True
+
+
+# --- one PR per drift SIGNAL, not per dataset --------------------------------------
+#
+# ucsc-cellbrowser declares three datasets (default / adult-ctx / dev-ctx) that are
+# distinct SCHEMA variants -- their obs cell-type column is `celltype`, `Class` and
+# `Type_v2` -- but all three share one drift_fingerprint and a zero-argument probe that
+# fingerprints the provider-wide catalog. One upstream event therefore produced three
+# identical PRs, and merging any one made the other two conflict (#241/#242/#243).
+
+
+def _drifted(name, path):
+    return {"dataset_name": name, "status": "drifted", "fingerprint_path": path,
+            "observed": {}, "expected": {}, "diff": {}, "probe_error": None}
+
+
+UCSC_FP = "hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json"
+
+
+def test_datasets_sharing_a_baseline_collapse_to_one_entry(drift_to_pr):
+    groups = drift_to_pr.group_by_drift_signal([
+        _drifted("ucsc-cellbrowser:default", UCSC_FP),
+        _drifted("ucsc-cellbrowser:adult-ctx", UCSC_FP),
+        _drifted("ucsc-cellbrowser:dev-ctx", UCSC_FP),
+    ])
+
+    assert len(groups) == 1
+    assert groups[0]["datasets"] == [
+        "ucsc-cellbrowser:default",
+        "ucsc-cellbrowser:adult-ctx",
+        "ucsc-cellbrowser:dev-ctx",
+    ]
+
+
+def test_distinct_baselines_are_never_merged(drift_to_pr):
+    """The guard that keeps this from over-collapsing: different file, different PR."""
+    groups = drift_to_pr.group_by_drift_signal([
+        _drifted("clinvar:variants", "hvantk/skills/clinvar/tests/drift_fingerprint.json"),
+        _drifted("hgnc:lookup", "hvantk/skills/hgnc/tests/drift_fingerprint.json"),
+    ])
+    assert len(groups) == 2
+
+
+def test_entries_without_a_fingerprint_path_are_never_grouped(drift_to_pr):
+    """An older report shape must not silently collapse unrelated datasets into one PR."""
+    groups = drift_to_pr.group_by_drift_signal([
+        {"dataset_name": "a:x", "status": "drifted"},
+        {"dataset_name": "b:y", "status": "drifted"},
+    ])
+    assert len(groups) == 2
+    assert [g["datasets"] for g in groups] == [["a:x"], ["b:y"]]
+
+
+def test_group_branch_is_provider_level_but_single_datasets_keep_their_name(drift_to_pr):
+    """A lone dataset must keep its historical branch, or open PRs stop being matched."""
+    assert drift_to_pr.branch_name_for_signal(["clinvar:variants"]) == "drift/clinvar-variants"
+    assert drift_to_pr.branch_name_for_signal([
+        "ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx",
+    ]) == "drift/ucsc-cellbrowser"
+
+
+def test_group_branch_is_stable_regardless_of_member_order(drift_to_pr):
+    """Branch names must not move between runs, or every run orphans yesterday's PR."""
+    a = drift_to_pr.branch_name_for_signal(["ucsc:default", "ucsc:adult", "ucsc:dev"])
+    b = drift_to_pr.branch_name_for_signal(["ucsc:dev", "ucsc:default", "ucsc:adult"])
+    assert a == b
+
+
+def test_grouped_pr_names_every_dataset_it_covers(drift_to_pr):
+    body = drift_to_pr.build_pr_body(
+        "ucsc-cellbrowser:default", {}, None, [],
+        covers=["ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx"],
+    )
+    assert "ucsc-cellbrowser:adult-ctx" in body
+
+    title = drift_to_pr.pr_title_for(
+        "ucsc-cellbrowser:default",
+        covers=["ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx"],
+    )
+    assert "2 datasets" in title
+    # A single dataset keeps the original title verbatim.
+    assert drift_to_pr.pr_title_for("clinvar:variants") == (
+        "chore(drift): clinvar:variants snapshot regeneration"
+    )

--- a/hvantk/tools/plugins/drift_cli.py
+++ b/hvantk/tools/plugins/drift_cli.py
@@ -52,7 +52,11 @@ def drift_cmd(dataset, all_flag, domain, as_json, regenerate, timeout):
         click.echo(f"unknown dataset: {dataset}", err=True)
         raise SystemExit(EXIT_REGISTRY_ERROR)
 
-    results = [drift_runner.run_drift_check(spec.name, timeout=timeout) for spec in targets]
+    # run_drift_checks, not a comprehension over run_drift_check: datasets sharing a
+    # baseline AND a probe callable share one drift signal, so it is probed once and
+    # fanned out. Every dataset still gets its own entry; they just agree, and the CI
+    # bot collapses them into one PR via the shared fingerprint_path.
+    results = drift_runner.run_drift_checks(targets, timeout=timeout)
 
     if as_json:
         click.echo(json.dumps([_serialize(r) for r in results], indent=2, default=str))

--- a/hvantk/tools/plugins/plugins_cli.py
+++ b/hvantk/tools/plugins/plugins_cli.py
@@ -146,4 +146,31 @@ def validate_cmd(manifest_path: str, strict_artifacts: bool):
             err=True,
         )
 
+    # Datasets may deliberately SHARE a drift_fingerprint -- that is how a manifest says
+    # "these have one drift signal, not N", and the drift runner groups on it so one
+    # upstream event yields one PR rather than one per dataset. Sharing is only coherent
+    # when the probe is also shared: two datasets pointing different probes at one
+    # baseline would each overwrite the other's, and whichever regenerated last would
+    # define "clean" for both. That is a manifest error, so name it.
+    by_fingerprint: dict[str, list[tuple[str, tuple[str, str]]]] = {}
+    for dataset in content.get("datasets", []):
+        rel = (dataset.get("tests") or {}).get("drift_fingerprint")
+        probe = dataset.get("drift_probe") or {}
+        if not rel:
+            continue
+        by_fingerprint.setdefault(rel, []).append(
+            (dataset.get("name", "?"), (probe.get("module", ""), probe.get("function", "")))
+        )
+    conflicts = [
+        f"{rel} is shared by "
+        + ", ".join(f"{name} -> {mod}:{fn}" for name, (mod, fn) in members)
+        for rel, members in sorted(by_fingerprint.items())
+        if len({probe for _, probe in members}) > 1
+    ]
+    if conflicts:
+        raise click.ClickException(
+            "datasets share a drift_fingerprint but declare different drift probes; "
+            "they would overwrite each other's baseline:\n  - " + "\n  - ".join(conflicts)
+        )
+
     click.echo(f"ok: {manifest_path}")


### PR DESCRIPTION
> **Stacks on #262** (both touch `drift_to_pr.py`). Merge that first; this diff will shrink to its own changes once it lands.

`ucsc-cellbrowser` produced three identical drift PRs per upstream event, and merging any one made the other two conflict — #241 merged, #242 and #243 closed as superseded.

## The three datasets are not redundant

Worth saying up front, because the obvious fix is wrong. `default`, `adult-ctx` and `dev-ctx` are genuinely distinct **schema** variants:

| dataset | obs cell-type column |
|---|---|
| `default` | `celltype` |
| `adult-ctx` | `Class` |
| `dev-ctx` | `Type_v2` |

UCSC collections don't standardise that column name, and the plugin contract's rule is to add a `datasets:` entry when a collection's obs columns differ structurally. Each of the three earns its own fixture, snapshot and `schema_id`. **None of them should be removed.**

## What *is* redundant is the drift signal

`fetch_fingerprint()` takes no arguments and fingerprints the provider-wide catalog at `cells.ucsc.edu/dataset.json`. It cannot distinguish one collection from another. So a **provider-scoped probe was registered on the per-schema-variant axis**, and one upstream event got reported three times — three branches, all writing the same file, mutually conflicting.

It scaled the wrong way *by design*: the contract tells contributors to add a `datasets:` entry whenever obs columns differ, so onboarding a fourth collection with a new column name would have meant four identical PRs, a fifth five.

## The manifest already declared the grouping

All three datasets name the same `drift_fingerprint: tests/drift_fingerprint.json`, while **every other** test artifact — fixture, schema snapshot, row snapshot — is per-dataset. That shared path is the declaration; nothing read it that way.

- **Runner.** `run_drift_checks()` probes once per group and fans the result out with `dataclasses.replace`. Every dataset still gets its own report entry, so the report shape is unchanged; entries now carry `fingerprint_path`.
- **Bot.** `group_by_drift_signal()` collapses entries sharing that path into one PR, which names every dataset it covers.
- **Validate.** `hvantk plugins validate` now rejects a shared baseline with *differing* probes — each would overwrite the other's file, and whichever regenerated last would define "clean" for both.

Grouping is keyed on **(baseline path, probe callable)**, not the path alone, so the runtime stays conservative about that misconfiguration rather than silently merging two different signals.

## Safety properties

| situation | behaviour |
|---|---|
| single dataset | keeps `drift/<provider>-<dataset>` **verbatim**, so open PRs stay matched |
| group, one provider | `drift/<provider>` — stable across runs, doesn't privilege the manifest's first member |
| no `fingerprint_path` (older report) | **never grouped** |
| different probes, same baseline | not grouped; validate rejects the declaration |

## Verified end to end

Synthetic four-dataset report through the real script:

```
4 drifted dataset(s) share 2 distinct drift signal(s); opening one PR per signal.
=== Drifted: ucsc-cellbrowser:default -> branch drift/ucsc-cellbrowser ===
   --title chore(drift): ucsc-cellbrowser snapshot regeneration (3 datasets)
=== Drifted: hgnc:lookup -> branch drift/hgnc-lookup ===
   --title chore(drift): hgnc:lookup snapshot regeneration
```

hgnc — the control — keeps its original branch and title untouched.

The validate guard was confirmed with a negative control (mutate one dataset's probe function, keep the shared baseline) rather than assumed:

```
Error: datasets share a drift_fingerprint but declare different drift probes;
they would overwrite each other's baseline:
  - tests/drift_fingerprint.json is shared by default -> …:fetch_fingerprint,
    adult-ctx -> …:some_other_probe, dev-ctx -> …:fetch_fingerprint
```

## A bug this change introduced, caught before merge

Hoisting `fp_path` so every return could report it left the `stub` branch referencing it **before assignment** — a `NameError` that would have broken all 8 stub datasets on the first `--all` run. Fixed, with a comment noting that reading the *path* early does not disturb the deliberate probe-before-baseline ordering.

## Verification

- **1454 passed, 11 skipped, 0 failed** (full default suite).
- 9 new tests: probe-runs-once, distinct baselines stay separate, different probes don't group, no-path entries never group, branch stability under member reordering, single-dataset branch/title unchanged, grouped PR names its members.
- flake8 error-pass 0; style pass **identical to baseline** (the 2 F401s in `test_drift_runner.py` are pre-existing, byte-for-byte).
- `_conventions/SKILL.md` documents the semantics, since "shared fingerprint = shared signal" is now part of the plugin contract.
