### PR TITLE
Regenerate drift snapshots for clingen, clinvar, gencc, gtex-eqtl, gwas-catalog, hgnc, and ucsc datasets

### DIFF
--- a/hvantk/skills/clingen/tests/drift_fingerprint.json
+++ b/hvantk/skills/clingen/tests/drift_fingerprint.json
@@ -19,7 +19,7 @@
     "Clingen-Gene-Disease-Summary.csv": "1bf26b3670c0d7ff2700df59ee07d1aff8a70bc2c63a7ffc062377312cccf440"
   },
   "extras": {
-    "content_length": "1118136"
+    "content_length": "1118138"
   },
-  "fetched_at": "2026-08-21T06:46:28.535144+00:00"
+  "fetched_at": "2026-08-22T06:39:57.275497+00:00"
 }

--- a/hvantk/skills/clingen/tests/drift_fingerprint.json
+++ b/hvantk/skills/clingen/tests/drift_fingerprint.json
@@ -19,7 +19,7 @@
     "Clingen-Gene-Disease-Summary.csv": "1bf26b3670c0d7ff2700df59ee07d1aff8a70bc2c63a7ffc062377312cccf440"
   },
   "extras": {
-    "content_length": "1118138"
+    "content_length": "1119208"
   },
-  "fetched_at": "2026-08-22T06:39:57.275497+00:00"
+  "fetched_at": "2026-08-27T17:25:22.276080+00:00"
 }

--- a/hvantk/skills/clinvar/tests/drift_fingerprint.json
+++ b/hvantk/skills/clinvar/tests/drift_fingerprint.json
@@ -1,11 +1,11 @@
 {
   "probe_version": 1,
-  "source_version": "Tue, 18 Aug 2026 07:43:28 GMT",
+  "source_version": "Sun, 23 Aug 2026 16:56:29 GMT",
   "headers": {
     "clinvar.vcf.gz": {
-      "content_length": "193311199"
+      "content_length": "193420805"
     }
   },
   "checksums": {},
-  "fetched_at": "2026-08-20T06:45:49.757563+00:00"
+  "fetched_at": "2026-08-24T06:58:23.075872+00:00"
 }

--- a/hvantk/skills/gencc/tests/drift_fingerprint.json
+++ b/hvantk/skills/gencc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Sun, 16 Aug 2026 06:01:44 GMT",
+  "source_version": "Sun, 23 Aug 2026 06:01:43 GMT",
   "headers": {
     "gencc-submissions.tsv": [
       "sgc_id",
@@ -39,5 +39,5 @@
   "checksums": {
     "gencc-submissions.tsv": "6f07ac79f908bca4cfb99874e13d7d1ae5a9c839112baba0243b45fbc018f308"
   },
-  "fetched_at": "2026-08-16T06:40:12.263765+00:00"
+  "fetched_at": "2026-08-23T06:41:27.489442+00:00"
 }

--- a/hvantk/skills/gtex_eqtl/tests/drift_fingerprint.json
+++ b/hvantk/skills/gtex_eqtl/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "cl361-18-g22266644",
+  "source_version": "cl362",
   "headers": {
     "gtex-portal-qtl-downloads": [
       "gtex-version",
@@ -10,13 +10,13 @@
     ]
   },
   "checksums": {
-    "gtex-portal-qtl-downloads": "f4d9e7abc470f25e8a3c116ca738cc065057064d35a32c744a4465d29ffe8ff5"
+    "gtex-portal-qtl-downloads": "b443a8c7df141d3504ef702d033f7720d459f9a8d3a3762ac839a6f6e2fd8955"
   },
-  "fetched_at": "2026-08-04T08:37:02.512856+00:00",
+  "fetched_at": "2026-08-27T17:25:39.948145+00:00",
   "extras": {
-    "gtex_version": "cl361-18-g22266644",
-    "gtex_build_date": "6/26/2026, 12:09:59 PM",
-    "etag": "W/\"6a3ea4e8-23af\"",
-    "last_modified": "Fri, 26 Jun 2026 16:12:24 GMT"
+    "gtex_version": "cl362",
+    "gtex_build_date": "8/26/2026, 2:53:07 PM",
+    "etag": "W/\"6a8f363d-2235\"",
+    "last_modified": "Wed, 26 Aug 2026 18:53:49 GMT"
   }
 }

