### PR TITLE
fix(review): normalize fingerprint paths and cover grouped entries

### DIFF
--- a/.github/scripts/drift_to_pr.py
+++ b/.github/scripts/drift_to_pr.py
@@ -373,10 +373,20 @@ def _discard_staged_fingerprints(*, dry_run: bool) -> None:
     if dry_run:
         print("[dry-run] (would discard staged fingerprint changes)")
         return
-    subprocess.run(
+    result = subprocess.run(
         ["git", "checkout", "HEAD", "--", "hvantk/skills"],
         check=False, text=True, capture_output=True,
     )
+    if result.returncode != 0:
+        # `check=False` keeps one failed cleanup from aborting the whole run, but
+        # swallowing the output would hide the exact state this function exists to
+        # prevent: the fingerprint stays staged and the next dataset commits it onto
+        # ITS branch. Surface it so the job log names the contaminating run.
+        print(
+            "  WARNING: could not discard staged fingerprints; the next dataset may "
+            f"commit them onto its branch: {(result.stderr or '').strip()}",
+            file=sys.stderr,
+        )
 
 
 def branch_needs_update(branch: str, *, dry_run: bool) -> bool:
@@ -730,17 +740,23 @@ def main(argv: list[str] | None = None) -> int:
             # One drifted dataset failing to PR shouldn't stop the others, but it
             # must not vanish either: collected here and re-raised as a nonzero
             # exit once every dataset has had its turn.
-            failed.append(str(entry.get("dataset_name")))
+            #
+            # Name every dataset the signal covers, not just the anchor. A grouped
+            # entry regenerates one baseline on behalf of several datasets, so
+            # reporting `dataset_name` alone would show the operator one dataset when
+            # several are left unaddressed.
+            covered = [str(d) for d in (entry.get("datasets") or [entry.get("dataset_name")])]
+            failed.extend(covered)
+            label = ", ".join(covered)
             print(
-                f"error handling {entry.get('dataset_name')}: "
+                f"error handling {label}: "
                 f"{exc.cmd} exited {exc.returncode}\n"
                 f"stdout: {exc.stdout}\nstderr: {exc.stderr}",
                 file=sys.stderr,
             )
             _summary_line(
                 step_summary,
-                f"- ERROR: `{entry.get('dataset_name')}` -- "
-                f"{exc.cmd[0]} exited {exc.returncode}",
+                f"- ERROR: `{label}` -- {exc.cmd[0]} exited {exc.returncode}",
             )
 
     for entry in probe_failed:

--- a/hvantk/tests/test_drift_to_pr_script.py
+++ b/hvantk/tests/test_drift_to_pr_script.py
@@ -52,6 +52,16 @@ DRIFTED = {
     "probe_error": None,
 }
 
+#: A grouped entry, as `group_by_drift_signal` emits it: several datasets sharing one
+#: baseline, with the first as the anchor. `DRIFTED` carries neither `datasets` nor
+#: `fingerprint_path`, so it only ever exercises the single-dataset path.
+GROUPED = {
+    **DRIFTED,
+    "dataset_name": "ucsc-cellbrowser:default",
+    "datasets": ["ucsc-cellbrowser:default", "ucsc-cellbrowser:adult-ctx"],
+    "fingerprint_path": "hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json",
+}
+
 
 def test_exits_nonzero_when_a_pr_cannot_be_opened(drift_to_pr, tmp_path, monkeypatch):
     """The regression: drift detected, branch pushed, `gh pr create` refused, exit 0.
@@ -281,7 +291,7 @@ def test_grouped_pr_names_every_dataset_it_covers(drift_to_pr):
 
 
 def _capture_handle_drifted(
-    drift_to_pr, monkeypatch, tmp_path, *, needs_update, pr_exists, staged=True
+    drift_to_pr, monkeypatch, tmp_path, *, needs_update, pr_exists, staged=True, entry=None
 ):
     """Run handle_drifted with git/gh stubbed.
 
@@ -321,7 +331,7 @@ def _capture_handle_drifted(
 
     summary = tmp_path / "summary.md"
     drift_to_pr.handle_drifted(
-        dict(DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
+        dict(entry or DRIFTED), base_branch="dev", dry_run=False, step_summary=summary
     )
     return cmds, cleanups, (summary.read_text() if summary.exists() else "")
 
@@ -355,6 +365,32 @@ def test_update_still_commits_pushes_and_edits(drift_to_pr, monkeypatch, tmp_pat
     assert any(c.startswith("git commit") for c in joined), joined
     assert any(c.startswith("git push") for c in joined), joined
     assert any(c.startswith("gh pr edit") for c in joined), joined
+
+
+def test_grouped_entry_checks_out_the_signal_branch_and_titles_the_group(
+    drift_to_pr, monkeypatch, tmp_path
+):
+    """`handle_drifted`'s grouping wiring, not just the helpers it calls.
+
+    `branch_name_for_signal` and `pr_title_for` are unit-tested on their own, but every
+    other test here passes `DRIFTED`, which has no `datasets` and no `fingerprint_path`
+    -- so the single-dataset path is the only one they run. Passing `[dataset]` instead
+    of `covers`, or dropping `fingerprint_path`, would leave those unit tests green
+    while the bot silently opened a per-dataset PR for a grouped signal: the exact
+    regression #263 exists to prevent.
+    """
+    cmds, _, _ = _capture_handle_drifted(
+        drift_to_pr, monkeypatch, tmp_path, needs_update=True, pr_exists=False, entry=GROUPED
+    )
+    joined = [" ".join(c) for c in cmds]
+
+    checkout = next(c for c in joined if c.startswith("git checkout -B"))
+    assert "drift/ucsc-cellbrowser" in checkout, checkout
+    # The anchor's per-dataset name is what a dropped `covers` would produce.
+    assert "drift/ucsc-cellbrowser-default" not in checkout, checkout
+
+    create = next(c for c in joined if c.startswith("gh pr create"))
+    assert "(2 datasets)" in create, create
 
 
 def test_matching_branch_with_no_open_pr_is_never_skipped(drift_to_pr, monkeypatch, tmp_path):

--- a/hvantk/tests/test_plugins_cli.py
+++ b/hvantk/tests/test_plugins_cli.py
@@ -107,6 +107,46 @@ def test_validate_rejects_catalog_entry_missing_required_field(tmp_path):
     assert "accession" in res.output
 
 
+def test_validate_normalizes_fingerprint_paths_before_grouping(tmp_path):
+    """`tests/x.json` and `./tests/x.json` name ONE baseline, as the loader resolves them.
+
+    Grouping on the declared string files them in separate buckets, so the
+    conflicting-probe check never fires and the baseline overwrite this validation
+    exists to name ships silently.
+    """
+    from click.testing import CliRunner
+    from hvantk.tools.plugins.plugins_cli import plugins_group
+
+    def _dataset(name: str, spelling: str, function: str) -> str:
+        return (
+            f"  - name: {name}\n"
+            "    domain: genomics\n"
+            "    backend: hail\n"
+            "    builder:\n"
+            "      module: hvantk.tests.testdata.raw.plugins.fake_plugin.builder\n"
+            "      function: build\n"
+            "    drift_probe:\n"
+            "      module: hvantk.tests.testdata.raw.plugins.fake_plugin.drift_probe\n"
+            f"      function: {function}\n"
+            "    skill: SKILL.md\n"
+            "    tests:\n"
+            "      command: pytest -q\n"
+            "      fixture: tests/testdata/raw/fake\n"
+            "      schema_snapshot: tests/snapshots/schema.json\n"
+            "      row_snapshot: tests/snapshots/sample_rows.json\n"
+            f"      drift_fingerprint: {spelling}\n"
+        )
+
+    (tmp_path / "plugin.yaml").write_text(
+        "api_version: 2\nname: tmp-plug\nversion: 0.1.0\ndatasets:\n"
+        + _dataset("a", "tests/drift_fingerprint.json", "fetch_fingerprint")
+        + _dataset("b", "./tests/drift_fingerprint.json", "a_different_probe")
+    )
+    res = CliRunner().invoke(plugins_group, ["validate", str(tmp_path / "plugin.yaml")])
+    assert res.exit_code != 0, res.output
+    assert "different drift probes" in res.output, res.output
+
+
 def test_validate_rejects_duplicate_accession_within_catalog(tmp_path):
     from click.testing import CliRunner
     from hvantk.tools.plugins.plugins_cli import plugins_group

--- a/hvantk/tools/plugins/plugins_cli.py
+++ b/hvantk/tools/plugins/plugins_cli.py
@@ -152,19 +152,28 @@ def validate_cmd(manifest_path: str, strict_artifacts: bool):
     # when the probe is also shared: two datasets pointing different probes at one
     # baseline would each overwrite the other's, and whichever regenerated last would
     # define "clean" for both. That is a manifest error, so name it.
+    # Key on the RESOLVED path rather than the declared string. The loader resolves
+    # these against the plugin directory before anything at runtime sees them (see
+    # `loader.py`), so `tests/x.json` and `./tests/x.json` are one baseline there.
+    # Grouping on the raw spelling would file them in separate buckets, the
+    # single-probe check would not fire, and the overwrite this validation exists to
+    # name would escape. The declared spelling is kept only for the message.
     by_fingerprint: dict[str, list[tuple[str, tuple[str, str]]]] = {}
+    declared: dict[str, str] = {}
     for dataset in content.get("datasets", []):
         rel = (dataset.get("tests") or {}).get("drift_fingerprint")
         probe = dataset.get("drift_probe") or {}
         if not rel:
             continue
-        by_fingerprint.setdefault(rel, []).append(
+        key = (plugin_dir / rel).resolve().as_posix()
+        declared.setdefault(key, rel)
+        by_fingerprint.setdefault(key, []).append(
             (dataset.get("name", "?"), (probe.get("module", ""), probe.get("function", "")))
         )
     conflicts = [
-        f"{rel} is shared by "
+        f"{declared[key]} is shared by "
         + ", ".join(f"{name} -> {mod}:{fn}" for name, (mod, fn) in members)
-        for rel, members in sorted(by_fingerprint.items())
+        for key, members in sorted(by_fingerprint.items())
         if len({probe for _, probe in members}) > 1
     ]
     if conflicts:


### PR DESCRIPTION
Follow-up to #269. Reconciling the review round on #268 against the head turned up a
miscount: CodeRabbit posted **8** actionable inline comments, #269 addressed seven. The
eighth was never triaged, and three nitpicks were left open. All four are in code #268
itself introduces, so they are fixed here rather than after the release.

No version bump — this stays `0.3.0`.

## The missed finding

`hvantk plugins validate` rejects datasets that share a `drift_fingerprint` but declare
different probes: they would each overwrite the other's baseline, and whichever
regenerated last would define "clean" for both. The check grouped on the **declared
string**, while [`loader.py:261`](../blob/dev/hvantk/core/plugin/loader.py#L261) resolves
the path (`(plugin_dir / …).resolve()`) before anything at runtime sees it.

So `tests/x.json` and `./tests/x.json` are one baseline to the loader and two to the
validator. They land in separate buckets, the single-probe check never fires, and the
overwrite this validation exists to name ships silently. Now keyed on the resolved path;
the declared spelling is kept for the error message.

No shipped manifest uses a non-canonical spelling today — all 26 declarations are already
canonical — so nothing was broken in practice. It is a gap in the one check standing
between a manifest typo and a baseline that quietly redefines "clean".

## Nitpicks

**A grouped failure named only the anchor.** When `handle_drifted` raises, `failed`
recorded `entry["dataset_name"]`. A grouped entry regenerates one baseline on behalf of
several datasets, so the error and the step summary showed the operator one dataset when
several were unaddressed. Now names every dataset the signal covers.

**A failed cleanup was silent.** `_discard_staged_fingerprints` runs `git checkout HEAD --
hvantk/skills` with `check=False` and captured-but-unused output. `check=False` is right —
one failed cleanup should not abort the run — but the silence hid the exact state the
function exists to prevent: the fingerprint survives into the next dataset's `git add` and
is committed onto ITS branch. That contamination was a real bug fixed in #262; its guard
failing should not be invisible. Now warns to stderr.

**Not applicable:** the fourth nitpick warned that grouping orphans the previously opened
per-dataset PRs. `branch_name_for_signal` returns the historical name unchanged for a
single-dataset signal, and the only open drift PRs (#264 clingen, #265 clinvar, #266 hgnc)
are single-dataset. No `drift/ucsc*` branch exists to orphan.

## The coverage gap

The most consequential of the four. `_capture_handle_drifted` always passed a fixture with
neither `datasets` nor `fingerprint_path`, so **every** existing test ran the
single-dataset path and the grouping wiring #263 added was never executed. Its helpers
(`branch_name_for_signal`, `pr_title_for`) are unit-tested in isolation, so passing
`[dataset]` instead of `covers` would have left the whole suite green while the bot opened
a per-dataset PR for a grouped signal — the regression #263 exists to prevent.

This is the #208 failure mode again: wired, echoed back, read by nothing.

## Verification

Both guards are mutation-verified — reverting either fails a specific test, and neither
failed before:

| mutation | result |
|---|---|
| `key = (plugin_dir / rel).resolve()...` → `key = rel` | `test_validate_normalizes_fingerprint_paths_before_grouping` fails |
| `branch_name_for_signal(covers, …)` → `(…[dataset], …)` | `test_grouped_entry_checks_out_the_signal_branch_and_titles_the_group` fails, on `drift/ucsc-cellbrowser-default` |

Full default suite green.
