### PR TITLE
chore(release): stamp 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 — 2026-08-05
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
 [project]
 name = "hvantk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Hail-based toolkit for multi-omics variant annotation and analysis"
 authors = [
     { name = "Yasset Perez-Riverol", email = "ypriverol@gmail.com" },


### PR DESCRIPTION
Version bump and CHANGELOG stamp ahead of the `dev` → `main` release.

**Minor, not patch.** #261 adds `--n-partitions`, a new user-facing flag on two commands; #263 changes documented drift behaviour (datasets sharing a `drift_fingerprint` now report one signal rather than N, and `hvantk drift --all --json` gains a `fingerprint_path` field). Both are additive-or-behavioural rather than pure fixes, so `0.2.0` → `0.3.0`.

Stamped *before* the release PR rather than after, so `main` never carries an unstamped `Unreleased` section. That habit is what let `0.1.0` sit on `main` across 61 merges over fifteen months.

CHANGELOG-only plus the one version line; `poetry check` reports "All set!" and `test_pyproject_extras.py` passes.