### PR TITLE
release: 0.3.0

### DIFF
--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -159,17 +159,25 @@ def group_by_drift_signal(drifted: list[dict]) -> list[dict]:
 
     Order is preserved so branch names stay stable across runs.
     """
-    grouped: dict[str, dict] = {}
+    grouped: dict[tuple, dict] = {}
     out: list[dict] = []
     for entry in drifted:
         path = entry.get("fingerprint_path")
         if not path:
             out.append({**entry, "datasets": [entry.get("dataset_name")]})
             continue
-        existing = grouped.get(path)
+        # Key on (baseline, probe), exactly as `run_drift_checks` does. Grouping on the
+        # baseline alone would re-merge what the runner deliberately kept apart: two
+        # datasets sharing a baseline while declaring DIFFERENT probes is a manifest
+        # error, and merging them would open a single PR whose regeneration covers only
+        # `entry["dataset_name"]`, leaving the other dataset's drift silently
+        # unaddressed. A report without probe_ref (older shape) falls back to the path,
+        # which is the pre-existing behaviour rather than a new risk.
+        key = (path, entry.get("probe_ref"))
+        existing = grouped.get(key)
         if existing is None:
             merged = {**entry, "datasets": [entry.get("dataset_name")]}
-            grouped[path] = merged
+            grouped[key] = merged
             out.append(merged)
         else:
             existing["datasets"].append(entry.get("dataset_name"))
@@ -405,10 +413,19 @@ def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
         return True
 
     for path in paths:
-        current = (REPO_ROOT / path).read_text() if (REPO_ROOT / path).exists() else None
+        # `errors="replace"` rather than a bare read_text(): a staged file that is not
+        # valid UTF-8 raises UnicodeDecodeError, which is not a CalledProcessError, so
+        # `main` would not catch it and every remaining dataset would be skipped. And
+        # `paths` is every staged path, not only JSON under hvantk/skills, so that
+        # depends on runner state rather than on this script's own staging. A mangled
+        # decode can only make the comparison unequal, which pushes -- the safe answer.
+        target = REPO_ROOT / path
+        current = target.read_text(errors="replace") if target.exists() else None
+        # errors="replace" here too: text=True decodes strictly, so a blob that is not
+        # valid UTF-8 would raise UnicodeDecodeError out of subprocess itself.
         previous = subprocess.run(
             ["git", "show", f"FETCH_HEAD:{path}"],
-            check=False, text=True, capture_output=True,
+            check=False, text=True, errors="replace", capture_output=True,
         )
         if current is None or previous.returncode != 0:
             return True

--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -267,6 +267,29 @@ def remote_branch_exists(branch: str, *, dry_run: bool) -> bool:
     return bool((result.stdout or "").strip())
 
 
+def _discard_staged_fingerprints(*, dry_run: bool) -> None:
+    """Return index AND working tree for ``hvantk/skills`` to HEAD.
+
+    Every early return out of `handle_drifted` after `git add` must call this. The
+    regeneration is per-dataset but the checkout is not isolated: the next iteration
+    does `git checkout -B <next-branch> origin/<base>`, which leaves both the index and
+    the working tree untouched. A leftover staged fingerprint would therefore be picked
+    up by the next dataset's `git add hvantk/skills` and committed onto ITS branch --
+    contaminating an unrelated PR, and masking that dataset's own skip check because
+    the diff is no longer empty.
+
+    `git checkout HEAD -- <path>` rather than `git reset`: reset alone unstages but
+    leaves the modified file in the working tree, where the next `git add` re-stages it.
+    """
+    if dry_run:
+        print("[dry-run] (would discard staged fingerprint changes)")
+        return
+    subprocess.run(
+        ["git", "checkout", "HEAD", "--", "hvantk/skills"],
+        check=False, text=True, capture_output=True,
+    )
+
+
 def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
     """Should the staged fingerprints be pushed to ``branch``?
 
@@ -386,6 +409,7 @@ def handle_drifted(
                 f"  no fingerprint changes to commit for {dataset}; "
                 "drift may have already been addressed. Skipping PR."
             )
+            _discard_staged_fingerprints(dry_run=dry_run)
             return
 
         # ...and neither should a re-push that changes nothing but a timestamp.
@@ -403,10 +427,32 @@ def handle_drifted(
         # So: if the branch already exists and already proposes materially the same
         # fingerprint, leave it alone. The PR stays open with its original body; only a
         # genuine upstream change re-pushes.
-        if not branch_needs_update(branch, dry_run=dry_run):
+        # Only skip when an open PR actually exists to be left alone. A branch can
+        # outlive its PR -- closing a PR does not delete the head branch, and a run
+        # whose push succeeded while `gh pr create` failed leaves a branch with no PR
+        # at all (that exact failure is why this script exits nonzero on gh errors; see
+        # the module docstring). In either case the branch content matches, so a
+        # content-only check would skip forever and the dataset's drift would never be
+        # surfaced again -- the precise outcome `branch_needs_update` promises cannot
+        # happen. Re-opening a PR for an existing branch is cheap; silence is not.
+        if not branch_needs_update(branch, dry_run=dry_run) and pr_exists_for_branch(
+            branch, dry_run=dry_run
+        ):
             print(
                 f"  branch {branch} already proposes this fingerprint "
                 f"(only volatile keys differ); leaving it untouched."
+            )
+            # The regenerated fingerprint is still staged at this point. Leaving it
+            # there would carry THIS dataset's baseline into the NEXT dataset's branch:
+            # `git checkout -B` does not clear the index, so the next iteration's
+            # `git add hvantk/skills` would stage both, and the next PR would commit a
+            # bump it has nothing to do with. It would also defeat this very skip for
+            # every dataset processed after a skipped one.
+            _discard_staged_fingerprints(dry_run=dry_run)
+            _summary_line(
+                step_summary,
+                f"- DRIFT (unchanged): `{dataset}` -> branch `{branch}` still open; "
+                f"nothing new to push",
             )
             return
 

--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -111,23 +111,34 @@ def fingerprints_match(a: str, b: str) -> bool:
         return False
 
 
-def branch_name_for_signal(datasets: list[str]) -> str:
+def branch_name_for_signal(datasets: list[str], fingerprint_path: str = "") -> str:
     """Branch name for a drift signal covering one or more datasets.
 
     A single dataset keeps its historical name exactly (``drift/<provider>-<dataset>``),
-    so existing branches and their open PRs are still matched. A group that is entirely
-    one provider's collapses to ``drift/<provider>`` -- stable across runs, and it does
-    not privilege whichever member happened to be listed first in the manifest.
+    so existing branches and their open PRs are still matched.
+
+    A group takes ``drift/<provider>``, plus the baseline's distinguishing suffix when it
+    has one. The suffix matters: the branch must identify the SIGNAL, and a provider can
+    own more than one. Multi-dataset providers suffix their baselines per dataset
+    (``drift_fingerprint_samples.json`` alongside ``drift_fingerprint.json``), so keying
+    on the provider alone would collapse two independent signals onto one branch, where
+    the second would overwrite the first's commit and rewrite its PR body. Deriving from
+    the path rather than from the member list also keeps the name stable across runs, and
+    does not privilege whichever member the manifest happens to list first.
     """
     if len(datasets) == 1:
         return branch_name_for(datasets[0])
+
     providers = {split_dataset(d)[0] for d in datasets}
-    if len(providers) == 1:
-        return "drift/" + providers.pop()
-    # A baseline shared ACROSS providers should be impossible -- the path lives inside
-    # one plugin directory -- but fall back to something deterministic rather than
-    # picking arbitrarily, so the branch does not move between runs.
-    return branch_name_for(sorted(datasets)[0])
+    if len(providers) != 1:
+        # A baseline shared ACROSS providers should be impossible -- the path lives
+        # inside one plugin directory -- but stay deterministic rather than arbitrary.
+        return branch_name_for(sorted(datasets)[0])
+
+    base = "drift/" + providers.pop()
+    stem = Path(fingerprint_path).stem if fingerprint_path else ""
+    suffix = stem[len("drift_fingerprint"):].strip("_-") if stem.startswith("drift_fingerprint") else stem
+    return f"{base}-{suffix}" if suffix else base
 
 
 def group_by_drift_signal(drifted: list[dict]) -> list[dict]:
@@ -446,7 +457,7 @@ def handle_drifted(
     # to just this one, so a report without the field behaves exactly as before.
     covers = entry.get("datasets") or [dataset]
     provider, dataset_short = split_dataset(dataset)
-    branch = branch_name_for_signal(covers)
+    branch = branch_name_for_signal(covers, entry.get("fingerprint_path") or "")
     skill_md = find_skill_md(provider, dataset_short)
     maintainers = read_maintainers(provider)
     diff = entry.get("diff") or {}

--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -28,7 +28,11 @@ For each ``status == "drifted"`` entry the script:
 3. Runs ``hvantk drift --regenerate <provider:dataset>`` to overwrite the
    committed ``drift_fingerprint.json``.
 4. Commits with a plain Conventional Commits message.
-5. Force-pushes with lease (the branch is bot-owned).
+5. Force-pushes with lease (the branch is bot-owned) -- but only if the branch does
+   not already propose the same fingerprint. ``--regenerate`` rewrites ``fetched_at``
+   every run, so without that check each open PR was re-pushed and its body re-edited
+   once a day forever: nine PRs churned daily for a week, ~63 notifications, none of
+   them new information.
 6. Opens a draft PR (or updates the body of an existing one).
 
 Probe-failed entries are recorded in the GitHub step summary but never
@@ -66,6 +70,13 @@ except ImportError:  # pragma: no cover - exercised only in stripped envs
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILLS_ROOT = REPO_ROOT / "hvantk" / "skills"
 
+# Mirrors hvantk.core.plugin.api.PROBE_FINGERPRINT_IGNORED_KEYS. Duplicated rather than
+# imported because this script runs from a checkout where the package may not be
+# importable, and `_fingerprints_match` must not become a no-op if the import fails --
+# a silently-empty ignore set would make every comparison "different" and restore the
+# exact churn this guards against. Kept in sync by test_drift_to_pr_script.py.
+FINGERPRINT_IGNORED_KEYS = frozenset({"fetched_at", "probe_version"})
+
 
 # --------------------------------------------------------------------------- #
 # Pure helpers (no side effects, easy to reason about / test).
@@ -81,6 +92,23 @@ def branch_name_for(dataset: str) -> str:
     if ":" not in dataset:
         raise ValueError(f"expected '<provider>:<dataset>', got: {dataset!r}")
     return "drift/" + dataset.replace(":", "-")
+
+
+def strip_ignored(fingerprint: dict) -> dict:
+    """Fingerprint minus the keys that change on every probe regardless of upstream."""
+    return {k: v for k, v in fingerprint.items() if k not in FINGERPRINT_IGNORED_KEYS}
+
+
+def fingerprints_match(a: str, b: str) -> bool:
+    """True if two fingerprint JSON blobs agree once volatile keys are dropped.
+
+    Unparseable input returns False -- "I cannot tell" must mean "push it", never
+    "skip it", or a malformed fingerprint would silently suppress a real drift PR.
+    """
+    try:
+        return strip_ignored(json.loads(a)) == strip_ignored(json.loads(b))
+    except (ValueError, AttributeError, TypeError):
+        return False
 
 
 def split_dataset(dataset: str) -> tuple[str, str]:
@@ -233,7 +261,57 @@ def remote_branch_exists(branch: str, *, dry_run: bool) -> bool:
         text=True,
         capture_output=True,
     )
-    return bool(result.stdout.strip())
+    # `or ""` rather than a bare .strip(): stdout is None whenever the call was made
+    # without capture_output, and a crash here would abort a drift run over a branch
+    # existence check.
+    return bool((result.stdout or "").strip())
+
+
+def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
+    """Should the staged fingerprints be pushed to ``branch``?
+
+    False only when the branch already exists AND every staged fingerprint is
+    materially identical to the one it already carries -- i.e. the sole difference is
+    `fetched_at`. Everything else returns True, deliberately: a branch that does not
+    exist, a file the branch lacks, an unreadable blob or a git failure all mean "I
+    cannot prove this is redundant", and the safe answer is to push. Suppressing a real
+    drift PR is far worse than one redundant force-push.
+    """
+    if dry_run:
+        return True
+    if not remote_branch_exists(branch, dry_run=dry_run):
+        return True
+
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=False, text=True, capture_output=True,
+    )
+    paths = [p for p in (staged.stdout or "").split("\n") if p.strip()]
+    if staged.returncode != 0 or not paths:
+        return True
+
+    # The branch ref may not exist locally -- the run checked out BASE_BRANCH, not this
+    # one -- so fetch it and read blobs out of FETCH_HEAD rather than assuming
+    # origin/<branch> is present.
+    fetched = subprocess.run(
+        ["git", "fetch", "origin", branch],
+        check=False, text=True, capture_output=True,
+    )
+    if fetched.returncode != 0:
+        return True
+
+    for path in paths:
+        current = (REPO_ROOT / path).read_text() if (REPO_ROOT / path).exists() else None
+        previous = subprocess.run(
+            ["git", "show", f"FETCH_HEAD:{path}"],
+            check=False, text=True, capture_output=True,
+        )
+        if current is None or previous.returncode != 0:
+            return True
+        if not fingerprints_match(current, previous.stdout):
+            return True
+
+    return False
 
 
 def pr_exists_for_branch(branch: str, *, dry_run: bool) -> str | None:
@@ -307,6 +385,28 @@ def handle_drifted(
             print(
                 f"  no fingerprint changes to commit for {dataset}; "
                 "drift may have already been addressed. Skipping PR."
+            )
+            return
+
+        # ...and neither should a re-push that changes nothing but a timestamp.
+        #
+        # The check above compares against BASE_BRANCH, so for a dataset that is still
+        # drifted it can never fire: `--regenerate` rewrites `fetched_at` on every run,
+        # which alone guarantees a non-empty diff. The result was that each of the nine
+        # open drift PRs got a fresh force-push and a body edit EVERY morning for a
+        # week -- ~63 notification events, none of them carrying new information --
+        # because nothing compared the new fingerprint against what the branch already
+        # proposed. `fetched_at` is excluded from drift comparison
+        # (PROBE_FINGERPRINT_IGNORED_KEYS) but still written into the committed file,
+        # so it is invisible to the detector and load-bearing for the diff.
+        #
+        # So: if the branch already exists and already proposes materially the same
+        # fingerprint, leave it alone. The PR stays open with its original body; only a
+        # genuine upstream change re-pushes.
+        if not branch_needs_update(branch, dry_run=dry_run):
+            print(
+                f"  branch {branch} already proposes this fingerprint "
+                f"(only volatile keys differ); leaving it untouched."
             )
             return
 

--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -111,6 +111,60 @@ def fingerprints_match(a: str, b: str) -> bool:
         return False
 
 
+def branch_name_for_signal(datasets: list[str]) -> str:
+    """Branch name for a drift signal covering one or more datasets.
+
+    A single dataset keeps its historical name exactly (``drift/<provider>-<dataset>``),
+    so existing branches and their open PRs are still matched. A group that is entirely
+    one provider's collapses to ``drift/<provider>`` -- stable across runs, and it does
+    not privilege whichever member happened to be listed first in the manifest.
+    """
+    if len(datasets) == 1:
+        return branch_name_for(datasets[0])
+    providers = {split_dataset(d)[0] for d in datasets}
+    if len(providers) == 1:
+        return "drift/" + providers.pop()
+    # A baseline shared ACROSS providers should be impossible -- the path lives inside
+    # one plugin directory -- but fall back to something deterministic rather than
+    # picking arbitrarily, so the branch does not move between runs.
+    return branch_name_for(sorted(datasets)[0])
+
+
+def group_by_drift_signal(drifted: list[dict]) -> list[dict]:
+    """Collapse drifted entries that report the SAME drift signal into one.
+
+    Datasets sharing a ``fingerprint_path`` share a baseline file, so they cannot have
+    independent drift: one upstream event produces N identical reports, N branches
+    writing the same file, and N mutually conflicting PRs. `ucsc-cellbrowser` is the
+    worked case -- `default`, `adult-ctx` and `dev-ctx` are distinct *schema* variants
+    (obs cell-type column `celltype` / `Class` / `Type_v2`), but the probe fingerprints
+    the provider-wide catalog, so all three always agree. Merging one made the other two
+    conflict.
+
+    Returns one entry per signal, each carrying a ``datasets`` list naming every member,
+    so the PR can say what it covers. Entries WITHOUT a fingerprint_path are never
+    grouped -- an older report shape, or a runner that did not populate it, must not
+    silently collapse unrelated datasets into one PR.
+
+    Order is preserved so branch names stay stable across runs.
+    """
+    grouped: dict[str, dict] = {}
+    out: list[dict] = []
+    for entry in drifted:
+        path = entry.get("fingerprint_path")
+        if not path:
+            out.append({**entry, "datasets": [entry.get("dataset_name")]})
+            continue
+        existing = grouped.get(path)
+        if existing is None:
+            merged = {**entry, "datasets": [entry.get("dataset_name")]}
+            grouped[path] = merged
+            out.append(merged)
+        else:
+            existing["datasets"].append(entry.get("dataset_name"))
+    return out
+
+
 def split_dataset(dataset: str) -> tuple[str, str]:
     provider, _, name = dataset.partition(":")
     return provider, name
@@ -181,11 +235,23 @@ def build_pr_body(
     diff: dict | None,
     skill_md: Path | None,
     maintainers: list[str],
+    covers: list[str] | None = None,
 ) -> str:
     lines: list[str] = []
+    others = [d for d in (covers or []) if d and d != dataset]
     lines.append(
         f"Automated drift detection found upstream changes for `{dataset}`."
     )
+    if others:
+        listed = ", ".join(f"`{d}`" for d in others)
+        lines.append("")
+        lines.append(
+            f"This also covers {listed}. Those datasets declare the same "
+            "`drift_fingerprint` baseline and the same probe, so they report one drift "
+            "signal between them, not one each -- they are distinct *schema* variants "
+            "of the same upstream resource. Previously each opened its own PR proposing "
+            "byte-identical content, and merging any one made the rest conflict."
+        )
     lines.append("")
     lines.append(
         "This PR regenerates `drift_fingerprint.json` so the test suite "
@@ -219,7 +285,11 @@ def build_pr_body(
     return "\n".join(lines) + "\n"
 
 
-def pr_title_for(dataset: str) -> str:
+def pr_title_for(dataset: str, covers: list[str] | None = None) -> str:
+    extra = len([d for d in (covers or []) if d and d != dataset])
+    if extra:
+        provider = split_dataset(dataset)[0]
+        return f"chore(drift): {provider} snapshot regeneration ({extra + 1} datasets)"
     return f"chore(drift): {dataset} snapshot regeneration"
 
 
@@ -349,8 +419,11 @@ def handle_drifted(
     step_summary: Path | None,
 ) -> None:
     dataset = entry["dataset_name"]
+    # Datasets sharing this entry's drift signal (see group_by_drift_signal). Defaults
+    # to just this one, so a report without the field behaves exactly as before.
+    covers = entry.get("datasets") or [dataset]
     provider, dataset_short = split_dataset(dataset)
-    branch = branch_name_for(dataset)
+    branch = branch_name_for_signal(covers)
     skill_md = find_skill_md(provider, dataset_short)
     maintainers = read_maintainers(provider)
     diff = entry.get("diff") or {}
@@ -422,8 +495,8 @@ def handle_drifted(
     )
 
     # 5) open or update PR
-    body = build_pr_body(dataset, diff, skill_md, maintainers)
-    title = pr_title_for(dataset)
+    body = build_pr_body(dataset, diff, skill_md, maintainers, covers=covers)
+    title = pr_title_for(dataset, covers=covers)
 
     existing = pr_exists_for_branch(branch, dry_run=dry_run)
     if existing:
@@ -563,8 +636,15 @@ def main(argv: list[str] | None = None) -> int:
         f"{len(clean)} clean, {len(stub)} stub"
     )
 
+    groups = group_by_drift_signal(drifted)
+    if len(groups) < len(drifted):
+        print(
+            f"  {len(drifted)} drifted dataset(s) share {len(groups)} distinct drift "
+            f"signal(s); opening one PR per signal."
+        )
+
     failed: list[str] = []
-    for entry in drifted:
+    for entry in groups:
         try:
             handle_drifted(
                 entry,

--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -373,10 +373,20 @@ def _discard_staged_fingerprints(*, dry_run: bool) -> None:
     if dry_run:
         print("[dry-run] (would discard staged fingerprint changes)")
         return
-    subprocess.run(
+    result = subprocess.run(
         ["git", "checkout", "HEAD", "--", "hvantk/skills"],
         check=False, text=True, capture_output=True,
     )
+    if result.returncode != 0:
+        # `check=False` keeps one failed cleanup from aborting the whole run, but
+        # swallowing the output would hide the exact state this function exists to
+        # prevent: the fingerprint stays staged and the next dataset commits it onto
+        # ITS branch. Surface it so the job log names the contaminating run.
+        print(
+            "  WARNING: could not discard staged fingerprints; the next dataset may "
+            f"commit them onto its branch: {(result.stderr or '').strip()}",
+            file=sys.stderr,
+        )
 
 
 def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
@@ -730,17 +740,23 @@ def main(argv: list[str] | None = None) -> int:
             # One drifted dataset failing to PR shouldn't stop the others, but it
             # must not vanish either: collected here and re-raised as a nonzero
             # exit once every dataset has had its turn.
-            failed.append(str(entry.get("dataset_name")))
+            #
+            # Name every dataset the signal covers, not just the anchor. A grouped
+            # entry regenerates one baseline on behalf of several datasets, so
+            # reporting `dataset_name` alone would show the operator one dataset when
+            # several are left unaddressed.
+            covered = [str(d) for d in (entry.get("datasets") or [entry.get("dataset_name")])]
+            failed.extend(covered)
+            label = ", ".join(covered)
             print(
-                f"error handling {entry.get('dataset_name')}: "
+                f"error handling {label}: "
                 f"{exc.cmd} exited {exc.returncode}\n"
                 f"stdout: {exc.stdout}\nstderr: {exc.stderr}",
                 file=sys.stderr,
             )
             _summary_line(
                 step_summary,
-                f"- ERROR: `{entry.get('dataset_name')}` -- "
-                f"{exc.cmd[0]} exited {exc.returncode}",
+                f"- ERROR: `{label}` -- {exc.cmd[0]} exited {exc.returncode}",
             )
 
     for entry in probe_failed:

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -61,9 +61,17 @@ jobs:
         run: |
           conda env update --file environment.yml --name base
 
+      # The `ptm` extra, not a bare install. The cptac probe fingerprints the INSTALLED
+      # cptac version (importlib.metadata) against PayneLab's latest GitHub release, so
+      # the package has to be present for the probe to mean anything -- and `cptac` is
+      # declared in the `ptm` extra. Under a bare `pip install -e .` both cptac:expression
+      # and cptac:phospho raised "The 'cptac' Python package is not installed; cannot
+      # fingerprint" on EVERY run, so upstream CPTAC drift has never once been detectable.
+      # Of the 22 probes these two are the only ones needing an extra; the other 20 use
+      # requests or the stdlib alone.
       - name: Install hvantk in development mode
         run: |
-          pip install -e .
+          pip install -e ".[ptm]"
 
       - name: Configure git author for bot commits
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Changed
+
+- **Datasets that share a `drift_fingerprint` baseline are now treated as sharing one
+  drift signal**, rather than as N independent ones. `hvantk drift` probes such a group
+  once and fans the result out — every dataset still gets its own report entry, and each
+  now carries `fingerprint_path` — and the drift workflow opens a single PR per signal.
+  `ucsc-cellbrowser` is the case that forced it: `default`, `adult-ctx` and `dev-ctx` are
+  genuinely distinct *schema* variants (their obs cell-type column is `celltype`, `Class`
+  and `Type_v2`, which is why each earns its own snapshot), but `fetch_fingerprint()`
+  takes no arguments and fingerprints the provider-wide catalog at
+  `cells.ucsc.edu/dataset.json`. One upstream event therefore produced three identical
+  PRs whose branches all wrote the same file, so merging any one made the other two
+  conflict — #241 merged, #242 and #243 were closed as superseded. Grouping is keyed on
+  *(baseline path, probe callable)*, not the path alone: two datasets sharing a baseline
+  while declaring different probes would each overwrite the other's, so they deliberately
+  do not group, and `hvantk plugins validate` now rejects that declaration outright. A
+  lone dataset keeps its historical `drift/<provider>-<dataset>` branch name exactly, so
+  existing open PRs are still matched; a group uses `drift/<provider>`.
+
 ### Fixed
 
 - **Every open drift PR was force-pushed and its body re-edited once a day, forever.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## Unreleased
 
+### Added
+
+- **`--n-partitions` now controls the VDS → MatrixTable partitioning** on both
+  `hvantk hgc vds2mt` and `hvantk hgc pipeline`, coalescing the dense MatrixTable before
+  the write. A VDS's on-disk layout is derived from its *reference-block* count, which is
+  a property of the genome and saturates (~229 M on chr1 by N≈500 samples) while the dense
+  matrix keeps growing with N×M(N). Past that point the partition count stops tracking the
+  size of the data it partitions and work-per-task collapses — measured at 0.69
+  MiB/partition on a 1,005-sample chr1 cohort, where densify and QC plateaued at 1.29× and
+  1.64× going from 16 to 128 cores while well-sized stages scaled 7.8× (#207).
+  Implemented with `naive_coalesce`, which merges adjacent partitions without a shuffle so
+  the densify for a merged group runs inside one task. Reduces only; the default is
+  unchanged. **Not** implemented at the read: `hl.vds.read_vds(n_partitions=…)` looks
+  tidier but derives intervals from the reference data via `_calculate_new_partitions`,
+  whose count saturates independently of the request — measured on the 2,586-partition
+  test VDS it returned 2 intervals for every request from 2 to 100, and `to_dense_mt` then
+  failed a Scala `require` on the reference/variant mismatch for requests of 2, 4 and 16,
+  where coalescing returned exactly 2, 4 and 16.
+
 ### Fixed
+
+- **`PipelineConfig.n_partitions` reached no pipeline stage.** It was accepted from the
+  CLI and echoed back in the run plan while being read by nothing, so the run plan
+  affirmatively told the user a setting had taken effect when it had not — the worst
+  failure mode for a dead flag, and the first knob a user reaches for when they hit #207.
+  It is now forwarded to `convert_vds_to_mt`; the run plan line names the stage it governs
+  (#208).
 
 - **The `cptac:expression` and `cptac:phospho` drift probes had never once succeeded.**
   The drift workflow installed with a bare `pip install -e .`, but the cptac probe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Fixed
 
+- **Every open drift PR was force-pushed and its body re-edited once a day, forever.**
+  Nine PRs churned daily for a week — roughly 63 notification events, none carrying new
+  information. `hvantk drift --regenerate` rewrites `fetched_at` on every run, and the
+  existing emptiness check compared against the *base branch*, so for a dataset that was
+  still drifted it could never fire: the timestamp alone guaranteed a non-empty diff.
+  Nothing compared the freshly regenerated fingerprint against what the branch already
+  proposed. `drift_to_pr.py` now skips the push and the PR edit when the branch already
+  carries a materially identical fingerprint — "materially" meaning equal once
+  `fetched_at` and `probe_version` are dropped, the same keys the drift detector ignores.
+  Every other outcome (no branch yet, a file the branch lacks, an unreadable blob, a git
+  failure) still pushes: suppressing a real drift PR is far worse than one redundant
+  force-push. Note this does **not** reduce how often drift is *detected* — a content
+  revision, such as ClinGen's `content_length` moving while the checksum holds, is still
+  a genuine change and still opens a PR.
+
 - **The `cptac:expression` and `cptac:phospho` drift probes had never once succeeded.**
   The drift workflow installed with a bare `pip install -e .`, but the cptac probe
   fingerprints the *installed* `cptac` version (via `importlib.metadata`) against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,15 @@
   proposed. `drift_to_pr.py` now skips the push and the PR edit when the branch already
   carries a materially identical fingerprint — "materially" meaning equal once
   `fetched_at` and `probe_version` are dropped, the same keys the drift detector ignores.
-  Every other outcome (no branch yet, a file the branch lacks, an unreadable blob, a git
-  failure) still pushes: suppressing a real drift PR is far worse than one redundant
-  force-push. Note this does **not** reduce how often drift is *detected* — a content
+  The skip additionally requires an **open PR** to still exist: a branch outlives its PR
+  when one is closed, and a run whose push succeeded while `gh pr create` failed leaves a
+  branch with no PR at all — in both cases the branch content matches, so a content-only
+  check would suppress that dataset's drift forever. Every other outcome (no branch yet,
+  a file the branch lacks, an unreadable blob, a git failure) still pushes: suppressing a
+  real drift PR is far worse than one redundant force-push. A skipped dataset also
+  restores the index and working tree before returning — `git checkout -B` does not clear
+  the index, so a leftover staged fingerprint would be committed onto the *next*
+  dataset's branch — and still reports itself in the job's step summary. Note this does **not** reduce how often drift is *detected* — a content
   revision, such as ClinGen's `content_length` moving while the checksum holds, is still
   a genuine change and still opens a PR.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The `cptac:expression` and `cptac:phospho` drift probes had never once succeeded.**
+  The drift workflow installed with a bare `pip install -e .`, but the cptac probe
+  fingerprints the *installed* `cptac` version (via `importlib.metadata`) against
+  PayneLab's latest GitHub release — and `cptac` is declared in the `ptm` extra. Every
+  scheduled run reported `The 'cptac' Python package is not installed; cannot
+  fingerprint`, so upstream CPTAC drift has never been detectable. The workflow now
+  installs `.[ptm]`. Of the 22 drift probes these two are the only ones needing an
+  extra; the other 20 use `requests` or the stdlib alone.
+- **A single rate-limited response could fail the whole scheduled drift run.** On
+  2026-08-04 GenCC answered the regeneration request with HTTP 429; the probe had no
+  retry, so it raised, no PR could be opened for the drifted dataset, and the run exited
+  non-zero with nothing actually wrong. New `hvantk/core/utils/http.py` provides
+  `request_with_retry`, which retries transient statuses (429 and the 5xx family) and
+  connection errors with exponential backoff. It honours `Retry-After` but **clamps**
+  it: `urllib3.util.Retry` sleeps for the header's full value with no upper bound
+  (`backoff_max` caps only the exponential path), so a host answering `Retry-After: 3600`
+  would park CI for an hour. The helper deliberately does not call `raise_for_status`,
+  so callers keep their existing error handling and only the transient case changes.
+  Wired into the GenCC probe; the other 12 HTTP probes can adopt it as needed.
+
 ## 0.2.0 — 2026-08-04
 
 First tagged release. Everything below had accumulated under `Unreleased` since `0.1.0`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 — 2026-08-05
 
 ### Added
 

--- a/hvantk/algorithms/hgc/converters.py
+++ b/hvantk/algorithms/hgc/converters.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 import hail as hl
 from hvantk.algorithms.hgc.constants import ADJ_GT_FIELD, VCF_EXTENSION
 from hvantk.core.models.backends import algorithm, Backend
@@ -154,6 +156,7 @@ def convert_vds_to_mt(
     skip_validation: bool = False,
     skip_keying_by_cols: bool = False,
     overwrite: bool = False,
+    n_partitions: Optional[int] = None,
 ) -> None:
     """
     Convert a Variant Dataset (VDS) to MatrixTable (MT).
@@ -176,6 +179,10 @@ def convert_vds_to_mt(
         skip_validation: If True, skip both the biallelic audit and the repair
         skip_keying_by_cols: If True, skip keying the MatrixTable by columns
         overwrite: Whether to overwrite the output if it already exists
+        n_partitions: Coalesce the dense MatrixTable to this many partitions before
+            writing. Reduces only -- `naive_coalesce` is a no-op if the count is already
+            lower. `None` (the default) keeps the VDS's on-disk layout and reproduces the
+            previous behaviour exactly.
 
     Notes:
         - VDS-level splitting is critical for correct GT/AD/PL alignment
@@ -186,10 +193,27 @@ def convert_vds_to_mt(
           and the repair is expressed lazily; see `_audit_split_variant_data`.
         - This algorithm operates on raw `hl.MatrixTable` / `hl.VariantDataset` instances
           (genotype data). ExpressionMatrix's hail-mt backend isn't available yet (Phase J).
+        - `n_partitions` coalesces the DENSE MatrixTable (step 3b), which is the only
+          lever that works: `to_dense_mt` takes no partitioning argument, and setting one
+          on the read raises inside Hail -- see the comment at step 3b for the measurement.
+          Boundaries are inherited by merging adjacent partitions, so what the caller
+          controls is the COUNT, not the balance. There is no auto-sizing: choosing a
+          heuristic needs measurement on a real cohort, not a guess here.
     """
     try:
         # Step 1: Load and split VDS
+        #
+        # Why the partition count is worth overriding at all: a VDS's on-disk layout is
+        # derived from its REFERENCE-BLOCK count, which is a property of the genome and
+        # saturates (~229 M on chr1 by N~=500 samples), while the dense matrix keeps
+        # growing with N x M(N). Past that point the partition count stops tracking the
+        # size of the data it partitions and work-per-task collapses -- measured at
+        # 0.69 MiB/partition for a 1,005-sample chr1 cohort, where densify and QC
+        # plateaued at 1.29x and 1.64x going from 16 to 128 cores while the well-sized
+        # stages scaled 7.8x. See #207.
         logging.info(f"Reading VDS from {vds_path}...")
+        if n_partitions is not None and n_partitions < 1:
+            raise ValueError(f"n_partitions must be >= 1, got {n_partitions}")
         vds = hl.vds.read_vds(vds_path)
         vds = _split_vds(vds, skip_split=skip_split_multi)
 
@@ -204,6 +228,33 @@ def convert_vds_to_mt(
         # Step 3: Densify to MatrixTable
         logging.info("Converting VDS to dense MatrixTable…")
         mt = hl.vds.to_dense_mt(vds)
+
+        # Step 3b: Coalesce to the requested partition count.
+        #
+        # `naive_coalesce` merges ADJACENT partitions with no shuffle, so the whole
+        # upstream chain for the merged group -- including the densify -- runs inside one
+        # task. That is the point: it makes tasks fatter, which is what #207 is about.
+        #
+        # Rejected alternative, and the reason this is not done at the read: passing
+        # `n_partitions` to `hl.vds.read_vds` looks like the tidier lever, but on a real
+        # VDS it fails. `read_vds` derives intervals from the reference data via
+        # `reference_data._calculate_new_partitions(n)`, and that count saturates
+        # independently of the request -- measured on the test cohort it returned 2
+        # intervals for every request from 2 to 100, while the read itself yielded 1
+        # actual partition. `to_dense_mt` then fails a Scala `require` on the mismatch
+        # between the reference and variant reads. Measured on the 2,586-partition test
+        # VDS: read-time requests of 2, 4 and 16 all raised
+        # `IllegalArgumentException: requirement failed`, where coalesce returned exactly
+        # 2, 4 and 16.
+        #
+        # `mt.n_partitions()` is deliberately NOT consulted first. Hail is lazy and does
+        # not cache; this function's whole design is that the densify executes exactly
+        # once, at the write (see the note above and `_audit_split_variant_data`), so a
+        # metadata probe here is a needless risk for a check Hail already does --
+        # `naive_coalesce` is a documented no-op when the current count is already lower.
+        if n_partitions is not None:
+            logging.info(f"Coalescing dense MatrixTable to {n_partitions} partitions.")
+            mt = mt.naive_coalesce(n_partitions)
 
         # Step 4: Repair out-of-bounds genotypes. A lazy expression: it costs no extra pass,
         # it fuses into the write below, and on clean data it is the identity.

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -39,12 +39,19 @@ from hvantk.algorithms.hgc import (
 logger = logging.getLogger(__name__)
 
 
-def _shown_partitions(n: Optional[int]) -> str:
+def _shown_partitions(n: Optional[int], *, skipped: bool = False) -> str:
     """Render `n_partitions` for the run plan.
 
     Keyed on `is None`, not truthiness: 0 is a rejected value, and `or` would print it
     as "auto", telling the user a dry run's plan is fine for an invocation that aborts.
+
+    `skipped` covers --skip-vds-to-mt: that stage is the only consumer, so with it off
+    the existing MatrixTable keeps whatever layout it already has. Printing the
+    requested number there would repeat #208's mistake in a new place -- affirming a
+    setting that no stage will read.
     """
+    if skipped:
+        return "n/a (VDS -> MT stage skipped)"
     return "auto (VDS layout)" if n is None else str(n)
 
 
@@ -351,7 +358,8 @@ class PipelineRunner:
         # Reaches convert_vds_to_mt as of #208. Before that this line printed a setting
         # no stage read -- keep it truthful, and say which stage it governs.
         print(
-            f"  Partitions (MT):  {_shown_partitions(self.config.n_partitions)}"
+            f"  Partitions (MT):  "
+            f"{_shown_partitions(self.config.n_partitions, skipped=self.config.skip_vds_to_mt)}"
         )
         print(f"  Overwrite:        {self.config.overwrite}")
         print(

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -39,6 +39,15 @@ from hvantk.algorithms.hgc import (
 logger = logging.getLogger(__name__)
 
 
+def _shown_partitions(n: Optional[int]) -> str:
+    """Render `n_partitions` for the run plan.
+
+    Keyed on `is None`, not truthiness: 0 is a rejected value, and `or` would print it
+    as "auto", telling the user a dry run's plan is fine for an invocation that aborts.
+    """
+    return "auto (VDS layout)" if n is None else str(n)
+
+
 class PipelineStage(Enum):
     """Enumeration of pipeline stages."""
 
@@ -61,8 +70,11 @@ class PipelineConfig:
     tmp_dir: Optional[str] = None
     reference_genome: str = "GRCh38"
     # Target partition count for the VDS -> MatrixTable stage, forwarded to
-    # convert_vds_to_mt and applied at the read (see #207/#208). NOT the combiner's
-    # interval tuning below -- that governs stage 1, this governs stage 2 onward.
+    # convert_vds_to_mt, which COALESCES the dense MatrixTable before writing it
+    # (see #207/#208). Deliberately not applied at the read: that approach was measured
+    # and fails -- see the step 3b comment in algorithms/hgc/converters.py before
+    # re-attempting it. NOT the combiner's interval tuning below: that governs stage 1,
+    # this governs stage 2 onward.
     n_partitions: Optional[int] = None
     overwrite: bool = False
     output_prefix: str = "cohort"
@@ -151,6 +163,14 @@ class PipelineConfig:
 
         if self.branch_factor is not None and self.branch_factor < 2:
             errors.append("branch_factor must be at least 2")
+
+        # Checked here, not only in convert_vds_to_mt, for the same reason as the three
+        # knobs above: this is the gate that runs before Hail init and before stage 1.
+        # convert_vds_to_mt does reject < 1, but stage 2 is reached only after the gVCF
+        # combine has run to completion -- hours on a real cohort -- so a value that was
+        # knowably wrong before any work started would cost the whole combine first.
+        if self.n_partitions is not None and self.n_partitions < 1:
+            errors.append("n_partitions must be at least 1")
 
         return errors
 
@@ -331,7 +351,7 @@ class PipelineRunner:
         # Reaches convert_vds_to_mt as of #208. Before that this line printed a setting
         # no stage read -- keep it truthful, and say which stage it governs.
         print(
-            f"  Partitions (MT):  {self.config.n_partitions or 'auto (VDS layout)'}"
+            f"  Partitions (MT):  {_shown_partitions(self.config.n_partitions)}"
         )
         print(f"  Overwrite:        {self.config.overwrite}")
         print(

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -60,6 +60,9 @@ class PipelineConfig:
     # Optional processing configuration
     tmp_dir: Optional[str] = None
     reference_genome: str = "GRCh38"
+    # Target partition count for the VDS -> MatrixTable stage, forwarded to
+    # convert_vds_to_mt and applied at the read (see #207/#208). NOT the combiner's
+    # interval tuning below -- that governs stage 1, this governs stage 2 onward.
     n_partitions: Optional[int] = None
     overwrite: bool = False
     output_prefix: str = "cohort"
@@ -325,7 +328,11 @@ class PipelineRunner:
 
         print("\n🔧 Configuration:")
         print(f"  Reference genome: {self.config.reference_genome}")
-        print(f"  Partitions:       {self.config.n_partitions or 'auto'}")
+        # Reaches convert_vds_to_mt as of #208. Before that this line printed a setting
+        # no stage read -- keep it truthful, and say which stage it governs.
+        print(
+            f"  Partitions (MT):  {self.config.n_partitions or 'auto (VDS layout)'}"
+        )
         print(f"  Overwrite:        {self.config.overwrite}")
         print(
             f"  Combiner options: {self.config.combiner_kwargs() or 'defaults (genome 1.2 Mb intervals)'}"
@@ -518,6 +525,11 @@ class PipelineRunner:
             skip_validation=self.config.skip_validation,
             skip_keying_by_cols=False,
             overwrite=self.config.overwrite,
+            # #208: this is the consumer `n_partitions` never had. It was accepted from
+            # the CLI and echoed back in the run plan while reaching no stage at all, so
+            # the run plan was affirmatively telling the user a setting had taken effect
+            # when it had not.
+            n_partitions=self.config.n_partitions,
         )
 
         self.logger.info(f"   ✓ MatrixTable created: {self.paths['mt']}")

--- a/hvantk/core/plugin/drift_runner.py
+++ b/hvantk/core/plugin/drift_runner.py
@@ -27,10 +27,17 @@ class DriftResult:
     expected: dict[str, Any] | None = None
     diff: dict[str, Any] | None = None
     probe_error: BaseException | None = None
-    #: The committed baseline this result was diffed against. Datasets that share one
-    #: share a drift signal, which is what lets the CI bot collapse them into a single
-    #: PR instead of one per dataset. See `run_drift_checks`.
+    #: The committed baseline this result was diffed against. Datasets sharing a
+    #: baseline share a single drift signal, which is what lets the CI bot collapse them
+    #: into one PR instead of one per dataset. See `run_drift_checks`.
     fingerprint_path: str | None = None
+    #: ``module:function`` of the probe that produced this result. Pairs with
+    #: ``fingerprint_path`` to identify the SIGNAL: the runner refuses to group two
+    #: datasets that share a baseline but declare different probes (a manifest error),
+    #: and the bot must apply the same rule or it would re-merge what the runner
+    #: deliberately kept apart -- opening one PR whose regeneration covers only the first
+    #: dataset and silently leaving the second's drift unaddressed.
+    probe_ref: str | None = None
 
 
 def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
@@ -67,18 +74,38 @@ def run_drift_checks(
     unchanged; members of a group share ``fingerprint_path``, which is what lets the CI
     bot open one PR per signal instead of one per dataset.
     """
-    cache: dict[tuple[str, int], DriftResult] = {}
+    # Values keep the probe object alive alongside its result. The key holds only
+    # id(probe), and CPython reuses addresses: `specs` is an Iterable, so a caller may
+    # pass a generator whose specs become unreachable as it advances, and a freshly
+    # allocated probe could land on a freed address. Two distinct probes would then
+    # collide on one key and a dataset would receive another dataset's drift result.
+    # Holding the reference makes the address un-reusable for the loop's lifetime.
+    cache: dict[tuple[str, int], tuple[object, DriftResult]] = {}
     results: list[DriftResult] = []
     for spec in specs:
-        key = (str(spec.test_paths.drift_fingerprint), id(spec.drift_probe))
-        cached = cache.get(key)
-        if cached is None:
+        probe = spec.drift_probe
+        key = (str(spec.test_paths.drift_fingerprint), id(probe))
+        entry = cache.get(key)
+        if entry is None:
             cached = _run_drift_check_with_spec(spec, timeout=timeout)
-            cache[key] = cached
+            cache[key] = (probe, cached)
+        else:
+            cached = entry[1]
         # `replace` rather than reuse: the shared result carries the FIRST member's
         # dataset_name, and every caller keys off that field.
         results.append(replace(cached, dataset_name=spec.name))
     return results
+
+
+def _probe_ref(spec: DatasetSpec) -> str:
+    """``module:qualname`` of a spec's probe -- a serialisable stand-in for the callable.
+
+    The runner can compare callables by identity; the JSON report the CI bot consumes
+    cannot, so the identity has to survive serialisation for the bot to apply the same
+    grouping rule.
+    """
+    fn = spec.drift_probe
+    return f"{getattr(fn, '__module__', '?')}:{getattr(fn, '__qualname__', repr(fn))}"
 
 
 def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
@@ -100,6 +127,7 @@ def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
         status="probe_failed",
         probe_error=exc,
         fingerprint_path=str(fp_path),
+        probe_ref=_probe_ref(spec),
     )
 
 
@@ -131,6 +159,7 @@ def _run_drift_check_with_spec(
             status="stub",
             observed=observed,
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
 
     try:
@@ -144,6 +173,7 @@ def _run_drift_check_with_spec(
                 f"missing expected fingerprint at {fp_path}"
             ),
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
 
     # A hand-seeded baseline cannot equal a live observation, so diffing it would
@@ -161,6 +191,7 @@ def _run_drift_check_with_spec(
                 f"probe ({seeded}); run `hvantk drift --regenerate {spec.name}`"
             ),
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
 
     diff = _compare_fingerprints(expected, observed)
@@ -171,6 +202,7 @@ def _run_drift_check_with_spec(
             observed=observed,
             expected=expected,
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
     return DriftResult(
         dataset_name=spec.name,
@@ -179,6 +211,7 @@ def _run_drift_check_with_spec(
         expected=expected,
         diff=diff,
         fingerprint_path=str(fp_path),
+        probe_ref=_probe_ref(spec),
     )
 
 

--- a/hvantk/core/plugin/drift_runner.py
+++ b/hvantk/core/plugin/drift_runner.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import json
 import signal
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from .api import (
     DatasetSpec,
@@ -27,6 +27,10 @@ class DriftResult:
     expected: dict[str, Any] | None = None
     diff: dict[str, Any] | None = None
     probe_error: BaseException | None = None
+    #: The committed baseline this result was diffed against. Datasets that share one
+    #: share a drift signal, which is what lets the CI bot collapse them into a single
+    #: PR instead of one per dataset. See `run_drift_checks`.
+    fingerprint_path: str | None = None
 
 
 def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
@@ -36,6 +40,45 @@ def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
     reg = plugin_loader.get_registry()
     spec = reg.get_dataset(dataset_name)
     return _run_drift_check_with_spec(spec, timeout=timeout)
+
+
+def run_drift_checks(
+    specs: "Iterable[DatasetSpec]", *, timeout: int = 60
+) -> list[DriftResult]:
+    """Drift-check many datasets, probing once per distinct drift signal.
+
+    Datasets that declare the SAME ``drift_fingerprint`` baseline and resolve to the
+    SAME probe callable do not have separate drift signals -- they have one, reported
+    several times. `ucsc-cellbrowser` is the worked example: `default`, `adult-ctx` and
+    `dev-ctx` are distinct *schema* variants (their obs cell-type column is `celltype`,
+    `Class` and `Type_v2` respectively, which is why each earns its own snapshot), but
+    `fetch_fingerprint()` takes no arguments and fingerprints the provider-wide catalog
+    at cells.ucsc.edu/dataset.json. One upstream event therefore produced three
+    identical drift reports, three branches writing the same file, and three mutually
+    conflicting PRs -- merging any one made the other two conflict.
+
+    Grouping is keyed on ``(fingerprint path, probe callable)`` rather than the path
+    alone. Two datasets sharing a baseline but resolving to DIFFERENT probes is a
+    manifest error (the two would overwrite each other's baseline), and this key makes
+    the runtime conservative about it: they simply do not group, and each is probed and
+    reported on its own. `hvantk plugins validate` reports the misconfiguration.
+
+    Every dataset still gets its own entry in the returned list, so the report shape is
+    unchanged; members of a group share ``fingerprint_path``, which is what lets the CI
+    bot open one PR per signal instead of one per dataset.
+    """
+    cache: dict[tuple[str, int], DriftResult] = {}
+    results: list[DriftResult] = []
+    for spec in specs:
+        key = (str(spec.test_paths.drift_fingerprint), id(spec.drift_probe))
+        cached = cache.get(key)
+        if cached is None:
+            cached = _run_drift_check_with_spec(spec, timeout=timeout)
+            cache[key] = cached
+        # `replace` rather than reuse: the shared result carries the FIRST member's
+        # dataset_name, and every caller keys off that field.
+        results.append(replace(cached, dataset_name=spec.name))
+    return results
 
 
 def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
@@ -53,13 +96,22 @@ def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
             f"{exc}; additionally, expected fingerprint is missing at {fp_path}"
         )
     return DriftResult(
-        dataset_name=spec.name, status="probe_failed", probe_error=exc
+        dataset_name=spec.name,
+        status="probe_failed",
+        probe_error=exc,
+        fingerprint_path=str(fp_path),
     )
 
 
 def _run_drift_check_with_spec(
     spec: DatasetSpec, *, timeout: int = 60
 ) -> DriftResult:
+    # Resolved up front because every return below reports it, including the stub
+    # branch, which returns before the baseline is read. Reading the PATH is not
+    # reading the FILE, so this does not disturb the probe-before-baseline ordering
+    # described below.
+    fp_path = Path(spec.test_paths.drift_fingerprint)
+
     # Invoke the probe before loading the baseline so an intentional stub
     # (documentation-only source with no probeable URL) is reported as
     # status="stub" — these plugins ship no committed baseline, so a
@@ -78,9 +130,9 @@ def _run_drift_check_with_spec(
             dataset_name=spec.name,
             status="stub",
             observed=observed,
+            fingerprint_path=str(fp_path),
         )
 
-    fp_path = Path(spec.test_paths.drift_fingerprint)
     try:
         expected = json.loads(fp_path.read_text())
     except FileNotFoundError:
@@ -91,6 +143,7 @@ def _run_drift_check_with_spec(
             probe_error=DriftProbeError(
                 f"missing expected fingerprint at {fp_path}"
             ),
+            fingerprint_path=str(fp_path),
         )
 
     # A hand-seeded baseline cannot equal a live observation, so diffing it would
@@ -107,6 +160,7 @@ def _run_drift_check_with_spec(
                 f"committed baseline at {fp_path} was never captured from a live "
                 f"probe ({seeded}); run `hvantk drift --regenerate {spec.name}`"
             ),
+            fingerprint_path=str(fp_path),
         )
 
     diff = _compare_fingerprints(expected, observed)
@@ -116,6 +170,7 @@ def _run_drift_check_with_spec(
             status="clean",
             observed=observed,
             expected=expected,
+            fingerprint_path=str(fp_path),
         )
     return DriftResult(
         dataset_name=spec.name,
@@ -123,6 +178,7 @@ def _run_drift_check_with_spec(
         observed=observed,
         expected=expected,
         diff=diff,
+        fingerprint_path=str(fp_path),
     )
 
 

--- a/hvantk/core/utils/http.py
+++ b/hvantk/core/utils/http.py
@@ -35,6 +35,9 @@ DEFAULT_ATTEMPTS = 4
 DEFAULT_BACKOFF_S = 2.0
 DEFAULT_MAX_SLEEP_S = 30.0
 
+# 2**32 s is ~136 years; any clamp is reached long before this.
+_MAX_EXP = 32
+
 
 def parse_retry_after(value: str | None) -> float | None:
     """``Retry-After`` as seconds, or ``None`` if absent/unparseable.
@@ -63,6 +66,18 @@ def parse_retry_after(value: str | None) -> float | None:
     return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
 
 
+def _backoff(backoff_s: float, attempt: int, max_sleep_s: float) -> float:
+    """Exponential backoff for `attempt`, clamped to `max_sleep_s`.
+
+    The exponent is capped before it is used. `backoff_s * 2 ** (attempt - 1)` looks
+    harmless because min() clamps the result, but the multiplication happens first: with
+    a large `attempts` it raises `OverflowError: int too large to convert to float`
+    rather than merely being slow. _MAX_EXP is far past any reachable max_sleep_s, so
+    capping it changes no real result.
+    """
+    return min(backoff_s * 2 ** min(attempt - 1, _MAX_EXP), max_sleep_s)
+
+
 def request_with_retry(
     method: str,
     url: str,
@@ -88,6 +103,13 @@ def request_with_retry(
     """
     if attempts < 1:
         raise ValueError(f"attempts must be >= 1, got {attempts}")
+    # Rejected here rather than at the sleep: a negative value only surfaces AFTER a
+    # transient failure, so the caller would see ValueError("sleep length must be
+    # non-negative") in place of the upstream error it was retrying.
+    if backoff_s < 0 or max_sleep_s < 0:
+        raise ValueError(
+            f"backoff_s and max_sleep_s must be >= 0, got {backoff_s} and {max_sleep_s}"
+        )
 
     retry_statuses = frozenset(retry_statuses)
     caller = session if session is not None else requests
@@ -99,7 +121,7 @@ def request_with_retry(
         except (requests.Timeout, requests.ConnectionError) as exc:
             if is_last:
                 raise
-            sleep_s = min(backoff_s * 2 ** (attempt - 1), max_sleep_s)
+            sleep_s = _backoff(backoff_s, attempt, max_sleep_s)
             logger.warning(
                 "%s %s failed (%s); retrying in %.1fs (attempt %d/%d)",
                 method.upper(), url, type(exc).__name__, sleep_s, attempt, attempts,
@@ -115,8 +137,8 @@ def request_with_retry(
         # attempts open would leak one connection per retry.
         retry_after = parse_retry_after(response.headers.get("Retry-After"))
         response.close()
-        backoff = backoff_s * 2 ** (attempt - 1)
-        sleep_s = min(retry_after if retry_after is not None else backoff, max_sleep_s)
+        backoff = _backoff(backoff_s, attempt, max_sleep_s)
+        sleep_s = min(retry_after, max_sleep_s) if retry_after is not None else backoff
         logger.warning(
             "%s %s returned %d; retrying in %.1fs (attempt %d/%d)",
             method.upper(), url, response.status_code, sleep_s, attempt, attempts,

--- a/hvantk/core/utils/http.py
+++ b/hvantk/core/utils/http.py
@@ -1,0 +1,126 @@
+"""Retrying HTTP request helper for drift probes and downloaders.
+
+Thirteen of the twenty-two drift probes call ``requests`` directly and none of them
+retried, so a single transient upstream response could fail the whole scheduled drift
+run. That is exactly what happened on 2026-08-04: GenCC answered the regenerate request
+with HTTP 429, the probe raised ``DriftProbeError``, no PR could be opened for the
+drifted dataset, and the workflow exited non-zero -- while nothing was actually wrong
+with either the data or the code.
+
+Why not ``urllib3.util.Retry`` mounted on an ``HTTPAdapter``, which is the obvious
+answer: it honours ``Retry-After`` through ``Retry.sleep_for_retry``, which calls
+``time.sleep(retry_after)`` with **no upper bound**. ``backoff_max`` (120s by default)
+caps only the exponential-backoff path, not this one -- verified against urllib3 2.6.3.
+A rate-limited host answering ``Retry-After: 3600`` would therefore park a CI job for an
+hour. This helper honours the header, because ignoring a server's explicit backoff
+request is how you get rate-limited harder, but clamps it to ``max_sleep_s``.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Iterable
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# 429 plus the transient 5xx family. 500 is included deliberately: several of the sources
+# these probes hit answer overload with a bare 500 rather than a 503.
+RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+DEFAULT_ATTEMPTS = 4
+DEFAULT_BACKOFF_S = 2.0
+DEFAULT_MAX_SLEEP_S = 30.0
+
+
+def parse_retry_after(value: str | None) -> float | None:
+    """``Retry-After`` as seconds, or ``None`` if absent/unparseable.
+
+    RFC 9110 permits both forms -- delta-seconds (``120``) and an HTTP-date
+    (``Wed, 21 Oct 2026 07:28:00 GMT``) -- and real servers send both. A date in the
+    past clamps to 0 rather than going negative.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:  # HTTP-dates are GMT; naive means UTC here
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    attempts: int = DEFAULT_ATTEMPTS,
+    backoff_s: float = DEFAULT_BACKOFF_S,
+    max_sleep_s: float = DEFAULT_MAX_SLEEP_S,
+    retry_statuses: Iterable[int] = RETRY_STATUSES,
+    session: requests.Session | None = None,
+    **kwargs,
+) -> requests.Response:
+    """``requests.request`` with retries on transient statuses and connection errors.
+
+    Returns the final :class:`requests.Response` **without** calling
+    ``raise_for_status``, so callers keep their existing error handling: a response that
+    is still 429 after the last attempt comes back as a 429 and raises where it always
+    did. Only the transient case changes behaviour.
+
+    Connection errors and timeouts are retried too -- they are the same class of problem
+    as a 503, and a probe that dies on one flaky TCP handshake is the bug this fixes.
+    Other ``RequestException`` subclasses (a malformed URL, say) are not retried, since
+    repeating them cannot help.
+    """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+
+    retry_statuses = frozenset(retry_statuses)
+    caller = session if session is not None else requests
+
+    for attempt in range(1, attempts + 1):
+        is_last = attempt == attempts
+        try:
+            response = caller.request(method, url, **kwargs)
+        except (requests.Timeout, requests.ConnectionError) as exc:
+            if is_last:
+                raise
+            sleep_s = min(backoff_s * 2 ** (attempt - 1), max_sleep_s)
+            logger.warning(
+                "%s %s failed (%s); retrying in %.1fs (attempt %d/%d)",
+                method.upper(), url, type(exc).__name__, sleep_s, attempt, attempts,
+            )
+            time.sleep(sleep_s)
+            continue
+
+        if is_last or response.status_code not in retry_statuses:
+            return response
+
+        # Retryable, with attempts left. Read Retry-After BEFORE closing: a streamed
+        # response holds its connection until closed or consumed, and leaving discarded
+        # attempts open would leak one connection per retry.
+        retry_after = parse_retry_after(response.headers.get("Retry-After"))
+        response.close()
+        backoff = backoff_s * 2 ** (attempt - 1)
+        sleep_s = min(retry_after if retry_after is not None else backoff, max_sleep_s)
+        logger.warning(
+            "%s %s returned %d; retrying in %.1fs (attempt %d/%d)",
+            method.upper(), url, response.status_code, sleep_s, attempt, attempts,
+        )
+        time.sleep(sleep_s)
+
+    raise AssertionError("unreachable: loop returns or raises on the last attempt")

--- a/hvantk/skills/_conventions/SKILL.md
+++ b/hvantk/skills/_conventions/SKILL.md
@@ -195,11 +195,17 @@ Each dataset declares a `drift_probe.module` + `function` in `plugin.yaml`. The 
 
 The expected fingerprint lives at `hvantk/skills/<provider>/[<dataset>/]tests/drift_fingerprint.json`. `hvantk drift <provider:dataset>` compares the live probe output against this file. Update the fingerprint when an intentional upstream change has been validated; do not silently regenerate it in the same PR as a behavioural change.
 
+**Sharing one `drift_fingerprint` across datasets is meaningful, not a shortcut.** Datasets that point at the same baseline *and* the same probe are declaring that they have **one** drift signal between them, not one each — which is the honest declaration when the probe is provider-scoped. `ucsc-cellbrowser` is the worked example: `default`, `adult-ctx` and `dev-ctx` are distinct *schema* variants (their obs cell-type column is `celltype`, `Class` and `Type_v2` respectively, so each earns its own snapshot), but `fetch_fingerprint()` takes no arguments and fingerprints the provider-wide catalog, so all three always report identically.
+
+`hvantk drift` probes such a group once and fans the result out — every dataset still gets its own report entry — and the drift workflow opens a single PR per signal. Without that, one upstream event produced three identical PRs whose branches all wrote the same file, so merging any one made the others conflict.
+
+Two datasets may **not** share a baseline while declaring *different* probes: each would overwrite the other's file, and whichever regenerated last would define "clean" for both. `hvantk plugins validate` rejects that.
+
 ### Automated drift workflow
 
 A scheduled GitHub Actions workflow (`.github/workflows/drift.yml`) runs `hvantk drift --all --json` daily at 06:00 UTC. For each plugin reporting `status: drifted`, the workflow:
 
-1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`).
+1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`) — or `drift/<provider>` when several of that provider's datasets share one drift signal, so the group gets a single PR.
 2. Regenerates `drift_fingerprint.json` via `hvantk drift --regenerate <provider:dataset>`.
 3. Opens (or updates) a draft PR via `gh pr create` / `gh pr edit`, with the structured diff embedded in the body and the regenerated fingerprint already committed. If the plugin's `plugin.yaml` declares `maintainers:` whose entries look like GitHub handles, those handles are `cc`'d in the PR body.
 

--- a/hvantk/skills/_conventions/SKILL.md
+++ b/hvantk/skills/_conventions/SKILL.md
@@ -205,7 +205,7 @@ Two datasets may **not** share a baseline while declaring *different* probes: ea
 
 A scheduled GitHub Actions workflow (`.github/workflows/drift.yml`) runs `hvantk drift --all --json` daily at 06:00 UTC. For each plugin reporting `status: drifted`, the workflow:
 
-1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`) — or `drift/<provider>` when several of that provider's datasets share one drift signal, so the group gets a single PR.
+1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`). When several of that provider's datasets share one drift signal the group gets a single branch instead: `drift/<provider>`, or `drift/<provider>-<suffix>` when the shared baseline's filename carries one (`drift_fingerprint_samples.json` → `drift/<provider>-samples`). The suffix is what keeps two independent signals from the same provider on separate branches, so a multi-dataset provider does not have its second signal overwrite its first.
 2. Regenerates `drift_fingerprint.json` via `hvantk drift --regenerate <provider:dataset>`.
 3. Opens (or updates) a draft PR via `gh pr create` / `gh pr edit`, with the structured diff embedded in the body and the regenerated fingerprint already committed. If the plugin's `plugin.yaml` declares `maintainers:` whose entries look like GitHub handles, those handles are `cc`'d in the PR body.
 

--- a/hvantk/skills/gencc/drift_probe.py
+++ b/hvantk/skills/gencc/drift_probe.py
@@ -19,6 +19,7 @@ import requests
 
 from hvantk.skills.gencc.shared.constants import GENCC_BASE_URL, GENCC_FILE_PREFIX
 from hvantk.core.plugin.api import DriftProbeError
+from hvantk.core.utils.http import request_with_retry
 
 PROBE_VERSION = 1
 _FILENAME = f"{GENCC_FILE_PREFIX}.tsv"
@@ -33,15 +34,19 @@ def fetch_fingerprint() -> dict:
     portion of the body up to and including the column-header line (begins
     with ``sgc_id``). Does not stream the full TSV (~MB-scale).
     """
+    # Retrying, because GenCC rate-limits: on 2026-08-04 it answered the scheduled
+    # drift regeneration with HTTP 429, which failed the probe and then the whole
+    # workflow run. request_with_retry honours Retry-After but clamps the wait, so a
+    # long backoff request cannot stall CI.
     try:
-        head = requests.head(
-            GENCC_BASE_URL, timeout=_TIMEOUT_S, allow_redirects=True
+        head = request_with_retry(
+            "HEAD", GENCC_BASE_URL, timeout=_TIMEOUT_S, allow_redirects=True
         )
         head.raise_for_status()
         last_modified = head.headers.get("Last-Modified")
 
-        with requests.get(
-            GENCC_BASE_URL, timeout=_TIMEOUT_S, stream=True, allow_redirects=True
+        with request_with_retry(
+            "GET", GENCC_BASE_URL, timeout=_TIMEOUT_S, stream=True, allow_redirects=True
         ) as resp:
             resp.raise_for_status()
             buf = io.StringIO()

--- a/hvantk/tests/hgc/test_cli_convert.py
+++ b/hvantk/tests/hgc/test_cli_convert.py
@@ -172,3 +172,43 @@ def test_mt2vcf_cli_no_filter_adj():
             assert result.exit_code == 0
             call_kwargs = mock_convert.call_args[1]
             assert call_kwargs["filter_adj_genotypes"] is False
+
+
+def test_vds2mt_forwards_n_partitions_to_the_converter():
+    """The REAL (non-dry-run) forwarding, which had no test at all.
+
+    Round-3 review: deleting `n_partitions=n_partitions` from the convert_vds_to_mt call
+    left the whole suite green, so `hvantk hgc vds2mt --n-partitions 4` would write with
+    the VDS's own layout while `--dry-run` on the identical command still printed
+    `Partitions: 4`. That is #208's failure mode -- a flag accepted, echoed back
+    affirmatively, and read by no stage -- reappearing on the command this PR was fixing.
+    """
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.convert_cli.convert_vds_to_mt") as mock_convert:
+        with patch(
+            "hvantk.tools.hgc.convert_cli.validate_input_files"
+        ) as mock_validate:
+            mock_validate.return_value = (True, [])
+
+            result = runner.invoke(
+                vds2mt,
+                ["--input", "/data.vds", "--output", "/out.mt", "--n-partitions", "4"],
+            )
+
+            assert result.exit_code == 0
+            assert mock_convert.call_args[1]["n_partitions"] == 4
+
+
+def test_vds2mt_defaults_n_partitions_to_none():
+    """Unset must reach the converter as None, not 0 or a number: None is what keeps the
+    VDS layout, and the converter rejects anything below 1."""
+    runner = CliRunner()
+    with patch("hvantk.tools.hgc.convert_cli.convert_vds_to_mt") as mock_convert:
+        with patch(
+            "hvantk.tools.hgc.convert_cli.validate_input_files"
+        ) as mock_validate:
+            mock_validate.return_value = (True, [])
+
+            runner.invoke(vds2mt, ["--input", "/data.vds", "--output", "/out.mt"])
+
+            assert mock_convert.call_args[1]["n_partitions"] is None

--- a/hvantk/tests/hgc/test_hgc_core_hail.py
+++ b/hvantk/tests/hgc/test_hgc_core_hail.py
@@ -87,6 +87,71 @@ def test_convert_vds_to_mt(tmp_path):
 
 
 @pytest.mark.hail
+@pytest.mark.order3
+def test_convert_vds_to_mt_honours_n_partitions(tmp_path):
+    """#207/#208: --n-partitions must actually change the written layout.
+
+    #208's acceptance criteria require that the flag either changes the output's
+    partitioning or does not exist; before this it was accepted, printed in the run plan,
+    and read by no stage. The default is asserted too, so a regression that silently
+    coalesced every run would fail rather than pass quietly.
+
+    The fixture VDS carries 2,586 partitions, so 4 is a genuine reduction rather than a
+    no-op -- `naive_coalesce` does nothing when the current count is already lower, which
+    would make a badly-chosen target vacuously "pass". That precondition is asserted from
+    the VDS's own partition count rather than by running a second, uncoalesced conversion:
+    it is free metadata, where the extra conversion cost ~4 minutes of a job that runs on
+    every push. The uncoalesced path is already covered by test_convert_vds_to_mt above.
+    """
+    import hail as hl
+
+    decompress_files(
+        zip_path=str(TESTS_DIR / "vds/cohort.vds.zip"),
+        extract_to=str(tmp_path / "cohort.vds"),
+        remove_originals=False,
+    )
+    vds_path = str(tmp_path / "cohort.vds")
+
+    source_parts = hl.vds.read_vds(vds_path).variant_data.n_partitions()
+    assert source_parts > 4, (
+        f"fixture VDS has only {source_parts} partitions; coalescing to 4 would be a "
+        f"no-op and the assertion below would prove nothing"
+    )
+
+    out = tmp_path / "coalesced.mt"
+    convert_vds_to_mt(
+        vds_path=vds_path,
+        output_path=str(out),
+        adjust_genotypes=False,
+        skip_validation=True,
+        skip_split_multi=False,
+        skip_keying_by_cols=False,
+        overwrite=True,
+        n_partitions=4,
+    )
+
+    written_parts = hl.read_matrix_table(str(out)).n_partitions()
+    assert written_parts == 4, f"expected 4 partitions, got {written_parts}"
+
+
+@pytest.mark.hail
+@pytest.mark.order3
+def test_convert_vds_to_mt_rejects_a_nonsense_partition_count(tmp_path):
+    """A bad count must fail before Hail does, with a message naming the parameter."""
+    decompress_files(
+        zip_path=str(TESTS_DIR / "vds/cohort.vds.zip"),
+        extract_to=str(tmp_path / "cohort.vds"),
+        remove_originals=False,
+    )
+    with pytest.raises(ValueError, match="n_partitions must be >= 1"):
+        convert_vds_to_mt(
+            vds_path=str(tmp_path / "cohort.vds"),
+            output_path=str(tmp_path / "never.mt"),
+            n_partitions=0,
+        )
+
+
+@pytest.mark.hail
 @pytest.mark.order4
 def test_convert_mt_to_cvcf(tmp_path):
     """Test MatrixTable → multi-sample VCF conversion."""

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -6,6 +6,8 @@ with Hail's 1.2 Mb genome default and had no way to raise the partition count ab
 core count. These tests pin the wiring so that cannot silently regress.
 """
 
+import re
+
 import pytest
 
 from hvantk.algorithms.hgc.pipeline import PipelineConfig
@@ -109,3 +111,44 @@ def test_pipeline_passes_none_when_unset(tmp_path, monkeypatch):
     runner._run_vds_to_mt()
 
     assert seen["n_partitions"] is None
+
+
+# --- adversarial-review findings on #261 --------------------------------------------
+
+
+def test_invalid_n_partitions_is_rejected_by_validate(tmp_path):
+    """Bad values must be caught by config validation, not deep inside stage 2.
+
+    n_partitions was the only tuning knob with no validate() clause, so `--n-partitions 0`
+    passed the gate, ran the multi-hour gVCF combine, and only then hit the guard inside
+    convert_vds_to_mt. Its three siblings are all checked here for exactly this reason.
+    """
+    for bad in (0, -5):
+        errors = _cfg(tmp_path, n_partitions=bad).validate()
+        assert any("n_partitions" in e for e in errors), (bad, errors)
+
+
+def test_valid_n_partitions_passes_validate(tmp_path):
+    assert [e for e in _cfg(tmp_path, n_partitions=64).validate() if "n_partitions" in e] == []
+    assert [e for e in _cfg(tmp_path).validate() if "n_partitions" in e] == []
+
+
+def test_run_plan_does_not_render_zero_as_auto():
+    """`or` printed 0 -- a value that aborts the run -- as "auto"."""
+    from hvantk.algorithms.hgc.pipeline import _shown_partitions
+
+    assert _shown_partitions(None) == "auto (VDS layout)"
+    assert _shown_partitions(0) == "0"
+    assert _shown_partitions(64) == "64"
+
+
+def test_pipeline_help_names_flags_that_exist():
+    """The --n-partitions help pointed at a `--combiner-*` family that does not exist."""
+    from hvantk.tools.hgc.pipeline_cli import pipeline as pipeline_cmd
+
+    opt = next(p for p in pipeline_cmd.params if "--n-partitions" in getattr(p, "opts", []))
+    declared = {o for p in pipeline_cmd.params for o in getattr(p, "opts", [])}
+    referenced = re.findall(r"--[a-z][a-z0-9-]+", opt.help)
+
+    missing = [f for f in referenced if f not in declared]
+    assert not missing, f"help references flags this command does not define: {missing}"

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -152,3 +152,46 @@ def test_pipeline_help_names_flags_that_exist():
 
     missing = [f for f in referenced if f not in declared]
     assert not missing, f"help references flags this command does not define: {missing}"
+
+
+def test_vds2mt_dry_run_shows_zero_rather_than_auto(tmp_path):
+    """The CALL SITE, not just the helper.
+
+    Round-2 review: the helper test alone left both call sites unprotected -- reverting
+    convert_cli.py to `n_partitions or 'auto (VDS layout)'` kept the suite green. This is
+    the live half: `vds2mt` has no config.validate() gate, so 0 reaches the dry-run
+    printer and the user is told a plan is fine for an invocation that aborts.
+    """
+    from unittest.mock import patch
+    from click.testing import CliRunner
+
+    from hvantk.tools.hgc.convert_cli import vds2mt
+
+    with patch("hvantk.tools.hgc.convert_cli.validate_input_files", return_value=(True, [])), \
+         patch("hvantk.tools.hgc.convert_cli.validate_output_path", return_value=True):
+        result = CliRunner().invoke(
+            vds2mt,
+            ["-i", str(tmp_path / "in.vds"), "-o", str(tmp_path / "out.mt"),
+             "--n-partitions", "0", "--dry-run"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Partitions: 0" in result.output, result.output
+    assert "auto" not in result.output, result.output
+
+
+def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path):
+    """The other call site: PipelineRunner.show_plan."""
+    from hvantk.algorithms.hgc.pipeline import PipelineRunner
+
+    import io
+    import contextlib
+
+    runner = PipelineRunner(_cfg(tmp_path, n_partitions=0))
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        runner.show_plan()
+    out = buf.getvalue()
+
+    assert "Partitions (MT):  0" in out, out
+    assert "auto" not in out, out

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -81,6 +81,20 @@ def test_valid_combiner_tuning_passes_validate(tmp_path):
 # test_hgc_core_hail.py, which needs Hail.
 
 
+def _runner_without_hail(pipeline_mod, monkeypatch, cfg):
+    """Build a PipelineRunner without booting a JVM.
+
+    PipelineRunner.__init__ calls _initialize_hail(). None of these tests need Hail --
+    show_plan() only prints strings and _run_vds_to_mt's converter is stubbed -- but
+    without this the file boots Spark inside the DEFAULT `pytest -q` run, which
+    pytest.ini deliberately configures to deselect the `hail` marker, and fails outright
+    on any machine with no JVM. Round-3 review caught it: the pre-PR file produced zero
+    Spark banners, this one produced three.
+    """
+    monkeypatch.setattr(pipeline_mod.PipelineRunner, "_initialize_hail", lambda self: None)
+    return pipeline_mod.PipelineRunner(cfg)
+
+
 def test_pipeline_forwards_n_partitions_to_the_converter(tmp_path, monkeypatch):
     """The regression: PipelineConfig.n_partitions must REACH convert_vds_to_mt."""
     from hvantk.algorithms.hgc import pipeline as pipeline_mod
@@ -92,7 +106,7 @@ def test_pipeline_forwards_n_partitions_to_the_converter(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", _spy)
 
-    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path, n_partitions=64))
+    runner = _runner_without_hail(pipeline_mod, monkeypatch, _cfg(tmp_path, n_partitions=64))
     runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
     runner._run_vds_to_mt()
 
@@ -106,7 +120,7 @@ def test_pipeline_passes_none_when_unset(tmp_path, monkeypatch):
     seen = {}
     monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", lambda **kw: seen.update(kw))
 
-    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path))
+    runner = _runner_without_hail(pipeline_mod, monkeypatch, _cfg(tmp_path))
     runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
     runner._run_vds_to_mt()
 
@@ -176,22 +190,31 @@ def test_vds2mt_dry_run_shows_zero_rather_than_auto(tmp_path):
         )
 
     assert result.exit_code == 0, result.output
-    assert "Partitions: 0" in result.output, result.output
-    assert "auto" not in result.output, result.output
+    # The Partitions LINE only -- result.output embeds tmp_path, so a blanket
+    # `assert "auto" not in result.output` depends on pytest's tmp-dir naming rather
+    # than on the code under test.
+    line = next(ln for ln in result.output.splitlines() if "Partitions:" in ln)
+    assert line.split(":", 1)[1].strip() == "0", line
 
 
-def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path):
+def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path, monkeypatch):
     """The other call site: PipelineRunner.show_plan."""
-    from hvantk.algorithms.hgc.pipeline import PipelineRunner
-
-    import io
     import contextlib
+    import io
 
-    runner = PipelineRunner(_cfg(tmp_path, n_partitions=0))
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    runner = _runner_without_hail(
+        pipeline_mod, monkeypatch, _cfg(tmp_path, n_partitions=0)
+    )
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         runner.show_plan()
-    out = buf.getvalue()
 
-    assert "Partitions (MT):  0" in out, out
-    assert "auto" not in out, out
+    # Assert on the Partitions LINE, not the whole capture. A blanket
+    # `assert "auto" not in out` scans output that embeds tmp_path, whose directory name
+    # pytest derives from this function's own name truncated to 30 chars -- it passed
+    # only because the cut landed one character before the trailing "auto". Renaming the
+    # test would have broken it for reasons having nothing to do with the code.
+    line = next(ln for ln in buf.getvalue().splitlines() if "Partitions (MT):" in ln)
+    assert line.split(":", 1)[1].strip() == "0", line

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -218,3 +218,25 @@ def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path, monkeypatch):
     # test would have broken it for reasons having nothing to do with the code.
     line = next(ln for ln in buf.getvalue().splitlines() if "Partitions (MT):" in ln)
     assert line.split(":", 1)[1].strip() == "0", line
+
+
+def test_run_plan_does_not_advertise_partitions_when_the_stage_is_skipped(
+    tmp_path, monkeypatch
+):
+    """--skip-vds-to-mt means convert_vds_to_mt never runs, so the existing MatrixTable
+    keeps its layout. Printing the requested number there would repeat #208's mistake in
+    a new place: affirming a setting no stage will read."""
+    import contextlib
+    import io
+
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    cfg = _cfg(tmp_path, n_partitions=64, skip_vds_to_mt=True, mt_path=str(tmp_path))
+    runner = _runner_without_hail(pipeline_mod, monkeypatch, cfg)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        runner.show_plan()
+
+    line = next(ln for ln in buf.getvalue().splitlines() if "Partitions (MT):" in ln)
+    assert "64" not in line, line
+    assert "skipped" in line.lower(), line

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -69,3 +69,43 @@ def test_valid_combiner_tuning_passes_validate(tmp_path):
         e for e in errors if "interval" in e or "batch" in e or "branch" in e
     ]
     assert combiner_errors == []
+
+
+# --- #208: n_partitions reached no pipeline stage ----------------------------------
+#
+# The field was accepted from the CLI and echoed back in the run plan while being read by
+# nothing, so the run plan affirmatively told the user a setting had taken effect when it
+# had not. These pin the wiring; the end-to-end partition-count assertion lives in
+# test_hgc_core_hail.py, which needs Hail.
+
+
+def test_pipeline_forwards_n_partitions_to_the_converter(tmp_path, monkeypatch):
+    """The regression: PipelineConfig.n_partitions must REACH convert_vds_to_mt."""
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    seen = {}
+
+    def _spy(**kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", _spy)
+
+    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path, n_partitions=64))
+    runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
+    runner._run_vds_to_mt()
+
+    assert seen["n_partitions"] == 64
+
+
+def test_pipeline_passes_none_when_unset(tmp_path, monkeypatch):
+    """Unset must stay None rather than becoming a number, so the VDS layout is kept."""
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    seen = {}
+    monkeypatch.setattr(pipeline_mod, "convert_vds_to_mt", lambda **kw: seen.update(kw))
+
+    runner = pipeline_mod.PipelineRunner(_cfg(tmp_path))
+    runner.state.outputs["vds"] = str(tmp_path / "cohort.vds")
+    runner._run_vds_to_mt()
+
+    assert seen["n_partitions"] is None

--- a/hvantk/tests/test_drift_runner.py
+++ b/hvantk/tests/test_drift_runner.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from hvantk.core.plugin import drift_runner
 from hvantk.core.plugin.drift_runner import DriftResult, run_drift_check
 from hvantk.core.plugin.api import DatasetSpec, DriftProbeError, TestPaths
 
@@ -345,3 +346,88 @@ def test_empty_checksums_map_is_still_not_a_placeholder(tmp_path: Path):
     spec = _make_spec(probe_return=dict(fp), fingerprint_path=fp_path)
 
     assert _run_with_spec(spec).status == "clean"
+
+
+# --- one probe per drift signal ------------------------------------------------------
+
+
+def _spec(name, fingerprint_path, probe):
+    """Minimal DatasetSpec stand-in: run_drift_checks touches only these fields."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        name=name,
+        drift_probe=probe,
+        test_paths=SimpleNamespace(drift_fingerprint=str(fingerprint_path)),
+    )
+
+
+def test_datasets_sharing_a_baseline_and_probe_are_probed_once(tmp_path):
+    """ucsc-cellbrowser's three datasets share one baseline and one zero-arg probe, so
+    they have ONE drift signal. Probing per dataset made three identical HTTP calls and
+    produced three mutually-conflicting PRs."""
+    fp = tmp_path / "drift_fingerprint.json"
+    fp.write_text(json.dumps({"source_version": "v1", "fetched_at": "2026-01-01"}))
+
+    calls = []
+
+    def probe():
+        calls.append(1)
+        return {"source_version": "v1", "fetched_at": "2026-08-04"}
+
+    specs = [_spec(f"ucsc:{n}", fp, probe) for n in ("default", "adult-ctx", "dev-ctx")]
+    results = drift_runner.run_drift_checks(specs)
+
+    assert len(calls) == 1, f"probe ran {len(calls)} times; expected 1"
+    assert [r.dataset_name for r in results] == [
+        "ucsc:default", "ucsc:adult-ctx", "ucsc:dev-ctx"
+    ], "every dataset must still get its own entry"
+    assert {r.status for r in results} == {"clean"}
+    assert {r.fingerprint_path for r in results} == {str(fp)}
+
+
+def test_same_baseline_but_different_probes_are_not_grouped(tmp_path):
+    """Conservative on a manifest error: two probes writing one baseline would each
+    overwrite the other, so they must not share a result. `plugins validate` rejects the
+    declaration; the runtime simply refuses to merge them."""
+    fp = tmp_path / "drift_fingerprint.json"
+    fp.write_text(json.dumps({"source_version": "v1"}))
+
+    calls = []
+
+    def probe_a():
+        calls.append("a")
+        return {"source_version": "v1"}
+
+    def probe_b():
+        calls.append("b")
+        return {"source_version": "v1"}
+
+    results = drift_runner.run_drift_checks(
+        [_spec("p:one", fp, probe_a), _spec("p:two", fp, probe_b)]
+    )
+
+    assert sorted(calls) == ["a", "b"], "each distinct probe must run"
+    assert len(results) == 2
+
+
+def test_distinct_baselines_are_probed_separately(tmp_path):
+    """The obvious non-regression: unrelated datasets keep independent drift."""
+    calls = []
+
+    def make(version):
+        def probe():
+            calls.append(version)
+            return {"source_version": version}
+        return probe
+
+    specs = []
+    for name, version in (("a:x", "1"), ("b:y", "2")):
+        fp = tmp_path / f"{name.replace(':', '_')}.json"
+        fp.write_text(json.dumps({"source_version": version}))
+        specs.append(_spec(name, fp, make(version)))
+
+    results = drift_runner.run_drift_checks(specs)
+
+    assert sorted(calls) == ["1", "2"]
+    assert {r.status for r in results} == {"clean"}

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -188,3 +188,150 @@ def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeyp
     """No branch yet -> always push. Cheap, but it is the common first-drift path."""
     monkeypatch.setattr(drift_to_pr, "remote_branch_exists", lambda b, dry_run: False)
     assert drift_to_pr.branch_needs_update("drift/x-y", dry_run=False) is True
+
+
+# --- the skip path itself, end to end -----------------------------------------------
+#
+# Adversarial review caught that NO test exercised the behaviour this change adds:
+# replacing the whole body of `branch_needs_update` with `return True` -- a complete
+# neutering of the fix -- left every test green. These drive handle_drifted and assert
+# on the git/gh commands actually issued.
+
+
+def _capture_handle_drifted(drift_to_pr, monkeypatch, *, needs_update, pr_exists):
+    """Run handle_drifted with git/gh stubbed, returning the commands it issued."""
+    cmds: list[list[str]] = []
+
+    def _record(cmd, **kwargs):
+        cmds.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(drift_to_pr, "_run", _record)
+    monkeypatch.setattr(drift_to_pr, "branch_needs_update", lambda b, dry_run: needs_update)
+    monkeypatch.setattr(
+        drift_to_pr, "pr_exists_for_branch", lambda b, dry_run: "7" if pr_exists else None
+    )
+    # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
+    # which is the state after a real regeneration.
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 1)
+    )
+
+    drift_to_pr.handle_drifted(
+        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=None
+    )
+    return cmds
+
+
+def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch):
+    """The behaviour the whole PR exists for. Fails if branch_needs_update is neutered
+    to `return True`, which is exactly the hole review found."""
+    cmds = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, needs_update=False, pr_exists=True
+    )
+    joined = [" ".join(c) for c in cmds]
+    assert not any(c.startswith("git commit") for c in joined), joined
+    assert not any(c.startswith("git push") for c in joined), joined
+    assert not any(c.startswith("gh pr") for c in joined), joined
+
+
+def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch):
+    """The complement: when the branch DOES need updating, nothing is suppressed."""
+    cmds = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, needs_update=True, pr_exists=True
+    )
+    joined = [" ".join(c) for c in cmds]
+    assert any(c.startswith("git commit") for c in joined), joined
+    assert any(c.startswith("git push") for c in joined), joined
+    assert any(c.startswith("gh pr edit") for c in joined), joined
+
+
+def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch):
+    """A branch can outlive its PR -- closing a PR leaves the head branch, and a run
+    whose push succeeded while `gh pr create` failed leaves a branch with no PR at all.
+    Skipping on branch content alone would suppress that dataset's drift forever."""
+    cmds = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, needs_update=False, pr_exists=False
+    )
+    joined = [" ".join(c) for c in cmds]
+    assert any(c.startswith("gh pr create") for c in joined), joined
+
+
+# --- branch_needs_update against a REAL git repo -------------------------------------
+#
+# The stubbed tests above drive handle_drifted's branching, but they monkeypatch
+# branch_needs_update itself, so they cannot detect that function being wrong. Neutering
+# it to `return True` left them all green -- the same vacuity adversarial review found in
+# the first version of this test file. This exercises the real thing over real git.
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, text=True, capture_output=True
+    )
+
+
+@pytest.fixture
+def repo_with_drift_branch(tmp_path, drift_to_pr, monkeypatch):
+    """A repo whose `drift/p-d` branch already carries a fingerprint, with `origin`
+    pointing back at itself so ls-remote/fetch behave as they do in CI."""
+    repo = tmp_path / "repo"
+    (repo / "hvantk" / "skills").mkdir(parents=True)
+    fp = repo / "hvantk" / "skills" / "drift_fingerprint.json"
+
+    _git(repo.parent, "init", "-q", str(repo))
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    fp.write_text(json.dumps({"source_version": "v1", "fetched_at": "2026-08-01"}))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    _git(repo, "branch", "-M", "dev")
+    _git(repo, "checkout", "-qb", "drift/p-d")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "branch head")
+    _git(repo, "checkout", "-q", "dev")
+    _git(repo, "remote", "add", "origin", str(repo))
+
+    monkeypatch.setattr(drift_to_pr, "REPO_ROOT", repo)
+    monkeypatch.chdir(repo)
+    return repo, fp
+
+
+def test_branch_needs_update_false_when_only_the_timestamp_moved(
+    repo_with_drift_branch, drift_to_pr
+):
+    """The regression this PR exists for, against real git."""
+    repo, fp = repo_with_drift_branch
+    fp.write_text(json.dumps({"source_version": "v1", "fetched_at": "2026-08-04"}))
+    _git(repo, "add", "hvantk/skills")
+
+    assert drift_to_pr.branch_needs_update("drift/p-d", dry_run=False) is False
+
+
+def test_branch_needs_update_true_when_the_source_actually_moved(
+    repo_with_drift_branch, drift_to_pr
+):
+    """The signal must survive: a real upstream change still pushes."""
+    repo, fp = repo_with_drift_branch
+    fp.write_text(json.dumps({"source_version": "v2", "fetched_at": "2026-08-04"}))
+    _git(repo, "add", "hvantk/skills")
+
+    assert drift_to_pr.branch_needs_update("drift/p-d", dry_run=False) is True
+
+
+def test_discard_staged_fingerprints_clears_index_and_worktree(
+    repo_with_drift_branch, drift_to_pr
+):
+    """The contamination fix: a skipped dataset must leave nothing behind for the next
+    one. `git checkout -B` does not clear the index, so a leftover staged fingerprint
+    would be committed onto an unrelated dataset's branch."""
+    repo, fp = repo_with_drift_branch
+    original = fp.read_text()
+    fp.write_text(json.dumps({"source_version": "LEAKED", "fetched_at": "x"}))
+    _git(repo, "add", "hvantk/skills")
+    assert _git(repo, "diff", "--cached", "--name-only").stdout.strip()
+
+    drift_to_pr._discard_staged_fingerprints(dry_run=False)
+
+    assert _git(repo, "diff", "--cached", "--name-only").stdout.strip() == ""
+    assert fp.read_text() == original, "working tree must be restored too, or the next "\
+        "`git add hvantk/skills` re-stages the leak"

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -211,7 +211,7 @@ def _capture_handle_drifted(
     `subprocess.run` directly, not `_run`, so it was invisible here.
     """
     cmds: list[list[str]] = []
-    cleanups: list[bool] = []
+    cleanups: list[dict] = []
 
     def _record(cmd, **kwargs):
         cmds.append(list(cmd))
@@ -222,8 +222,12 @@ def _capture_handle_drifted(
     monkeypatch.setattr(
         drift_to_pr, "pr_exists_for_branch", lambda b, dry_run: "7" if pr_exists else None
     )
+    # Record the KWARGS, not just the fact of a call. `_discard_staged_fingerprints`
+    # is a no-op under dry_run=True (it prints and returns), so a spy that discards its
+    # arguments cannot tell a real cleanup from a neutered one -- a call site changed to
+    # `dry_run=True` would restore the contamination bug with the suite still green.
     monkeypatch.setattr(
-        drift_to_pr, "_discard_staged_fingerprints", lambda **kw: cleanups.append(True)
+        drift_to_pr, "_discard_staged_fingerprints", lambda **kw: cleanups.append(kw)
     )
     # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
     # which is the state after a real regeneration. 0 means nothing to commit.
@@ -237,7 +241,7 @@ def _capture_handle_drifted(
     drift_to_pr.handle_drifted(
         dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
     )
-    return cmds, len(cleanups), (summary.read_text() if summary.exists() else "")
+    return cmds, cleanups, (summary.read_text() if summary.exists() else "")
 
 
 def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch, tmp_path):
@@ -252,7 +256,10 @@ def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch, tmp_path):
     assert not any(c.startswith("gh pr") for c in joined), joined
     # The staged fingerprint MUST be discarded before returning, or it is committed
     # onto the next dataset's branch. Deleting this call site was a silent revert.
-    assert cleanups == 1, "skip path must discard the staged fingerprint"
+    assert cleanups == [{"dry_run": False}], (
+        "skip path must discard the staged fingerprint, and must do it for real -- "
+        "dry_run=True would print and return, leaving the index contaminated"
+    )
     # ...and a still-drifting dataset must not vanish from the rendered report.
     assert "DRIFT (unchanged)" in summary, summary
 
@@ -365,4 +372,6 @@ def test_nothing_staged_path_also_discards(drift_to_pr, monkeypatch, tmp_path):
     _, cleanups, _ = _capture_handle_drifted(
         drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=True, staged=False
     )
-    assert cleanups == 1, "the 'nothing to commit' return must discard too"
+    assert cleanups == [{"dry_run": False}], (
+        "the 'nothing to commit' return must discard too, and for real"
+    )

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -52,6 +52,16 @@ DRIFTED = {
     "probe_error": None,
 }
 
+#: A grouped entry, as `group_by_drift_signal` emits it: several datasets sharing one
+#: baseline, with the first as the anchor. `DRIFTED` carries neither `datasets` nor
+#: `fingerprint_path`, so it only ever exercises the single-dataset path.
+GROUPED = {
+    **DRIFTED,
+    "dataset_name": "ucsc-cellbrowser:default",
+    "datasets": ["ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx"],
+    "fingerprint_path": "hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json",
+}
+
 
 def test_exits_nonzero_when_a_pr_cannot_be_opened(drift_to_pr, tmp_path, monkeypatch):
     """The regression: drift detected, branch pushed, `gh pr create` refused, exit 0.
@@ -281,7 +291,7 @@ def test_grouped_pr_names_every_dataset_it_covers(drift_to_pr):
 
 
 def _capture_handle_drifted(
-    drift_to_pr, monkeypatch, tmp_path, *, needs_update, pr_exists, staged=True
+    drift_to_pr, monkeypatch, tmp_path, *, needs_update, pr_exists, staged=True, entry=None
 ):
     """Run handle_drifted with git/gh stubbed.
 
@@ -321,7 +331,7 @@ def _capture_handle_drifted(
 
     summary = tmp_path / "summary.md"
     drift_to_pr.handle_drifted(
-        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
+        dict(entry or DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
     )
     return cmds, cleanups, (summary.read_text() if summary.exists() else "")
 
@@ -355,6 +365,32 @@ def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch, tmp_pat
     assert any(c.startswith("git commit") for c in joined), joined
     assert any(c.startswith("git push") for c in joined), joined
     assert any(c.startswith("gh pr edit") for c in joined), joined
+
+
+def test_grouped_entry_checks_out_the_signal_branch_and_titles_the_group(
+    drift_to_pr, monkeypatch, tmp_path
+):
+    """`handle_drifted`'s grouping wiring, not just the helpers it calls.
+
+    `branch_name_for_signal` and `pr_title_for` are unit-tested on their own, but every
+    other test here passes `DRIFTED`, which has no `datasets` and no `fingerprint_path`
+    -- so the single-dataset path is the only one they run. Passing `[dataset]` instead
+    of `covers`, or dropping `fingerprint_path`, would leave those unit tests green
+    while the bot silently opened a per-dataset PR for a grouped signal: the exact
+    regression #263 exists to prevent.
+    """
+    cmds, _, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=False, entry=GROUPED
+    )
+    joined = [" ".join(c) for c in cmds]
+
+    checkout = next(c for c in joined if c.startswith("git checkout -B"))
+    assert "drift/ucsc-cellbrowser" in checkout, checkout
+    # The anchor's per-dataset name is what a dropped `covers` would produce.
+    assert "drift/ucsc-cellbrowser-default" not in checkout, checkout
+
+    create = next(c for c in joined if c.startswith("gh pr create"))
+    assert "(2 datasets)" in create, create
 
 
 def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch, tmp_path):

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -198,9 +198,20 @@ def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeyp
 # on the git/gh commands actually issued.
 
 
-def _capture_handle_drifted(drift_to_pr, monkeypatch, *, needs_update, pr_exists):
-    """Run handle_drifted with git/gh stubbed, returning the commands it issued."""
+def _capture_handle_drifted(
+    drift_to_pr, monkeypatch, tmp_path, *, needs_update, pr_exists, staged=True
+):
+    """Run handle_drifted with git/gh stubbed.
+
+    Returns (commands issued, cleanup-call count, step-summary text). The cleanup count
+    and summary are captured deliberately: an earlier version of this helper recorded
+    only `_run` and passed step_summary=None, so deleting the
+    `_discard_staged_fingerprints(...)` CALL SITES -- a full revert of the fix they
+    belong to -- left the whole suite green. `_discard_staged_fingerprints` calls
+    `subprocess.run` directly, not `_run`, so it was invisible here.
+    """
     cmds: list[list[str]] = []
+    cleanups: list[bool] = []
 
     def _record(cmd, **kwargs):
         cmds.append(list(cmd))
@@ -211,34 +222,45 @@ def _capture_handle_drifted(drift_to_pr, monkeypatch, *, needs_update, pr_exists
     monkeypatch.setattr(
         drift_to_pr, "pr_exists_for_branch", lambda b, dry_run: "7" if pr_exists else None
     )
-    # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
-    # which is the state after a real regeneration.
     monkeypatch.setattr(
-        subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 1)
+        drift_to_pr, "_discard_staged_fingerprints", lambda **kw: cleanups.append(True)
+    )
+    # `git diff --cached --quiet` -> returncode 1 means "there is something staged",
+    # which is the state after a real regeneration. 0 means nothing to commit.
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 1 if staged else 0),
     )
 
+    summary = tmp_path / "summary.md"
     drift_to_pr.handle_drifted(
-        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=None
+        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
     )
-    return cmds
+    return cmds, len(cleanups), (summary.read_text() if summary.exists() else "")
 
 
-def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch):
+def test_skip_issues_no_commit_push_or_pr(drift_to_pr, monkeypatch, tmp_path):
     """The behaviour the whole PR exists for. Fails if branch_needs_update is neutered
     to `return True`, which is exactly the hole review found."""
-    cmds = _capture_handle_drifted(
-        drift_to_pr, monkeypatch, needs_update=False, pr_exists=True
+    cmds, cleanups, summary = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=False, pr_exists=True
     )
     joined = [" ".join(c) for c in cmds]
     assert not any(c.startswith("git commit") for c in joined), joined
     assert not any(c.startswith("git push") for c in joined), joined
     assert not any(c.startswith("gh pr") for c in joined), joined
+    # The staged fingerprint MUST be discarded before returning, or it is committed
+    # onto the next dataset's branch. Deleting this call site was a silent revert.
+    assert cleanups == 1, "skip path must discard the staged fingerprint"
+    # ...and a still-drifting dataset must not vanish from the rendered report.
+    assert "DRIFT (unchanged)" in summary, summary
 
 
-def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch):
+def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch, tmp_path):
     """The complement: when the branch DOES need updating, nothing is suppressed."""
-    cmds = _capture_handle_drifted(
-        drift_to_pr, monkeypatch, needs_update=True, pr_exists=True
+    cmds, _, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=True
     )
     joined = [" ".join(c) for c in cmds]
     assert any(c.startswith("git commit") for c in joined), joined
@@ -246,12 +268,12 @@ def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch):
     assert any(c.startswith("gh pr edit") for c in joined), joined
 
 
-def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch):
+def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch, tmp_path):
     """A branch can outlive its PR -- closing a PR leaves the head branch, and a run
     whose push succeeded while `gh pr create` failed leaves a branch with no PR at all.
     Skipping on branch content alone would suppress that dataset's drift forever."""
-    cmds = _capture_handle_drifted(
-        drift_to_pr, monkeypatch, needs_update=False, pr_exists=False
+    cmds, _, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=False, pr_exists=False
     )
     joined = [" ".join(c) for c in cmds]
     assert any(c.startswith("gh pr create") for c in joined), joined
@@ -335,3 +357,12 @@ def test_discard_staged_fingerprints_clears_index_and_worktree(
     assert _git(repo, "diff", "--cached", "--name-only").stdout.strip() == ""
     assert fp.read_text() == original, "working tree must be restored too, or the next "\
         "`git add hvantk/skills` re-stages the leak"
+
+
+def test_nothing_staged_path_also_discards(drift_to_pr, monkeypatch, tmp_path):
+    """The OTHER early return after `git add`. Both must clean up, or whichever is left
+    uncovered reintroduces contamination on its own path."""
+    _, cleanups, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=True, staged=False
+    )
+    assert cleanups == 1, "the 'nothing to commit' return must discard too"

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -417,3 +417,25 @@ def test_discard_staged_fingerprints_clears_index_and_worktree(
     assert _git(repo, "diff", "--cached", "--name-only").stdout.strip() == ""
     assert fp.read_text() == original, "working tree must be restored too, or the next "\
         "`git add hvantk/skills` re-stages the leak"
+
+
+def test_two_signals_from_one_provider_do_not_collide_on_one_branch(drift_to_pr):
+    """Review finding on #263: keying a group's branch on the provider alone discards the
+    baseline path that DEFINES the signal. Multi-dataset providers suffix their baselines
+    per dataset, so a provider can own two independent signals; collapsing them onto one
+    branch means the second overwrites the first's commit and rewrites its PR."""
+    a = drift_to_pr.branch_name_for_signal(
+        ["p:one", "p:two"], "hvantk/skills/p/tests/drift_fingerprint.json"
+    )
+    b = drift_to_pr.branch_name_for_signal(
+        ["p:three", "p:four"], "hvantk/skills/p/tests/drift_fingerprint_samples.json"
+    )
+    assert a != b, f"distinct signals collided on {a}"
+    assert a == "drift/p"                 # the unsuffixed baseline keeps the plain name
+    assert b == "drift/p-samples"
+
+
+def test_group_branch_still_stable_across_member_order(drift_to_pr):
+    fp = "hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json"
+    assert drift_to_pr.branch_name_for_signal(["u:a", "u:b", "u:c"], fp) == \
+           drift_to_pr.branch_name_for_signal(["u:c", "u:a", "u:b"], fp)

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -478,3 +478,44 @@ def test_nothing_staged_path_also_discards(drift_to_pr, monkeypatch, tmp_path):
     assert cleanups == [{"dry_run": False}], (
         "the 'nothing to commit' return must discard too, and for real"
     )
+
+
+def test_same_baseline_different_probes_are_not_grouped(drift_to_pr):
+    """The bot must apply the runner's rule, not a weaker one.
+
+    `run_drift_checks` keys on (baseline, probe callable) so that two datasets sharing a
+    baseline while declaring DIFFERENT probes -- a manifest error -- are never merged.
+    Grouping on the baseline alone here would re-merge them, opening one PR whose
+    regeneration covers only the first dataset and leaving the second's drift silently
+    unaddressed.
+    """
+    groups = drift_to_pr.group_by_drift_signal([
+        {**_drifted("p:one", UCSC_FP), "probe_ref": "mod:probe_a"},
+        {**_drifted("p:two", UCSC_FP), "probe_ref": "mod:probe_b"},
+    ])
+    assert len(groups) == 2, "different probes must not share a PR"
+
+
+def test_same_baseline_same_probe_still_groups(drift_to_pr):
+    """The complement: the ucsc case must keep collapsing."""
+    groups = drift_to_pr.group_by_drift_signal([
+        {**_drifted("u:a", UCSC_FP), "probe_ref": "mod:fetch_fingerprint"},
+        {**_drifted("u:b", UCSC_FP), "probe_ref": "mod:fetch_fingerprint"},
+    ])
+    assert len(groups) == 1
+    assert groups[0]["datasets"] == ["u:a", "u:b"]
+
+
+def test_an_undecodable_staged_file_does_not_abort_the_run(
+    repo_with_drift_branch, drift_to_pr
+):
+    """`read_text()` raises UnicodeDecodeError on non-UTF-8, which is not a
+    CalledProcessError, so `main` would not catch it and every remaining dataset would be
+    skipped. `paths` is every staged path, not only JSON this script wrote."""
+    repo, fp = repo_with_drift_branch
+    fp.write_bytes(b'\xff\xfe{"source_version": "v1"}')
+    _git(repo, "add", "hvantk/skills")
+
+    # Must return a verdict rather than raising. Undecodable content cannot match, so
+    # the safe answer is "push".
+    assert drift_to_pr.branch_needs_update("drift/p-d", dry_run=False) is True

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -125,3 +125,66 @@ def test_branch_name_rejects_a_bare_provider(drift_to_pr):
     assert drift_to_pr.branch_name_for("clinvar:variants") == "drift/clinvar-variants"
     with pytest.raises(ValueError):
         drift_to_pr.branch_name_for("clinvar")
+
+
+# --- the daily-churn guard ---------------------------------------------------------
+#
+# Every open drift PR was force-pushed and its body re-edited once per DAY for a week --
+# nine PRs, ~63 notification events, none carrying new information. `--regenerate`
+# rewrites `fetched_at` on every run, and the pre-existing emptiness check compares
+# against BASE_BRANCH, so for a still-drifted dataset it could never fire. Nothing
+# compared the new fingerprint against what the branch already proposed.
+
+
+def test_fingerprints_match_ignores_only_volatile_keys(drift_to_pr):
+    """Same data, later probe -> match. Different source_version -> no match."""
+    base = {
+        "source_version": "2026-05-15",
+        "checksums": {"f.tsv": "abc"},
+        "fetched_at": "2026-08-01T00:00:00+00:00",
+        "probe_version": 1,
+    }
+    later = dict(base, fetched_at="2026-08-04T06:00:00+00:00", probe_version=2)
+    moved = dict(base, source_version="2026-07-31")
+
+    assert drift_to_pr.fingerprints_match(json.dumps(base), json.dumps(later))
+    assert not drift_to_pr.fingerprints_match(json.dumps(base), json.dumps(moved))
+
+
+def test_fingerprints_match_treats_a_content_change_as_material(drift_to_pr):
+    """ClinGen's real case: checksum identical, only `extras.content_length` moved.
+
+    That must still count as a change -- this guard is about suppressing *timestamp*
+    churn, not about suppressing upstream content revisions.
+    """
+    base = {"checksums": {"f.csv": "abc"}, "extras": {"content_length": "1113685"},
+            "fetched_at": "2026-08-01T00:00:00+00:00"}
+    grown = {"checksums": {"f.csv": "abc"}, "extras": {"content_length": "1114672"},
+             "fetched_at": "2026-08-04T00:00:00+00:00"}
+
+    assert not drift_to_pr.fingerprints_match(json.dumps(base), json.dumps(grown))
+
+
+def test_unparseable_fingerprint_is_never_treated_as_matching(drift_to_pr):
+    """"I cannot tell" must mean "push", never "skip".
+
+    Returning True here would silently suppress a real drift PR whenever a fingerprint
+    was malformed -- the failure mode this whole script exists to avoid.
+    """
+    assert not drift_to_pr.fingerprints_match("{not json", "{}")
+    assert not drift_to_pr.fingerprints_match("{}", "")
+
+
+def test_ignored_keys_stay_in_sync_with_the_package(drift_to_pr):
+    """The script duplicates PROBE_FINGERPRINT_IGNORED_KEYS because it runs from a
+    checkout where hvantk may not be importable. Duplication needs a guard, or the two
+    drift apart and the bot starts disagreeing with the detector."""
+    from hvantk.core.plugin.api import PROBE_FINGERPRINT_IGNORED_KEYS
+
+    assert drift_to_pr.FINGERPRINT_IGNORED_KEYS == PROBE_FINGERPRINT_IGNORED_KEYS
+
+
+def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeypatch):
+    """No branch yet -> always push. Cheap, but it is the common first-drift path."""
+    monkeypatch.setattr(drift_to_pr, "remote_branch_exists", lambda b, dry_run: False)
+    assert drift_to_pr.branch_needs_update("drift/x-y", dry_run=False) is True

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -188,3 +188,87 @@ def test_branch_needs_update_is_true_when_the_branch_is_new(drift_to_pr, monkeyp
     """No branch yet -> always push. Cheap, but it is the common first-drift path."""
     monkeypatch.setattr(drift_to_pr, "remote_branch_exists", lambda b, dry_run: False)
     assert drift_to_pr.branch_needs_update("drift/x-y", dry_run=False) is True
+
+
+# --- one PR per drift SIGNAL, not per dataset --------------------------------------
+#
+# ucsc-cellbrowser declares three datasets (default / adult-ctx / dev-ctx) that are
+# distinct SCHEMA variants -- their obs cell-type column is `celltype`, `Class` and
+# `Type_v2` -- but all three share one drift_fingerprint and a zero-argument probe that
+# fingerprints the provider-wide catalog. One upstream event therefore produced three
+# identical PRs, and merging any one made the other two conflict (#241/#242/#243).
+
+
+def _drifted(name, path):
+    return {"dataset_name": name, "status": "drifted", "fingerprint_path": path,
+            "observed": {}, "expected": {}, "diff": {}, "probe_error": None}
+
+
+UCSC_FP = "hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json"
+
+
+def test_datasets_sharing_a_baseline_collapse_to_one_entry(drift_to_pr):
+    groups = drift_to_pr.group_by_drift_signal([
+        _drifted("ucsc-cellbrowser:default", UCSC_FP),
+        _drifted("ucsc-cellbrowser:adult-ctx", UCSC_FP),
+        _drifted("ucsc-cellbrowser:dev-ctx", UCSC_FP),
+    ])
+
+    assert len(groups) == 1
+    assert groups[0]["datasets"] == [
+        "ucsc-cellbrowser:default",
+        "ucsc-cellbrowser:adult-ctx",
+        "ucsc-cellbrowser:dev-ctx",
+    ]
+
+
+def test_distinct_baselines_are_never_merged(drift_to_pr):
+    """The guard that keeps this from over-collapsing: different file, different PR."""
+    groups = drift_to_pr.group_by_drift_signal([
+        _drifted("clinvar:variants", "hvantk/skills/clinvar/tests/drift_fingerprint.json"),
+        _drifted("hgnc:lookup", "hvantk/skills/hgnc/tests/drift_fingerprint.json"),
+    ])
+    assert len(groups) == 2
+
+
+def test_entries_without_a_fingerprint_path_are_never_grouped(drift_to_pr):
+    """An older report shape must not silently collapse unrelated datasets into one PR."""
+    groups = drift_to_pr.group_by_drift_signal([
+        {"dataset_name": "a:x", "status": "drifted"},
+        {"dataset_name": "b:y", "status": "drifted"},
+    ])
+    assert len(groups) == 2
+    assert [g["datasets"] for g in groups] == [["a:x"], ["b:y"]]
+
+
+def test_group_branch_is_provider_level_but_single_datasets_keep_their_name(drift_to_pr):
+    """A lone dataset must keep its historical branch, or open PRs stop being matched."""
+    assert drift_to_pr.branch_name_for_signal(["clinvar:variants"]) == "drift/clinvar-variants"
+    assert drift_to_pr.branch_name_for_signal([
+        "ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx",
+    ]) == "drift/ucsc-cellbrowser"
+
+
+def test_group_branch_is_stable_regardless_of_member_order(drift_to_pr):
+    """Branch names must not move between runs, or every run orphans yesterday's PR."""
+    a = drift_to_pr.branch_name_for_signal(["ucsc:default", "ucsc:adult", "ucsc:dev"])
+    b = drift_to_pr.branch_name_for_signal(["ucsc:dev", "ucsc:default", "ucsc:adult"])
+    assert a == b
+
+
+def test_grouped_pr_names_every_dataset_it_covers(drift_to_pr):
+    body = drift_to_pr.build_pr_body(
+        "ucsc-cellbrowser:default", {}, None, [],
+        covers=["ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx"],
+    )
+    assert "ucsc-cellbrowser:adult-ctx" in body
+
+    title = drift_to_pr.pr_title_for(
+        "ucsc-cellbrowser:default",
+        covers=["ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx"],
+    )
+    assert "2 datasets" in title
+    # A single dataset keeps the original title verbatim.
+    assert drift_to_pr.pr_title_for("clinvar:variants") == (
+        "chore(drift): clinvar:variants snapshot regeneration"
+    )

--- a/hvantk/tests/test_http_retry.py
+++ b/hvantk/tests/test_http_retry.py
@@ -1,0 +1,103 @@
+"""Guard the drift-probe HTTP retry helper.
+
+Regression: on 2026-08-04 GenCC answered the scheduled drift regeneration with HTTP 429.
+No probe retried, so it raised, no PR could be opened for the drifted dataset, and the
+whole workflow run failed -- with nothing wrong with either the data or the code.
+
+The clamp is tested as carefully as the retry because it is the reason this helper exists
+instead of ``urllib3.util.Retry``: that honours ``Retry-After`` via ``time.sleep``
+with no upper bound, so a host answering ``Retry-After: 3600`` would park CI for an hour.
+Deliberately non-Hail so it runs in the default suite.
+"""
+from __future__ import annotations
+
+import pytest
+import requests
+
+from hvantk.core.utils import http as http_util
+
+URL = "https://example.invalid/drift.tsv"
+
+
+@pytest.fixture
+def slept(monkeypatch):
+    """Record sleep durations instead of actually sleeping."""
+    calls: list[float] = []
+    monkeypatch.setattr(http_util.time, "sleep", calls.append)
+    return calls
+
+
+def test_retries_past_a_429_and_returns_the_success(requests_mock, slept):
+    """The GenCC failure, end to end: transient 429 then a good response."""
+    requests_mock.get(URL, [{"status_code": 429}, {"status_code": 200, "text": "ok"}])
+
+    resp = http_util.request_with_retry("GET", URL)
+
+    assert resp.status_code == 200
+    assert resp.text == "ok"
+    assert len(slept) == 1, "should have backed off exactly once"
+
+
+def test_retry_after_is_honoured_but_clamped(requests_mock, slept):
+    """A long Retry-After must not be able to stall the job.
+
+    This is the specific behaviour urllib3 does NOT give us.
+    """
+    requests_mock.get(
+        URL,
+        [
+            {"status_code": 429, "headers": {"Retry-After": "3600"}},
+            {"status_code": 200, "text": "ok"},
+        ],
+    )
+
+    resp = http_util.request_with_retry("GET", URL, max_sleep_s=30.0)
+
+    assert resp.status_code == 200
+    assert slept == [30.0], "Retry-After should be clamped to max_sleep_s, not obeyed"
+
+
+def test_exhausted_retries_return_the_last_response(requests_mock, slept):
+    """Callers keep their existing error handling.
+
+    The helper never calls raise_for_status itself, so a response that is still 429
+    after the final attempt comes back as a 429 and raises exactly where it used to.
+    """
+    requests_mock.get(URL, status_code=429)
+
+    resp = http_util.request_with_retry("GET", URL, attempts=3)
+
+    assert resp.status_code == 429
+    assert len(slept) == 2, "3 attempts means 2 gaps"
+    with pytest.raises(requests.HTTPError):
+        resp.raise_for_status()
+
+
+def test_connection_errors_are_retried_but_other_request_errors_are_not(
+    requests_mock, slept
+):
+    """A flaky handshake is the same class of problem as a 503; a bad URL is not."""
+    requests_mock.get(URL, [{"exc": requests.ConnectionError}, {"text": "ok"}])
+    assert http_util.request_with_retry("GET", URL).text == "ok"
+    assert len(slept) == 1
+
+    slept.clear()
+    requests_mock.get(URL, exc=requests.URLRequired)
+    with pytest.raises(requests.URLRequired):
+        http_util.request_with_retry("GET", URL)
+    assert slept == [], "non-transient errors must not be retried"
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("120", 120.0),
+        ("  90  ", 90.0),
+        ("not-a-date", None),
+        ("", None),
+        (None, None),
+        ("Wed, 21 Oct 1990 07:28:00 GMT", 0.0),  # in the past -> clamped to 0, not negative
+    ],
+)
+def test_parse_retry_after(header, expected):
+    assert http_util.parse_retry_after(header) == expected

--- a/hvantk/tests/test_http_retry.py
+++ b/hvantk/tests/test_http_retry.py
@@ -101,3 +101,35 @@ def test_connection_errors_are_retried_but_other_request_errors_are_not(
 )
 def test_parse_retry_after(header, expected):
     assert http_util.parse_retry_after(header) == expected
+
+
+# --- review findings on #268 ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"backoff_s": -1.0},
+    {"max_sleep_s": -5.0},
+])
+def test_negative_timings_are_rejected_before_the_first_request(kwargs):
+    """A negative value would otherwise surface only AFTER a transient failure, replacing
+    the upstream error the caller was retrying with ValueError('sleep length must be
+    non-negative')."""
+    with pytest.raises(ValueError, match="must be >= 0"):
+        http_util.request_with_retry("GET", URL, **kwargs)
+
+
+def test_backoff_is_capped_at_max_sleep_for_any_attempt():
+    """`backoff_s * 2 ** (attempt - 1)` is evaluated BEFORE min() clamps it, so a high
+    attempt NUMBER raises `OverflowError: int too large to convert to float` -- not
+    merely a slow computation, an outright crash.
+
+    Asserted on the helper rather than by driving 1,200 real failures through the retry
+    loop: the `slept` fixture patches `time.sleep` globally, so under a full-suite run
+    that version captured sleeps from unrelated code (625,818 of them) and failed for a
+    reason having nothing to do with backoff. This form is deterministic and still fails
+    if the exponent cap is removed.
+    """
+    assert http_util._backoff(2.0, 1, 30.0) == 2.0
+    assert http_util._backoff(2.0, 4, 30.0) == 16.0
+    assert http_util._backoff(2.0, 99, 30.0) == 30.0
+    assert http_util._backoff(2.0, 10**6, 30.0) == 30.0

--- a/hvantk/tests/test_plugins_cli.py
+++ b/hvantk/tests/test_plugins_cli.py
@@ -107,6 +107,46 @@ def test_validate_rejects_catalog_entry_missing_required_field(tmp_path):
     assert "accession" in res.output
 
 
+def test_validate_normalizes_fingerprint_paths_before_grouping(tmp_path):
+    """`tests/x.json` and `./tests/x.json` name ONE baseline, as the loader resolves them.
+
+    Grouping on the declared string files them in separate buckets, so the
+    conflicting-probe check never fires and the baseline overwrite this validation
+    exists to name ships silently.
+    """
+    from click.testing import CliRunner
+    from hvantk.tools.plugins.plugins_cli import plugins_group
+
+    def _dataset(name: str, spelling: str, function: str) -> str:
+        return (
+            f"  - name: {name}\n"
+            "    domain: genomics\n"
+            "    backend: hail\n"
+            "    builder:\n"
+            "      module: hvantk.tests.testdata.raw.plugins.fake_plugin.builder\n"
+            "      function: build\n"
+            "    drift_probe:\n"
+            "      module: hvantk.tests.testdata.raw.plugins.fake_plugin.drift_probe\n"
+            f"      function: {function}\n"
+            "    skill: SKILL.md\n"
+            "    tests:\n"
+            "      command: pytest -q\n"
+            "      fixture: tests/testdata/raw/fake\n"
+            "      schema_snapshot: tests/snapshots/schema.json\n"
+            "      row_snapshot: tests/snapshots/sample_rows.json\n"
+            f"      drift_fingerprint: {spelling}\n"
+        )
+
+    (tmp_path / "plugin.yaml").write_text(
+        "api_version: 2\nname: tmp-plug\nversion: 0.1.0\ndatasets:\n"
+        + _dataset("a", "tests/drift_fingerprint.json", "fetch_fingerprint")
+        + _dataset("b", "./tests/drift_fingerprint.json", "a_different_probe")
+    )
+    res = CliRunner().invoke(plugins_group, ["validate", str(tmp_path / "plugin.yaml")])
+    assert res.exit_code != 0, res.output
+    assert "different drift probes" in res.output, res.output
+
+
 def test_validate_rejects_duplicate_accession_within_catalog(tmp_path):
     from click.testing import CliRunner
     from hvantk.tools.plugins.plugins_cli import plugins_group

--- a/hvantk/tools/hgc/convert_cli.py
+++ b/hvantk/tools/hgc/convert_cli.py
@@ -42,6 +42,17 @@ def register_convert_commands(group):
     "--overwrite/--no-overwrite", default=False, help="Overwrite output if exists"
 )
 @click.option(
+    "--n-partitions",
+    type=int,
+    default=None,
+    help=(
+        "Coalesce the dense MatrixTable to this many partitions before writing. Reduces "
+        "only. Default keeps the VDS's layout, which is derived from reference blocks and "
+        "saturates as sample count grows, leaving partitions too thin to amortise task "
+        "overhead (see issue #207). Size this from the dense matrix, not the VDS."
+    ),
+)
+@click.option(
     "--dry-run", is_flag=True, help="Show what would be done without executing"
 )
 @click.pass_context
@@ -54,6 +65,7 @@ def vds2mt(
     skip_validation,
     skip_keying_by_cols,
     overwrite,
+    n_partitions,
     dry_run,
 ):
     """
@@ -91,6 +103,7 @@ def vds2mt(
             click.echo(f"   • Adjust genotypes: {adjust_genotypes}")
             click.echo(f"   • Skip split multi: {skip_split_multi}")
             click.echo(f"   • Skip validation: {skip_validation}")
+            click.echo(f"   • Partitions: {n_partitions or 'auto (VDS layout)'}")
             return
 
         # Execute conversion
@@ -103,6 +116,7 @@ def vds2mt(
             skip_validation=skip_validation,
             skip_keying_by_cols=skip_keying_by_cols,
             overwrite=overwrite,
+            n_partitions=n_partitions,
         )
 
         click.echo(f"✅ Successfully converted {input} to MatrixTable at {output}")

--- a/hvantk/tools/hgc/convert_cli.py
+++ b/hvantk/tools/hgc/convert_cli.py
@@ -103,7 +103,11 @@ def vds2mt(
             click.echo(f"   • Adjust genotypes: {adjust_genotypes}")
             click.echo(f"   • Skip split multi: {skip_split_multi}")
             click.echo(f"   • Skip validation: {skip_validation}")
-            click.echo(f"   • Partitions: {n_partitions or 'auto (VDS layout)'}")
+            # `is None`, not `or`: 0 is rejected by convert_vds_to_mt, so rendering
+            # it as "auto" would have the dry run report a clean plan for an invocation
+            # that aborts.
+            shown = "auto (VDS layout)" if n_partitions is None else n_partitions
+            click.echo(f"   • Partitions: {shown}")
             return
 
         # Execute conversion

--- a/hvantk/tools/hgc/pipeline_cli.py
+++ b/hvantk/tools/hgc/pipeline_cli.py
@@ -138,7 +138,8 @@ def register_pipeline_command(group):
         "Reduces only. Default keeps the VDS's own layout, which is reference-block-derived "
         "and saturates as sample count grows, leaving partitions too thin to amortise task "
         "overhead (see #207). Size this from the dense matrix. Does not affect the gVCF "
-        "combiner -- use --combiner-* for stage 1."
+        "combiner -- use --import-interval-size / --gvcf-batch-size / --branch-factor / "
+        "--use-exome-default-intervals for stage 1."
     ),
 )
 @click.option(

--- a/hvantk/tools/hgc/pipeline_cli.py
+++ b/hvantk/tools/hgc/pipeline_cli.py
@@ -133,7 +133,13 @@ def register_pipeline_command(group):
     "--n-partitions",
     type=int,
     default=None,
-    help="Number of partitions for parallel processing",
+    help=(
+        "Coalesce the dense MatrixTable to this many partitions in the VDS -> MT stage. "
+        "Reduces only. Default keeps the VDS's own layout, which is reference-block-derived "
+        "and saturates as sample count grows, leaving partitions too thin to amortise task "
+        "overhead (see #207). Size this from the dense matrix. Does not affect the gVCF "
+        "combiner -- use --combiner-* for stage 1."
+    ),
 )
 @click.option(
     "--overwrite", is_flag=True, default=False, help="Overwrite existing output files"

--- a/hvantk/tools/plugins/drift_cli.py
+++ b/hvantk/tools/plugins/drift_cli.py
@@ -52,7 +52,11 @@ def drift_cmd(dataset, all_flag, domain, as_json, regenerate, timeout):
         click.echo(f"unknown dataset: {dataset}", err=True)
         raise SystemExit(EXIT_REGISTRY_ERROR)
 
-    results = [drift_runner.run_drift_check(spec.name, timeout=timeout) for spec in targets]
+    # run_drift_checks, not a comprehension over run_drift_check: datasets sharing a
+    # baseline AND a probe callable share one drift signal, so it is probed once and
+    # fanned out. Every dataset still gets its own entry; they just agree, and the CI
+    # bot collapses them into one PR via the shared fingerprint_path.
+    results = drift_runner.run_drift_checks(targets, timeout=timeout)
 
     if as_json:
         click.echo(json.dumps([_serialize(r) for r in results], indent=2, default=str))

--- a/hvantk/tools/plugins/plugins_cli.py
+++ b/hvantk/tools/plugins/plugins_cli.py
@@ -146,4 +146,31 @@ def validate_cmd(manifest_path: str, strict_artifacts: bool):
             err=True,
         )
 
+    # Datasets may deliberately SHARE a drift_fingerprint -- that is how a manifest says
+    # "these have one drift signal, not N", and the drift runner groups on it so one
+    # upstream event yields one PR rather than one per dataset. Sharing is only coherent
+    # when the probe is also shared: two datasets pointing different probes at one
+    # baseline would each overwrite the other's, and whichever regenerated last would
+    # define "clean" for both. That is a manifest error, so name it.
+    by_fingerprint: dict[str, list[tuple[str, tuple[str, str]]]] = {}
+    for dataset in content.get("datasets", []):
+        rel = (dataset.get("tests") or {}).get("drift_fingerprint")
+        probe = dataset.get("drift_probe") or {}
+        if not rel:
+            continue
+        by_fingerprint.setdefault(rel, []).append(
+            (dataset.get("name", "?"), (probe.get("module", ""), probe.get("function", "")))
+        )
+    conflicts = [
+        f"{rel} is shared by "
+        + ", ".join(f"{name} -> {mod}:{fn}" for name, (mod, fn) in members)
+        for rel, members in sorted(by_fingerprint.items())
+        if len({probe for _, probe in members}) > 1
+    ]
+    if conflicts:
+        raise click.ClickException(
+            "datasets share a drift_fingerprint but declare different drift probes; "
+            "they would overwrite each other's baseline:\n  - " + "\n  - ".join(conflicts)
+        )
+
     click.echo(f"ok: {manifest_path}")

--- a/hvantk/tools/plugins/plugins_cli.py
+++ b/hvantk/tools/plugins/plugins_cli.py
@@ -152,19 +152,28 @@ def validate_cmd(manifest_path: str, strict_artifacts: bool):
     # when the probe is also shared: two datasets pointing different probes at one
     # baseline would each overwrite the other's, and whichever regenerated last would
     # define "clean" for both. That is a manifest error, so name it.
+    # Key on the RESOLVED path rather than the declared string. The loader resolves
+    # these against the plugin directory before anything at runtime sees them (see
+    # `loader.py`), so `tests/x.json` and `./tests/x.json` are one baseline there.
+    # Grouping on the raw spelling would file them in separate buckets, the
+    # single-probe check would not fire, and the overwrite this validation exists to
+    # name would escape. The declared spelling is kept only for the message.
     by_fingerprint: dict[str, list[tuple[str, tuple[str, str]]]] = {}
+    declared: dict[str, str] = {}
     for dataset in content.get("datasets", []):
         rel = (dataset.get("tests") or {}).get("drift_fingerprint")
         probe = dataset.get("drift_probe") or {}
         if not rel:
             continue
-        by_fingerprint.setdefault(rel, []).append(
+        key = (plugin_dir / rel).resolve().as_posix()
+        declared.setdefault(key, rel)
+        by_fingerprint.setdefault(key, []).append(
             (dataset.get("name", "?"), (probe.get("module", ""), probe.get("function", "")))
         )
     conflicts = [
-        f"{rel} is shared by "
+        f"{declared[key]} is shared by "
         + ", ".join(f"{name} -> {mod}:{fn}" for name, (mod, fn) in members)
-        for rel, members in sorted(by_fingerprint.items())
+        for key, members in sorted(by_fingerprint.items())
         if len({probe for _, probe in members}) > 1
     ]
     if conflicts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
 [project]
 name = "hvantk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Hail-based toolkit for multi-omics variant annotation and analysis"
 authors = [
     { name = "Yasset Perez-Riverol", email = "ypriverol@gmail.com" },


### PR DESCRIPTION
Release `0.3.0` — 5 merged PRs since `0.2.0` (tagged `d117fb5`).

> Depends on #267 (version + CHANGELOG stamp, `d28ab8c`), #269 (seven reviewer findings, `729d331`) and #270 (the missed eighth, plus nitpicks). All target `dev` and are picked up automatically.

**Minor, not patch:** #261 adds a new user-facing flag, and #263 changes documented drift behaviour.

## HGC partitioning — closes #207 and #208

`--n-partitions` on `hvantk hgc vds2mt` and `hvantk hgc pipeline` now coalesces the dense MatrixTable before the write.

A VDS's on-disk layout is derived from its **reference-block** count, which is a property of the genome and saturates (~229 M on chr1 by N≈500) while the dense matrix keeps growing with N×M(N). Past that point the partition count stops tracking the data it partitions:

| N | partitions | dense MT | MiB/partition |
|---|---|---|---|
| 100 | 415 | 1.9 GB | 4.32 |
| 250 | 7,126 | 5.1 GB | **0.69** |

Measured on a 1,005-sample chr1 cohort: densify and QC plateau at **1.29×** and **1.64×** from 16 to 128 cores, while well-sized stages in the same jobs scale **7.8×**. Not core starvation — the plateauing stages have *more* tasks per core. It is work per task. Directly relevant to the HPC move, where those stages would otherwise waste most of a fat node.

#208 is the other half: `PipelineConfig.n_partitions` was accepted from the CLI, echoed back in the run plan, and read by **no stage** — an affirmative signal that a setting had taken effect when it had not, on the first knob a user reaches for after hitting #207.

**Implemented with `naive_coalesce`, not at the read.** `hl.vds.read_vds(n_partitions=…)` is the tidier-looking lever and does not work: it derives intervals from the reference data via `_calculate_new_partitions`, whose count saturates independently of the request. Measured on the 2,586-partition test VDS it returned **2 intervals for every request from 2 to 100**, and `to_dense_mt` then failed a Scala `require` for requests of 2, 4 and 16 — where coalescing returned exactly 2, 4 and 16. Recorded in code and CHANGELOG so it is not re-attempted.

**Not included:** auto-sizing the count from the dense matrix. That heuristic needs the 1,005-sample benchmark rig rather than a guess in the default path, so this ships the mechanism and leaves the policy to whoever runs it.

## Drift workflow — three defects, all long-standing

**cptac had never once probed successfully.** The workflow installed with a bare `pip install -e .`, but the cptac probe fingerprints the *installed* `cptac` version against PayneLab's latest release, and `cptac` lives in the `ptm` extra. Every run reported `The 'cptac' Python package is not installed`. Verified fixed by a `dry_run=true` dispatch: `2 probe_failed` → **0**, both datasets now `clean`.

**Nine PRs were force-pushed every morning** — ~63 notification events a week, none carrying new information. `--regenerate` rewrites `fetched_at` each run, and the emptiness check compared against the base branch, so for a still-drifted dataset it could never fire. The bot now skips when the branch already proposes a materially identical fingerprint *and* an open PR still exists.

**Three mutually-conflicting PRs per UCSC drift event.** `ucsc-cellbrowser`'s three datasets are real schema variants (obs cell-type column `celltype` / `Class` / `Type_v2`), but the probe is provider-scoped, so one upstream event was reported three times and merging any one made the others conflict. They share a `drift_fingerprint` — a declaration the manifest already carried and nothing read. Now grouped: probed once, one PR per signal.

Also: a shared retry helper for rate-limited probes (a GenCC 429 previously failed the whole run), which honours `Retry-After` but **clamps** it — `urllib3.util.Retry` sleeps the header's full value unbounded, so `Retry-After: 3600` would park CI for an hour.

## Review

**Reviewer findings on this PR: 8 actionable raised, 8 valid, no false positives.** Seven were fixed in #269; reconciling the round against the head afterwards showed I had miscounted, and the eighth — plus three nitpicks — are fixed in #270.

Two were worse than reported — the `git show` call carried the same `UnicodeDecodeError` exposure flagged one line above it, and the retry exponent raises `OverflowError: int too large to convert to float` rather than merely costing time. The most consequential: `group_by_drift_signal` keyed on the baseline alone while `run_drift_checks` keys on *(baseline, probe)*, so the bot would have re-merged what the runner deliberately kept apart — one PR whose regeneration covers only the first dataset, leaving the second's drift silently unaddressed.

The missed eighth was the mirror image, one layer up: `plugins validate` grouped the shared-baseline check on the declared string while the loader resolves it, so `tests/x.json` and `./tests/x.json` bypassed the conflicting-probe error entirely. #270 also closes a coverage gap worth naming — every `handle_drifted` test passed a fixture with neither `datasets` nor `fingerprint_path`, so the grouping wiring #263 added was never executed by any test.

Both fixes in #270 are mutation-verified: reverting the path normalization, or passing `[dataset]` where the grouped `covers` belongs, each fails a specific test that passed before.

Three adversarial rounds across #261/#262/#263 — **19, 4, then 4** surviving findings. Round 1 found two real production bugs in the drift bot fix, both introduced by that fix: a skipped dataset left its regenerated fingerprint staged, and `git checkout -B` does not clear the index, so it was committed onto the *next* dataset's PR; and the skip could suppress a dataset's drift forever when a branch outlived its PR.

Rounds 2 and 3 changed **test files only** — every finding was "your tests don't prove this," never "this code is wrong." All are now mutation-verified: reverting any individual fix fails a specific test.

## Verification

- Full default suite: **1480 passed, 11 skipped, 0 failed**, and **0 Spark banners** in the fast path (round 3 caught new tests booting a JVM inside the run `pytest.ini` configures to deselect `hail`).
- All five PRs merged with their real checks green; Codacy excluded by standing decision.
- Drift verified end-to-end by a dry-run dispatch: `9 drifted, 2 probe_failed, 7 clean` → `1 drifted, 0 probe_failed, 17 clean`.

## After merge

Tag `v0.3.0` on the merge commit and push branches plus tag to the cluster remote.