--- a/hvantk/skills/gwas_catalog/tests/drift_fingerprint.json
+++ b/hvantk/skills/gwas_catalog/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Mon, 03 Aug 2026 13:52:00 GMT",
+  "source_version": "Mon, 24 Aug 2026 10:32:30 GMT",
   "headers": {
     "gwas-catalog-associations-full.zip": [
       "ETag",
@@ -9,7 +9,7 @@
     ]
   },
   "checksums": {
-    "gwas-catalog-associations-full.zip": "01eb84105c079cd97c7c56df20c9f7fbe36904c1b0b599e282050b85130e8de0"
+    "gwas-catalog-associations-full.zip": "24cddd1337c3ab4c02e2de8393d2ea3c0f3c77f11a6f9facb1d2e29af5a15976"
   },
-  "fetched_at": "2026-08-04T08:37:09.312137+00:00"
+  "fetched_at": "2026-08-25T06:47:01.836770+00:00"
 }

--- a/hvantk/skills/hgnc/tests/drift_fingerprint.json
+++ b/hvantk/skills/hgnc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Fri, 21 Aug 2026 13:05:14 GMT",
+  "source_version": "Wed, 26 Aug 2026 12:56:33 GMT",
   "headers": {
     "hgnc_complete_set.txt": [
       "hgnc_id",
@@ -62,5 +62,5 @@
   "checksums": {
     "hgnc_complete_set.txt": "b8cfde58b7ea456e6f05482a4cf663fe329a6508a00809713167cc827200790c"
   },
-  "fetched_at": "2026-08-22T06:40:04.104343+00:00"
+  "fetched_at": "2026-08-27T17:25:55.408606+00:00"
 }

--- a/hvantk/skills/hgnc/tests/drift_fingerprint.json
+++ b/hvantk/skills/hgnc/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Tue, 18 Aug 2026 12:31:23 GMT",
+  "source_version": "Fri, 21 Aug 2026 13:05:14 GMT",
   "headers": {
     "hgnc_complete_set.txt": [
       "hgnc_id",
@@ -62,5 +62,5 @@
   "checksums": {
     "hgnc_complete_set.txt": "b8cfde58b7ea456e6f05482a4cf663fe329a6508a00809713167cc827200790c"
   },
-  "fetched_at": "2026-08-20T06:46:03.644457+00:00"
+  "fetched_at": "2026-08-22T06:40:04.104343+00:00"
 }

--- a/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
+++ b/hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "probe_version": 1,
-  "source_version": "Thu, 20 Aug 2026 05:37:04 GMT",
+  "source_version": "Tue, 25 Aug 2026 06:09:30 GMT",
   "headers": {
     "cells_ucsc_datasets.json": [
       "local-catalog-hash"
@@ -13,7 +13,7 @@
   },
   "checksums": {
     "cells_ucsc_datasets.json": "f448a4b146a7137d21a7c376db4734f39cb56623de362c96da8f05e7e5e380be",
-    "dataset.json": "a88266bb18fc2126826c8b0cbe7a505c8bcfbc1d4dace67cacf267b52b3e680b"
+    "dataset.json": "ab6a7d65d47c126b2ca310dd614f986a6c1f072b4ff2d9eddd70f2f97551518b"
   },
-  "fetched_at": "2026-08-20T06:46:11.474510+00:00"
+  "fetched_at": "2026-08-25T06:47:10.166616+00:00"
 }


### PR DESCRIPTION
Promotes 18 commits of accumulated drift-snapshot regeneration from `dev`. **Fingerprint JSON only — no code, no version bump, no CHANGELOG entry**, matching the shape of #284.

Content delta is 7 files, 22 insertions / 22 deletions:

```
hvantk/skills/clingen/tests/drift_fingerprint.json          |  4 ++--
hvantk/skills/clinvar/tests/drift_fingerprint.json          |  6 +++---
hvantk/skills/gencc/tests/drift_fingerprint.json            |  4 ++--
hvantk/skills/gtex_eqtl/tests/drift_fingerprint.json        | 14 +++++++-------
hvantk/skills/gwas_catalog/tests/drift_fingerprint.json     |  6 +++---
hvantk/skills/hgnc/tests/drift_fingerprint.json             |  4 ++--
hvantk/skills/ucsc_cellbrowser/tests/drift_fingerprint.json |  6 +++---
```

Picks up #285, #286, #287, #288 (already on `dev`) plus #289, #290, #291, #292, #293 (merged today).

## Review

Every dataset classified against the taxonomy the drift bot states in its own PR body — *compatible upstream update* / *breaking schema change* / *spurious probe difference*. **All seven are compatible updates. None required a `builder.py` change or a probe fix.**

| Dataset | Schema signal | Content signal | Reading |
| --- | --- | --- | --- |
| `clingen:gene-disease` | column-header hash **unchanged** | `content_length` +1,072 B | new curations, schema proven stable |
| `clinvar:variants` | n/a (HEAD-only probe) | `Last-Modified` 18→23 Aug, `content_length` +109,606 B | weekly VCF release |
| `gencc:submissions` | columns **unchanged** | `Last-Modified` 16→23 Aug | weekly re-publish |
| `gtex-eqtl:eqtls` | n/a (portal-freshness probe) | `cl361-18-g22266644` → `cl362` | portal redeploy, not a data release |
| `gwas-catalog:associations` | header list **unchanged** | zip checksum moved, 03→24 Aug | periodic release |
| `hgnc:lookup` | 58 columns **unchanged** | content checksum **unchanged**, `Last-Modified` 18→26 Aug | re-publish, byte-identical body |
| `ucsc-cellbrowser` | catalog checksum **unchanged** | `dataset.json` checksum moved | partial refresh |

Three points that needed verification rather than assumption:

**`clingen` — checksum unchanged while `content_length` grew** is not a contradiction. The probe hashes *only the column-header row* as the schema signal and tracks `Content-Length` separately as the content signal (`hvantk/skills/clingen/drift_probe.py`). Identical hash plus a larger body is precisely the "rows added, schema stable" case the probe is built to distinguish — the best-evidenced entry in this set.

**`gtex-eqtl` `cl361-18-g22266644` → `cl362`** is a `git describe` string resolving to a clean tag, i.e. the GTEx *portal site* cut a release. The probe hashes `(gtex-version, gtex-build-date, ETag)` of the download **page**, and its docstring is explicit that it tracks "portal freshness ... not strictly equivalent to v11 dataset releases." Confirmed the builder never references that URL — only `drift_probe.py` and `catalog/datasets.json` do — so a portal redeploy cannot affect the build.

**`clinvar` `headers` is a metadata dict, not a column list.** Its probe is HEAD-only with `checksums` deliberately `{}` (it never downloads the 193 MB VCF), so an empty checksum diff carries no information here; the live signals are `Last-Modified` and `Content-Length`, which moved consistently.

Also checked: every PR's base blob matched `origin/dev` exactly (no stale revert), `PROBE_VERSION` in code matched every committed fingerprint (clingen 2, rest 1), and all files parse as valid JSON.

## CI

All five contributing PRs merged green — 15 build jobs (Python 3.10 / 3.11 / 3.12) plus Codacy, 20 checks total, zero failures. The runs had been stalled since 2026-08-25 at `action_required`: the repo requires manual approval for bot-authored PR workflows, so no drift PR had been tested for three days. Approved and re-run before merging.
