### PR TITLE
Regenerate snapshots for clingen, clinvar, hgnc, and ucsc datasets

### DIFF
--- a/hvantk/skills/clingen/tests/drift_fingerprint.json
+++ b/hvantk/skills/clingen/tests/drift_fingerprint.json
@@ -19,7 +19,7 @@
     "Clingen-Gene-Disease-Summary.csv": "1bf26b3670c0d7ff2700df59ee07d1aff8a70bc2c63a7ffc062377312cccf440"
   },
   "extras": {
-    "content_length": "1114672"
+    "content_length": "1114960"
   },
-  "fetched_at": "2026-08-04T08:36:42.849280+00:00"
+  "fetched_at": "2026-08-05T08:36:12.003194+00:00"
 }

--- a/hvantk/skills/clingen/tests/drift_fingerprint.json
+++ b/hvantk/skills/clingen/tests/drift_fingerprint.json
@@ -19,7 +19,7 @@
     "Clingen-Gene-Disease-Summary.csv": "1bf26b3670c0d7ff2700df59ee07d1aff8a70bc2c63a7ffc062377312cccf440"
   },
   "extras": {
-    "content_length": "1116330"
+    "content_length": "1118136"
   },
-  "fetched_at": "2026-08-13T07:27:39.592691+00:00"
+  "fetched_at": "2026-08-21T06:46:28.535144+00:00"
 }

--- a/hvantk/skills/clingen/tests/drift_fingerprint.json
+++ b/hvantk/skills/clingen/tests/drift_fingerprint.json
@@ -19,7 +19,7 @@
     "Clingen-Gene-Disease-Summary.csv": "1bf26b3670c0d7ff2700df59ee07d1aff8a70bc2c63a7ffc062377312cccf440"
   },
   "extras": {
-    "content_length": "1116327"
+    "content_length": "1116330"
   },
-  "fetched_at": "2026-08-11T07:07:53.483494+00:00"
+  "fetched_at": "2026-08-13T07:27:39.592691+00:00"
 }

--- a/hvantk/skills/clingen/tests/drift_fingerprint.json
+++ b/hvantk/skills/clingen/tests/drift_fingerprint.json
@@ -19,7 +19,7 @@
     "Clingen-Gene-Disease-Summary.csv": "1bf26b3670c0d7ff2700df59ee07d1aff8a70bc2c63a7ffc062377312cccf440"
   },
   "extras": {
-    "content_length": "1114960"
+    "content_length": "1116327"
   },
-  "fetched_at": "2026-08-05T08:36:12.003194+00:00"
+  "fetched_at": "2026-08-11T07:07:53.483494+00:00"
 }

--- a/hvantk/skills/clinvar/tests/drift_fingerprint.json
+++ b/hvantk/skills/clinvar/tests/drift_fingerprint.json
@@ -1,11 +1,11 @@
 {
   "probe_version": 1,
-  "source_version": "Tue, 28 Jul 2026 22:07:55 GMT",
+  "source_version": "Wed, 05 Aug 2026 05:17:03 GMT",
   "headers": {
     "clinvar.vcf.gz": {
-      "content_length": "193012905"
+      "content_length": "193094343"
     }
   },
   "checksums": {},
-  "fetched_at": "2026-08-04T08:36:51.182152+00:00"
+  "fetched_at": "2026-08-05T08:36:20.969698+00:00"
 }

--- a/hvantk/skills/clinvar/tests/drift_fingerprint.json
+++ b/hvantk/skills/clinvar/tests/drift_fingerprint.json
@@ -1,11 +1,11 @@
 {
   "probe_version": 1,
-  "source_version": "Mon, 10 Aug 2026 13:00:35 GMT",
+  "source_version": "Tue, 18 Aug 2026 07:43:28 GMT",
   "headers": {
     "clinvar.vcf.gz": {
-      "content_length": "193118277"
+      "content_length": "193311199"
     }
   },
   "checksums": {},
-  "fetched_at": "2026-08-11T07:08:03.354332+00:00"
+  "fetched_at": "2026-08-20T06:45:49.757563+00:00"
 }

--- a/hvantk/skills/clinvar/tests/drift_fingerprint.json
+++ b/hvantk/skills/clinvar/tests/drift_fingerprint.json
@@ -1,11 +1,11 @@
 {
   "probe_version": 1,
-  "source_version": "Wed, 05 Aug 2026 05:17:03 GMT",
+  "source_version": "Mon, 10 Aug 2026 13:00:35 GMT",
   "headers": {
     "clinvar.vcf.gz": {
-      "content_length": "193094343"
+      "content_length": "193118277"
     }
   },
   "checksums": {},
-  "fetched_at": "2026-08-05T08:36:20.969698+00:00"
+  "fetched_at": "2026-08-11T07:08:03.354332+00:00"
 }

