### PR TITLE
fix(review): address all seven reviewer findings on #268

### DIFF
--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -159,17 +159,25 @@ def group_by_drift_signal(drifted: list[dict]) -> list[dict]:
 
     Order is preserved so branch names stay stable across runs.
     """
-    grouped: dict[str, dict] = {}
+    grouped: dict[tuple, dict] = {}
     out: list[dict] = []
     for entry in drifted:
         path = entry.get("fingerprint_path")
         if not path:
             out.append({**entry, "datasets": [entry.get("dataset_name")]})
             continue
-        existing = grouped.get(path)
+        # Key on (baseline, probe), exactly as `run_drift_checks` does. Grouping on the
+        # baseline alone would re-merge what the runner deliberately kept apart: two
+        # datasets sharing a baseline while declaring DIFFERENT probes is a manifest
+        # error, and merging them would open a single PR whose regeneration covers only
+        # `entry["dataset_name"]`, leaving the other dataset's drift silently
+        # unaddressed. A report without probe_ref (older shape) falls back to the path,
+        # which is the pre-existing behaviour rather than a new risk.
+        key = (path, entry.get("probe_ref"))
+        existing = grouped.get(key)
         if existing is None:
             merged = {**entry, "datasets": [entry.get("dataset_name")]}
-            grouped[path] = merged
+            grouped[key] = merged
             out.append(merged)
         else:
             existing["datasets"].append(entry.get("dataset_name"))
@@ -405,10 +413,19 @@ def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
         return True
 
     for path in paths:
-        current = (REPO_ROOT / path).read_text() if (REPO_ROOT / path).exists() else None
+        # `errors="replace"` rather than a bare read_text(): a staged file that is not
+        # valid UTF-8 raises UnicodeDecodeError, which is not a CalledProcessError, so
+        # `main` would not catch it and every remaining dataset would be skipped. And
+        # `paths` is every staged path, not only JSON under hvantk/skills, so that
+        # depends on runner state rather than on this script's own staging. A mangled
+        # decode can only make the comparison unequal, which pushes -- the safe answer.
+        target = REPO_ROOT / path
+        current = target.read_text(errors="replace") if target.exists() else None
+        # errors="replace" here too: text=True decodes strictly, so a blob that is not
+        # valid UTF-8 would raise UnicodeDecodeError out of subprocess itself.
         previous = subprocess.run(
             ["git", "show", f"FETCH_HEAD:{path}"],
-            check=False, text=True, capture_output=True,
+            check=False, text=True, errors="replace", capture_output=True,
         )
         if current is None or previous.returncode != 0:
             return True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 — 2026-08-05
 
 ### Added
 

--- a/hvantk/algorithms/hgc/pipeline.py
+++ b/hvantk/algorithms/hgc/pipeline.py
@@ -39,12 +39,19 @@ from hvantk.algorithms.hgc import (
 logger = logging.getLogger(__name__)
 
 
-def _shown_partitions(n: Optional[int]) -> str:
+def _shown_partitions(n: Optional[int], *, skipped: bool = False) -> str:
     """Render `n_partitions` for the run plan.
 
     Keyed on `is None`, not truthiness: 0 is a rejected value, and `or` would print it
     as "auto", telling the user a dry run's plan is fine for an invocation that aborts.
+
+    `skipped` covers --skip-vds-to-mt: that stage is the only consumer, so with it off
+    the existing MatrixTable keeps whatever layout it already has. Printing the
+    requested number there would repeat #208's mistake in a new place -- affirming a
+    setting that no stage will read.
     """
+    if skipped:
+        return "n/a (VDS -> MT stage skipped)"
     return "auto (VDS layout)" if n is None else str(n)
 
 
@@ -351,7 +358,8 @@ class PipelineRunner:
         # Reaches convert_vds_to_mt as of #208. Before that this line printed a setting
         # no stage read -- keep it truthful, and say which stage it governs.
         print(
-            f"  Partitions (MT):  {_shown_partitions(self.config.n_partitions)}"
+            f"  Partitions (MT):  "
+            f"{_shown_partitions(self.config.n_partitions, skipped=self.config.skip_vds_to_mt)}"
         )
         print(f"  Overwrite:        {self.config.overwrite}")
         print(

--- a/hvantk/core/plugin/drift_runner.py
+++ b/hvantk/core/plugin/drift_runner.py
@@ -27,10 +27,17 @@ class DriftResult:
     expected: dict[str, Any] | None = None
     diff: dict[str, Any] | None = None
     probe_error: BaseException | None = None
-    #: The committed baseline this result was diffed against. Datasets that share one
-    #: share a drift signal, which is what lets the CI bot collapse them into a single
-    #: PR instead of one per dataset. See `run_drift_checks`.
+    #: The committed baseline this result was diffed against. Datasets sharing a
+    #: baseline share a single drift signal, which is what lets the CI bot collapse them
+    #: into one PR instead of one per dataset. See `run_drift_checks`.
     fingerprint_path: str | None = None
+    #: ``module:function`` of the probe that produced this result. Pairs with
+    #: ``fingerprint_path`` to identify the SIGNAL: the runner refuses to group two
+    #: datasets that share a baseline but declare different probes (a manifest error),
+    #: and the bot must apply the same rule or it would re-merge what the runner
+    #: deliberately kept apart -- opening one PR whose regeneration covers only the first
+    #: dataset and silently leaving the second's drift unaddressed.
+    probe_ref: str | None = None
 
 
 def run_drift_check(dataset_name: str, *, timeout: int = 60) -> DriftResult:
@@ -67,18 +74,38 @@ def run_drift_checks(
     unchanged; members of a group share ``fingerprint_path``, which is what lets the CI
     bot open one PR per signal instead of one per dataset.
     """
-    cache: dict[tuple[str, int], DriftResult] = {}
+    # Values keep the probe object alive alongside its result. The key holds only
+    # id(probe), and CPython reuses addresses: `specs` is an Iterable, so a caller may
+    # pass a generator whose specs become unreachable as it advances, and a freshly
+    # allocated probe could land on a freed address. Two distinct probes would then
+    # collide on one key and a dataset would receive another dataset's drift result.
+    # Holding the reference makes the address un-reusable for the loop's lifetime.
+    cache: dict[tuple[str, int], tuple[object, DriftResult]] = {}
     results: list[DriftResult] = []
     for spec in specs:
-        key = (str(spec.test_paths.drift_fingerprint), id(spec.drift_probe))
-        cached = cache.get(key)
-        if cached is None:
+        probe = spec.drift_probe
+        key = (str(spec.test_paths.drift_fingerprint), id(probe))
+        entry = cache.get(key)
+        if entry is None:
             cached = _run_drift_check_with_spec(spec, timeout=timeout)
-            cache[key] = cached
+            cache[key] = (probe, cached)
+        else:
+            cached = entry[1]
         # `replace` rather than reuse: the shared result carries the FIRST member's
         # dataset_name, and every caller keys off that field.
         results.append(replace(cached, dataset_name=spec.name))
     return results
+
+
+def _probe_ref(spec: DatasetSpec) -> str:
+    """``module:qualname`` of a spec's probe -- a serialisable stand-in for the callable.
+
+    The runner can compare callables by identity; the JSON report the CI bot consumes
+    cannot, so the identity has to survive serialisation for the bot to apply the same
+    grouping rule.
+    """
+    fn = spec.drift_probe
+    return f"{getattr(fn, '__module__', '?')}:{getattr(fn, '__qualname__', repr(fn))}"
 
 
 def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
@@ -100,6 +127,7 @@ def _probe_failed(spec: DatasetSpec, exc: DriftProbeError) -> DriftResult:
         status="probe_failed",
         probe_error=exc,
         fingerprint_path=str(fp_path),
+        probe_ref=_probe_ref(spec),
     )
 
 