--- a/hvantk/skills/gencc/tests/drift_fingerprint.json
+++ b/hvantk/skills/gencc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Sun, 02 Aug 2026 06:02:19 GMT",
+  "source_version": "Sun, 16 Aug 2026 06:01:44 GMT",
   "headers": {
     "gencc-submissions.tsv": [
       "sgc_id",
@@ -39,5 +39,5 @@
   "checksums": {
     "gencc-submissions.tsv": "6f07ac79f908bca4cfb99874e13d7d1ae5a9c839112baba0243b45fbc018f308"
   },
-  "fetched_at": "2026-08-03T09:43:52.920327+00:00"
+  "fetched_at": "2026-08-16T06:40:12.263765+00:00"
 }

--- a/hvantk/skills/hgnc/tests/drift_fingerprint.json
+++ b/hvantk/skills/hgnc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Tue, 04 Aug 2026 13:01:56 GMT",
+  "source_version": "Fri, 07 Aug 2026 12:37:25 GMT",
   "headers": {
     "hgnc_complete_set.txt": [
       "hgnc_id",
@@ -62,5 +62,5 @@
   "checksums": {
     "hgnc_complete_set.txt": "b8cfde58b7ea456e6f05482a4cf663fe329a6508a00809713167cc827200790c"
   },
-  "fetched_at": "2026-08-05T08:36:30.827355+00:00"
+  "fetched_at": "2026-08-08T06:53:41.473348+00:00"
 }

--- a/hvantk/skills/hgnc/tests/drift_fingerprint.json
+++ b/hvantk/skills/hgnc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Fri, 07 Aug 2026 12:37:25 GMT",
+  "source_version": "Tue, 11 Aug 2026 12:47:22 GMT",
   "headers": {
     "hgnc_complete_set.txt": [
       "hgnc_id",
@@ -62,5 +62,5 @@
   "checksums": {
     "hgnc_complete_set.txt": "b8cfde58b7ea456e6f05482a4cf663fe329a6508a00809713167cc827200790c"
   },
-  "fetched_at": "2026-08-08T06:53:41.473348+00:00"
+  "fetched_at": "2026-08-12T07:25:32.510588+00:00"
 }

--- a/hvantk/skills/hgnc/tests/drift_fingerprint.json
+++ b/hvantk/skills/hgnc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Fri, 31 Jul 2026 12:53:50 GMT",
+  "source_version": "Tue, 04 Aug 2026 13:01:56 GMT",
   "headers": {
     "hgnc_complete_set.txt": [
       "hgnc_id",
@@ -62,5 +62,5 @@
   "checksums": {
     "hgnc_complete_set.txt": "b8cfde58b7ea456e6f05482a4cf663fe329a6508a00809713167cc827200790c"
   },
-  "fetched_at": "2026-08-04T08:37:16.272927+00:00"
+  "fetched_at": "2026-08-05T08:36:30.827355+00:00"
 }

--- a/hvantk/skills/hgnc/tests/drift_fingerprint.json
+++ b/hvantk/skills/hgnc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Tue, 11 Aug 2026 12:47:22 GMT",
+  "source_version": "Tue, 18 Aug 2026 12:31:23 GMT",
   "headers": {
     "hgnc_complete_set.txt": [
       "hgnc_id",
@@ -62,5 +62,5 @@
   "checksums": {
     "hgnc_complete_set.txt": "b8cfde58b7ea456e6f05482a4cf663fe329a6508a00809713167cc827200790c"
   },
-  "fetched_at": "2026-08-12T07:25:32.510588+00:00"
+  "fetched_at": "2026-08-20T06:46:03.644457+00:00"
 }

--- a/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
+++ b/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Sat, 01 Aug 2026 00:28:36 GMT",
+  "source_version": "Fri, 07 Aug 2026 20:10:53 GMT",
   "headers": {
     "cells_ucsc_datasets.json": [
       "local-catalog-hash"
@@ -13,7 +13,7 @@
   },
   "checksums": {
     "cells_ucsc_datasets.json": "f448a4b146a7137d21a7c376db4734f39cb56623de362c96da8f05e7e5e380be",
-    "dataset.json": "91aceacd2ac9432bf83c4fc997e2d5aae0237bc171f3aad4a75ea3d1973b2bb1"
+    "dataset.json": "af70766681a7a47b26c77b6a29ef96b16623f9fcf670dd5eef2ebc8ccbd3b8fe"
   },
-  "fetched_at": "2026-08-04T08:37:23.836275+00:00"
+  "fetched_at": "2026-08-08T06:53:49.257974+00:00"
 }

--- a/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
+++ b/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Fri, 07 Aug 2026 20:10:53 GMT",
+  "source_version": "Wed, 12 Aug 2026 23:07:08 GMT",
   "headers": {
     "cells_ucsc_datasets.json": [
       "local-catalog-hash"
@@ -13,7 +13,7 @@
   },
   "checksums": {
     "cells_ucsc_datasets.json": "f448a4b146a7137d21a7c376db4734f39cb56623de362c96da8f05e7e5e380be",
-    "dataset.json": "af70766681a7a47b26c77b6a29ef96b16623f9fcf670dd5eef2ebc8ccbd3b8fe"
+    "dataset.json": "42d93932620efe59cef61054b87abac3d7774aa1f976c6fca7c27eea292bdbf0"
   },
-  "fetched_at": "2026-08-08T06:53:49.257974+00:00"
+  "fetched_at": "2026-08-13T07:27:54.197786+00:00"
 }

--- a/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
+++ b/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Wed, 12 Aug 2026 23:07:08 GMT",
+  "source_version": "Thu, 20 Aug 2026 05:37:04 GMT",
   "headers": {
     "cells_ucsc_datasets.json": [
       "local-catalog-hash"
@@ -13,7 +13,7 @@
   },
   "checksums": {
     "cells_ucsc_datasets.json": "f448a4b146a7137d21a7c376db4734f39cb56623de362c96da8f05e7e5e380be",
-    "dataset.json": "42d93932620efe59cef61054b87abac3d7774aa1f976c6fca7c27eea292bdbf0"
+    "dataset.json": "a88266bb18fc2126826c8b0cbe7a505c8bcfbc1d4dace67cacf267b52b3e680b"
   },
-  "fetched_at": "2026-08-13T07:27:54.197786+00:00"
+  "fetched_at": "2026-08-20T06:46:11.474510+00:00"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated source metadata and fetch timestamps for ClinGen, ClinVar, GenCC, HGNC, and UCSC Cell Browser datasets.
  * Refreshed ClinVar content metadata and the UCSC Cell Browser dataset checksum.
  * Preserved existing HGNC header and checksum data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->