@@ -131,6 +159,7 @@ def _run_drift_check_with_spec(
             status="stub",
             observed=observed,
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
 
     try:
@@ -144,6 +173,7 @@ def _run_drift_check_with_spec(
                 f"missing expected fingerprint at {fp_path}"
             ),
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
 
     # A hand-seeded baseline cannot equal a live observation, so diffing it would
@@ -161,6 +191,7 @@ def _run_drift_check_with_spec(
                 f"probe ({seeded}); run `hvantk drift --regenerate {spec.name}`"
             ),
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
 
     diff = _compare_fingerprints(expected, observed)
@@ -171,6 +202,7 @@ def _run_drift_check_with_spec(
             observed=observed,
             expected=expected,
             fingerprint_path=str(fp_path),
+            probe_ref=_probe_ref(spec),
         )
     return DriftResult(
         dataset_name=spec.name,
@@ -179,6 +211,7 @@ def _run_drift_check_with_spec(
         expected=expected,
         diff=diff,
         fingerprint_path=str(fp_path),
+        probe_ref=_probe_ref(spec),
     )
 
 

--- a/hvantk/core/utils/http.py
+++ b/hvantk/core/utils/http.py
@@ -35,6 +35,9 @@ DEFAULT_ATTEMPTS = 4
 DEFAULT_BACKOFF_S = 2.0
 DEFAULT_MAX_SLEEP_S = 30.0
 
+# 2**32 s is ~136 years; any clamp is reached long before this.
+_MAX_EXP = 32
+
 
 def parse_retry_after(value: str | None) -> float | None:
     """``Retry-After`` as seconds, or ``None`` if absent/unparseable.
@@ -63,6 +66,18 @@ def parse_retry_after(value: str | None) -> float | None:
     return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
 
 
+def _backoff(backoff_s: float, attempt: int, max_sleep_s: float) -> float:
+    """Exponential backoff for `attempt`, clamped to `max_sleep_s`.
+
+    The exponent is capped before it is used. `backoff_s * 2 ** (attempt - 1)` looks
+    harmless because min() clamps the result, but the multiplication happens first: with
+    a large `attempts` it raises `OverflowError: int too large to convert to float`
+    rather than merely being slow. _MAX_EXP is far past any reachable max_sleep_s, so
+    capping it changes no real result.
+    """
+    return min(backoff_s * 2 ** min(attempt - 1, _MAX_EXP), max_sleep_s)
+
+
 def request_with_retry(
     method: str,
     url: str,
@@ -88,6 +103,13 @@ def request_with_retry(
     """
     if attempts < 1:
         raise ValueError(f"attempts must be >= 1, got {attempts}")
+    # Rejected here rather than at the sleep: a negative value only surfaces AFTER a
+    # transient failure, so the caller would see ValueError("sleep length must be
+    # non-negative") in place of the upstream error it was retrying.
+    if backoff_s < 0 or max_sleep_s < 0:
+        raise ValueError(
+            f"backoff_s and max_sleep_s must be >= 0, got {backoff_s} and {max_sleep_s}"
+        )
 
     retry_statuses = frozenset(retry_statuses)
     caller = session if session is not None else requests
@@ -99,7 +121,7 @@ def request_with_retry(
         except (requests.Timeout, requests.ConnectionError) as exc:
             if is_last:
                 raise
-            sleep_s = min(backoff_s * 2 ** (attempt - 1), max_sleep_s)
+            sleep_s = _backoff(backoff_s, attempt, max_sleep_s)
             logger.warning(
                 "%s %s failed (%s); retrying in %.1fs (attempt %d/%d)",
                 method.upper(), url, type(exc).__name__, sleep_s, attempt, attempts,
@@ -115,8 +137,8 @@ def request_with_retry(
         # attempts open would leak one connection per retry.
         retry_after = parse_retry_after(response.headers.get("Retry-After"))
         response.close()
-        backoff = backoff_s * 2 ** (attempt - 1)
-        sleep_s = min(retry_after if retry_after is not None else backoff, max_sleep_s)
+        backoff = _backoff(backoff_s, attempt, max_sleep_s)
+        sleep_s = min(retry_after, max_sleep_s) if retry_after is not None else backoff
         logger.warning(
             "%s %s returned %d; retrying in %.1fs (attempt %d/%d)",
             method.upper(), url, response.status_code, sleep_s, attempt, attempts,

--- a/hvantk/skills/_conventions/SKILL.md
+++ b/hvantk/skills/_conventions/SKILL.md
@@ -205,7 +205,7 @@ Two datasets may **not** share a baseline while declaring *different* probes: ea
 
 A scheduled GitHub Actions workflow (`.github/workflows/drift.yml`) runs `hvantk drift --all --json` daily at 06:00 UTC. For each plugin reporting `status: drifted`, the workflow:
 
-1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`) — or `drift/<provider>` when several of that provider's datasets share one drift signal, so the group gets a single PR.
+1. Branches `drift/<provider>-<dataset>` from the base branch (`env.BASE_BRANCH`, defaulting to `dev`). When several of that provider's datasets share one drift signal the group gets a single branch instead: `drift/<provider>`, or `drift/<provider>-<suffix>` when the shared baseline's filename carries one (`drift_fingerprint_samples.json` → `drift/<provider>-samples`). The suffix is what keeps two independent signals from the same provider on separate branches, so a multi-dataset provider does not have its second signal overwrite its first.
 2. Regenerates `drift_fingerprint.json` via `hvantk drift --regenerate <provider:dataset>`.
 3. Opens (or updates) a draft PR via `gh pr create` / `gh pr edit`, with the structured diff embedded in the body and the regenerated fingerprint already committed. If the plugin's `plugin.yaml` declares `maintainers:` whose entries look like GitHub handles, those handles are `cc`'d in the PR body.
 

--- a/hvantk/tests/hgc/test_pipeline_partitioning.py
+++ b/hvantk/tests/hgc/test_pipeline_partitioning.py
@@ -218,3 +218,25 @@ def test_run_plan_call_site_shows_zero_rather_than_auto(tmp_path, monkeypatch):
     # test would have broken it for reasons having nothing to do with the code.
     line = next(ln for ln in buf.getvalue().splitlines() if "Partitions (MT):" in ln)
     assert line.split(":", 1)[1].strip() == "0", line
+
+
+def test_run_plan_does_not_advertise_partitions_when_the_stage_is_skipped(
+    tmp_path, monkeypatch
+):
+    """--skip-vds-to-mt means convert_vds_to_mt never runs, so the existing MatrixTable
+    keeps its layout. Printing the requested number there would repeat #208's mistake in
+    a new place: affirming a setting no stage will read."""
+    import contextlib
+    import io
+
+    from hvantk.algorithms.hgc import pipeline as pipeline_mod
+
+    cfg = _cfg(tmp_path, n_partitions=64, skip_vds_to_mt=True, mt_path=str(tmp_path))
+    runner = _runner_without_hail(pipeline_mod, monkeypatch, cfg)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        runner.show_plan()
+
+    line = next(ln for ln in buf.getvalue().splitlines() if "Partitions (MT):" in ln)
+    assert "64" not in line, line
+    assert "skipped" in line.lower(), line

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -478,3 +478,44 @@ def test_nothing_staged_path_also_discards(drift_to_pr, monkeypatch, tmp_path):
     assert cleanups == [{"dry_run": False}], (
         "the 'nothing to commit' return must discard too, and for real"
     )
+
+
+def test_same_baseline_different_probes_are_not_grouped(drift_to_pr):
+    """The bot must apply the runner's rule, not a weaker one.
+
+    `run_drift_checks` keys on (baseline, probe callable) so that two datasets sharing a
+    baseline while declaring DIFFERENT probes -- a manifest error -- are never merged.
+    Grouping on the baseline alone here would re-merge them, opening one PR whose
+    regeneration covers only the first dataset and leaving the second's drift silently
+    unaddressed.
+    """
+    groups = drift_to_pr.group_by_drift_signal([
+        {**_drifted("p:one", UCSC_FP), "probe_ref": "mod:probe_a"},
+        {**_drifted("p:two", UCSC_FP), "probe_ref": "mod:probe_b"},
+    ])
+    assert len(groups) == 2, "different probes must not share a PR"
+
+
+def test_same_baseline_same_probe_still_groups(drift_to_pr):
+    """The complement: the ucsc case must keep collapsing."""
+    groups = drift_to_pr.group_by_drift_signal([
+        {**_drifted("u:a", UCSC_FP), "probe_ref": "mod:fetch_fingerprint"},
+        {**_drifted("u:b", UCSC_FP), "probe_ref": "mod:fetch_fingerprint"},
+    ])
+    assert len(groups) == 1
+    assert groups[0]["datasets"] == ["u:a", "u:b"]
+
+
+def test_an_undecodable_staged_file_does_not_abort_the_run(
+    repo_with_drift_branch, drift_to_pr
+):
+    """`read_text()` raises UnicodeDecodeError on non-UTF-8, which is not a
+    CalledProcessError, so `main` would not catch it and every remaining dataset would be
+    skipped. `paths` is every staged path, not only JSON this script wrote."""
+    repo, fp = repo_with_drift_branch
+    fp.write_bytes(b'\xff\xfe{"source_version": "v1"}')
+    _git(repo, "add", "hvantk/skills")
+
+    # Must return a verdict rather than raising. Undecodable content cannot match, so
+    # the safe answer is "push".
+    assert drift_to_pr.branch_needs_update("drift/p-d", dry_run=False) is True

--- a/hvantk/tests/test_http_retry.py
+++ b/hvantk/tests/test_http_retry.py
@@ -101,3 +101,35 @@ def test_connection_errors_are_retried_but_other_request_errors_are_not(
 )
 def test_parse_retry_after(header, expected):
     assert http_util.parse_retry_after(header) == expected
+
+
+# --- review findings on #268 ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"backoff_s": -1.0},
+    {"max_sleep_s": -5.0},
+])
+def test_negative_timings_are_rejected_before_the_first_request(kwargs):
+    """A negative value would otherwise surface only AFTER a transient failure, replacing
+    the upstream error the caller was retrying with ValueError('sleep length must be
+    non-negative')."""
+    with pytest.raises(ValueError, match="must be >= 0"):
+        http_util.request_with_retry("GET", URL, **kwargs)
+
+
+def test_backoff_is_capped_at_max_sleep_for_any_attempt():
+    """`backoff_s * 2 ** (attempt - 1)` is evaluated BEFORE min() clamps it, so a high
+    attempt NUMBER raises `OverflowError: int too large to convert to float` -- not
+    merely a slow computation, an outright crash.
+
+    Asserted on the helper rather than by driving 1,200 real failures through the retry
+    loop: the `slept` fixture patches `time.sleep` globally, so under a full-suite run
+    that version captured sleeps from unrelated code (625,818 of them) and failed for a
+    reason having nothing to do with backoff. This form is deterministic and still fails
+    if the exponent cap is removed.
+    """
+    assert http_util._backoff(2.0, 1, 30.0) == 2.0
+    assert http_util._backoff(2.0, 4, 30.0) == 16.0
+    assert http_util._backoff(2.0, 99, 30.0) == 30.0
+    assert http_util._backoff(2.0, 10**6, 30.0) == 30.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # [tool.poetry] -- they have no PEP 621 equivalent and are not deprecated.
 [project]
 name = "hvantk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Hail-based toolkit for multi-omics variant annotation and analysis"
 authors = [
     { name = "Yasset Perez-Riverol", email = "ypriverol@gmail.com" },


### PR DESCRIPTION
Copilot and CodeRabbit each reviewed the `0.3.0` release PR (#268). **All seven findings were valid** — no false positives. Two turned out worse than reported.

Targets `dev`, so #268 picks it up automatically.

## Both reviewers, independently: the bot and the runner disagreed on what a signal is

`run_drift_checks` keys on **(baseline, probe callable)** so that two datasets sharing a baseline while declaring *different* probes — a manifest error — are never merged. `group_by_drift_signal` keyed on the **baseline alone**, re-merging exactly what the runner kept apart: one PR whose regeneration covers only `entry["dataset_name"]`, leaving the other dataset's drift silently unaddressed.

I wrote both halves, and wrote the comment explaining why the runner is conservative, then applied a weaker rule one file over. `DriftResult` now carries `probe_ref` (`module:qualname`) so the identity survives serialisation into the JSON report.

## Worse than reported (2)

**An undecodable staged file aborted the whole run.** `read_text()` raises `UnicodeDecodeError` on non-UTF-8; that is not a `CalledProcessError`, so `main` would not catch it and every remaining dataset is skipped. CodeRabbit flagged that call — the adjacent `git show` had the **identical exposure** via `text=True`, which nobody flagged. Confirmed by feeding a non-UTF-8 blob through it:

```
strict decode: UnicodeDecodeError (confirms the exposure)
with errors=replace: OK
```

Both now decode with `errors="replace"`. A mangled decode can only make the comparison unequal, which pushes — the safe answer.

**Overflow, not slowness.** CodeRabbit said a large `attempts` "evaluates `2 ** (attempt - 1)` before the cap applies." It does not merely cost time:

```
min(2.0 * 2**9999, 30.0)  →  OverflowError: int too large to convert to float
```

Exponent capped before use; negative `backoff_s`/`max_sleep_s` now rejected up front rather than surfacing as `ValueError("sleep length must be non-negative")` *in place of* the upstream error being retried.

## The rest (4)

- **Run plan advertised a skipped stage.** With `--skip-vds-to-mt`, `convert_vds_to_mt` never runs and the existing MatrixTable keeps its layout, but the plan still printed the requested count — #208's mistake in a new place. Now `n/a (VDS -> MT stage skipped)`.
- **`id()` key could be reused.** `specs` is an `Iterable`, so a generator's specs can become unreachable mid-loop and CPython can reallocate a probe at a freed address, colliding two probes on one cache key. The cache now holds the probe object alongside its result. Latent today (the CLI passes a list), cheap to close.
- A grammatical slip in my own `DriftResult` comment.
- The conventions doc omitted the `drift/<provider>-<suffix>` branch form, which is what keeps two signals from one provider apart.

## A test of mine that was wrong twice

Worth recording. My overflow test passed in isolation both times and was wrong both times: first it asserted a clamp on **attempt 1**, where `2.0` is the correct backoff; then it became scale-dependent while the `slept` fixture patches `time.sleep` **globally** — under the full suite it collected **625,818** sleeps from unrelated code and failed for reasons having nothing to do with backoff.

Replaced with a deterministic `_backoff` assertion that cannot be perturbed by the rest of the session and still reproduces the `OverflowError` under mutation. The docstring records why, so it is not re-added.

## Verification

- Full default suite: **1480 passed, 11 skipped, 0 failed**.
- All seven fixes mutation-verified — reverting any one fails a specific test.
- flake8 error-pass clean.